### PR TITLE
Prepare nautilus extension for localization

### DIFF
--- a/data/nautilus/open-terminix.py
+++ b/data/nautilus/open-terminix.py
@@ -3,6 +3,10 @@
 import os
 import urllib
 
+import gettext
+gettext.textdomain("terminix")
+_ = gettext.gettext
+
 import gi
 
 gi.require_version('Nautilus', '3.0')
@@ -32,14 +36,14 @@ class OpenTerminixExtension(GObject.GObject, Nautilus.MenuProvider):
             return
         
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                 label='Open in Terminix',
-                                 tip='Open Terminix In %s' % file.get_name())
+                                 label=_('Open in Terminix'),
+                                 tip=_('Open Terminix In %s') % file.get_name())
         item.connect('activate', self.menu_activate_cb, file)
         return item,
 
     def get_background_items(self, window, file):
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_item',
-                                 label='Open Terminix Here',
-                                 tip='Open Terminix In This Directory')
+                                 label=_('Open Terminix Here'),
+                                 tip=_('Open Terminix In This Directory'))
         item.connect('activate', self.menu_background_activate_cb, file)
         return item,

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -690,3 +690,19 @@ msgstr "zoom-normal"
 
 msgid "maximize"
 msgstr "maximizar"
+
+# ******************
+# Nautilus extension
+# ******************
+
+msgid "Open in Terminix"
+msgstr "Abrir no Terminix"
+
+msgid "Open Terminix Here"
+msgstr "Abrir Terminix aqui"
+
+msgid "Open Terminix In This Directory"
+msgstr "Abrir Terminix neste diretório"
+
+msgid "Open Terminix In %s"
+msgstr "Abrir Terminix em %s"

--- a/po/terminix.pot
+++ b/po/terminix.pot
@@ -680,3 +680,20 @@ msgstr "maximize"
 
 msgid "fullscreen"
 msgstr "fullscreen"
+
+# ******************
+# Nautilus extension
+# ******************
+
+msgid "Open in Terminix"
+msgstr "Open in Terminix"
+
+msgid "Open Terminix Here"
+msgstr "Open Terminix Here"
+
+msgid "Open Terminix In This Directory"
+msgstr "Open Terminix In This Directory"
+
+#, c-format
+msgid "Open Terminix In %s"
+msgstr "Open Terminix In %s"


### PR DESCRIPTION
Hello, I took the liberty to add localization support in the nautilus extension (`open-terminix.py`) by using the `gettext` module. I used the same domain as the application to make it simpler, so I added 4 new keys to `terminix.pot`. Then I updated the pt_BR localization with the new keys.