### PR TITLE
Nearly complete German translation.

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,715 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+# Terminix gettext pot file
+msgid "Backspace key generates"
+msgstr "Rücktaste erzeugt"
+
+msgid "Dark"
+msgstr "Dunkel"
+
+msgid "Save"
+msgstr "Speichern"
+
+msgid "Terminix"
+msgstr "Terminix"
+
+msgid "About"
+msgstr "Über"
+
+msgid "rows"
+msgstr "Zeilen"
+
+msgid "Match entire word only"
+msgstr "Nur vollständige Wörter berücksichtigen"
+
+msgid "IBeam"
+msgstr "Senkrechter Strich"
+
+msgid "Run command as a login shell"
+msgstr "Befehl als Login-Shell ausführen"
+
+msgid "Exit the terminal"
+msgstr "Terminal verlassen"
+
+msgid "Restart the command"
+msgstr "Befehl neu starten"
+
+msgid "Choose A Terminal Font"
+msgstr "Wähle eine Terminal-Schriftart"
+
+msgid "Action"
+msgstr "Aktion"
+
+msgid "Turquoise"
+msgstr "Türkis"
+
+msgid "New"
+msgstr "Neu"
+
+msgid "Encodings showing in menu:"
+msgstr "Im Menü angezeigte Zeichenkodierungen:"
+
+msgid "Delete"
+msgstr "Löschen"
+
+msgid "Paste"
+msgstr "Einfügen"
+
+msgid "Wrap around"
+msgstr "Text umbrechen"
+
+msgid "Default"
+msgstr "Standard"
+
+msgid "Run a custom command instead of my shell"
+msgstr "Einen benutzerdefinierten Befehl statt meiner Shell ausführen"
+
+msgid "Green"
+msgstr "Grün"
+
+msgid "Black"
+msgstr "Schwarz"
+
+msgid "Options"
+msgstr "Optionen"
+
+msgid "Escape sequence"
+msgstr "Escape-Sequenz"
+
+msgid "Synchronize Input"
+msgstr "Eingabe synchronisieren"
+
+msgid "Copy"
+msgstr "Kopieren"
+
+msgid "Delete key generates"
+msgstr "Entfernen-Taste erzeugt"
+
+msgid "Edit Profile"
+msgstr "Profil bearbeiten"
+
+msgid "Find"
+msgstr "Suchen"
+
+msgid "Blue"
+msgstr "Blau"
+
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Helle Farbe für »%s« wählen"
+
+msgid "Preferences"
+msgstr "Einstellungen"
+
+msgid "Terminal Size"
+msgstr "Terminal-Größe"
+
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+msgid "Shortcuts"
+msgstr "Tastenkombinationen"
+
+msgid "Title"
+msgstr "Titel"
+
+msgid "Color scheme"
+msgstr "Farbschema"
+
+msgid "Cursor"
+msgstr "Cursor"
+
+msgid "Encoding"
+msgstr "Zeichenkodierung"
+
+msgid "Global"
+msgstr "Global"
+
+msgid "Set the starting profile"
+msgstr "Als Startprofil festlegen"
+
+msgid "Close"
+msgstr "Schließen"
+
+msgid "Edit"
+msgstr "Bearbeiten"
+
+msgid "Send an action to current Terminix instance"
+msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
+
+#, c-format
+msgid "Select %s Color"
+msgstr "Farbe für »%s« wählen"
+
+msgid "Command"
+msgstr "Befehl"
+
+msgid "Profile"
+msgstr "Profil"
+
+#, c-format
+msgid "Editing Profile: %s"
+msgstr "Editiere Profil: %s"
+
+msgid "Select Foreground Color"
+msgstr "Vordergrundfarbe wählen"
+
+msgid "Purple"
+msgstr "Lila"
+
+msgid "New Session"
+msgstr "Neue Sitzung"
+
+msgid "Ambiguous-width characters"
+msgstr "Zeichen mit unbekannter Breite:"
+
+msgid "Enabled"
+msgstr "Aktiviert"
+
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+msgid ""
+"There appears to be an issue with the configuration of the terminal.This "
+"issue is not serious, but correcting it will improve your experience.Click "
+"the link below for more information:"
+msgstr ""
+"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
+"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
+"Klciken Sie auf den untenstehenden Link für weitere Informationen:"
+
+msgid "General"
+msgstr "Allgemein"
+
+msgid "Match as regular expression"
+msgstr "Als regulären Ausdruck verarbeiten"
+
+msgid "Scroll on output"
+msgstr "Bildlauf bei Ausgabe"
+
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+msgid "Allow bold text"
+msgstr "Fettformatierten Text zulassen"
+
+msgid "columns"
+msgstr "Spalten"
+
+msgid "Open the specified session"
+msgstr "Die angegebene Sitzung öffnen"
+
+msgid "Profiles"
+msgstr "Profile"
+
+msgid "Red"
+msgstr "Rot"
+
+msgid "Prompt when creating a new session"
+msgstr "Beim Erstellen einer neuen Sitzung nachfragen"
+
+msgid "Switch to a new session"
+msgstr "Zu neuer Sitzung wechseln"
+
+msgid "Background"
+msgstr "Hintergrund"
+
+msgid "New Window"
+msgstr "Neues Fenster"
+
+msgid "Terminal Title"
+msgstr "Terminal-Titel"
+
+msgid "Split Down"
+msgstr "Horizontal teilen"
+
+msgid "Scroll on keystroke"
+msgstr "Bildlauf bei Tastendruck"
+
+msgid "Load"
+msgstr "Laden"
+
+msgid "Wide"
+msgstr "Breit"
+
+msgid "Rewrap on resize"
+msgstr "Bei Größenänderung neu umbrechen"
+
+msgid "Read-Only"
+msgstr "Nur lesen"
+
+msgid "TTY"
+msgstr "TTY"
+
+msgid "Custom Font"
+msgstr "Benutzerdefinierte Schrift"
+
+msgid "Search Options"
+msgstr "Suchoptionen"
+
+msgid "Execute the passed command"
+msgstr "Übergebenen Befehl ausführen"
+
+msgid "Warn when attempting unsafe paste"
+msgstr "Vor unsicherem Einfügen warnen"
+
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+msgid "Do not show this message again"
+msgstr "Diese Meldung nicht mehr anzeigen"
+
+msgid "Terminal"
+msgstr "Terminal"
+
+msgid "Transparency"
+msgstr "Transparenz"
+
+msgid "Grey"
+msgstr "Grau"
+
+msgid "Narrow"
+msgstr "Schmal"
+
+msgid "Save As"
+msgstr "Speichern unter"
+
+msgid "Text Appearance"
+msgstr "Text-Erscheinungsbild"
+
+msgid "Terminal Bell"
+msgstr "Terminal-Glocke"
+
+msgid "Underline"
+msgstr "Unterstrich"
+
+msgid "Limit scrollback to:"
+msgstr "Zeilenpuffer beschränken auf:"
+
+msgid "Hold the terminal open"
+msgstr "Terminal geöffnet lassen"
+
+msgid "Match case"
+msgstr "Groß-/Kleinschreibung beachten"
+
+msgid "Shortcut Key"
+msgstr "Tastenkombination"
+
+msgid "Color palette"
+msgstr "Farbpalette"
+
+msgid "Send desktop notification on process complete"
+msgstr "Desktop-Benachrichtigung bei Beendigung des Prozesses senden"
+
+msgid "Appearance"
+msgstr "Erscheinungsbild"
+
+msgid "Split Right"
+msgstr "Vertikal teilen"
+
+msgid "Show scrollbar"
+msgstr "Bildlaufleiste anzeigen"
+
+msgid "Compatibility"
+msgstr "Kompatibilität"
+
+msgid "Set the working directory of the terminal"
+msgstr "Arbeitsverzeichnis des Terminals wählen"
+
+msgid "Orange"
+msgstr "Orange"
+
+msgid "Color"
+msgstr "Farbe"
+
+msgid "Behavior"
+msgstr "Verhalten"
+
+msgid "Automatic"
+msgstr "automatisch"
+
+msgid "Configuration Issue Detected"
+msgstr "Probleme mit der Konfiguration entdeckt"
+
+msgid "Block"
+msgstr "Block"
+
+msgid "Select All"
+msgstr "Alles wählen"
+
+msgid "Foreground"
+msgstr "Vordergrund"
+
+msgid "Use theme colors for foreground/background"
+msgstr "Farbe des Themas für Vorder-/Hintergrund verwenden"
+
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Das erste Zeichen beim Einfügen von Kommentaren oder Variablendeklarationen "
+"entfernen"
+
+msgid "Profile Name"
+msgstr "Profilname"
+
+msgid "Quit"
+msgstr "Beenden"
+
+msgid "Scrolling"
+msgstr "Bildlauf"
+
+msgid "Select Background Color"
+msgstr "Hintergrundfarbe wählen"
+
+msgid "Theme Variant"
+msgstr "Themen-Variante"
+
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Terminal beim Überfahren mit der Maus fokusieren"
+
+msgid "Light"
+msgstr "Hell"
+
+msgid "Control-H"
+msgstr "Strg-H"
+
+msgid "Create a new session"
+msgstr "Neue Sitzung erstellen"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "When command exists"
+msgstr "Wenn Befehl beendet:"
+
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+msgid "Could not load session due to unexpected error."
+msgstr ""
+"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
+
+msgid "Load Session"
+msgstr "Sitzung laden"
+
+msgid "Save Session"
+msgstr "Sitzung speichern"
+
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Dateiname \"%s\" existiert nicht"
+
+msgid "Enter Custom Title"
+msgstr "Benutzerdefinierten Titel eingeben"
+
+msgid "Change Session Name"
+msgstr "Sitzungsnamen ändern"
+
+msgid "Enter a new name for the session"
+msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
+
+msgid "Autohide the mouse pointer when typing"
+msgstr "Mauszeiger beim Tippen ausblenden"
+
+msgid "Blink Mode"
+msgstr "Cursor blinkt"
+
+msgid "System"
+msgstr "System"
+
+msgid "On"
+msgstr "An"
+
+msgid "Off"
+msgstr "Aus"
+
+msgid "Enable the menu accelerator key (F10 by default)"
+msgstr "Menütastenkombination aktivieren (Vorgabe: F10)"
+
+# ************************************************
+# Encodings
+# ************************************************
+msgid "Arabic"
+msgstr "Arabisch"
+
+msgid "Armenian"
+msgstr "Armenisch"
+
+msgid "Baltic"
+msgstr "Baltisch"
+
+msgid "Celtic"
+msgstr "Keltisch"
+
+msgid "Central European"
+msgstr "Mitteleuropäisch"
+
+msgid "Chinese Simplified"
+msgstr "Chinesisch (vereinfacht)"
+
+msgid "Chinese Traditional"
+msgstr "Chinesisch (traditionell)"
+
+msgid "Croatian"
+msgstr "Kroatisch"
+
+msgid "Cyrillic"
+msgstr "Kyrillisch"
+
+msgid "Cyrillic/Russian"
+msgstr "Kyrillisch / Russland"
+
+msgid "Cyrillic/Ukrainian"
+msgstr "Kyrillisch / Ukraine"
+
+msgid "Georgian"
+msgstr "Georgisch"
+
+msgid "Greek"
+msgstr "Griechisch"
+
+msgid "Gurmukhi"
+msgstr "Gurmukhi"
+
+msgid "Gujarati"
+msgstr "Gujarati"
+
+msgid "Hebrew"
+msgstr "Hebräisch"
+
+msgid "Hindi"
+msgstr "Hindi"
+
+msgid "Icelandic"
+msgstr "Isländisch"
+
+msgid "Japanese"
+msgstr "Japanisch"
+
+msgid "Korean"
+msgstr "Koreanisch"
+
+msgid "Nordic"
+msgstr "Nordisch"
+
+msgid "Persian"
+msgstr "Persisch"
+
+msgid "Romanian"
+msgstr "Rumänisch"
+
+msgid "South European"
+msgstr "Südeuropäisch"
+
+msgid "Thai"
+msgstr "Thai"
+
+msgid "Turkish"
+msgstr "Türkisch"
+
+msgid "Vietnamese"
+msgstr "Vietnamesisch"
+
+msgid "Western"
+msgstr "Westlich"
+
+msgid "Unicode"
+msgstr "Unicode"
+
+# *****************************************
+# Keyboard shortcut categories
+# *****************************************
+msgid "app"
+msgstr ""
+
+msgid "session"
+msgstr ""
+
+msgid "terminal"
+msgstr ""
+
+msgid "win"
+msgstr ""
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+msgid "find-previous"
+msgstr ""
+
+msgid "close"
+msgstr ""
+
+msgid "copy"
+msgstr ""
+
+msgid "find"
+msgstr ""
+
+msgid "find-next"
+msgstr ""
+
+msgid "list"
+msgstr ""
+
+msgid "load"
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+msgid "new-session"
+msgstr ""
+
+msgid "new-window"
+msgstr ""
+
+msgid "paste"
+msgstr ""
+
+msgid "preferences"
+msgstr ""
+
+msgid "profile-preference"
+msgstr ""
+
+msgid "read-only"
+msgstr ""
+
+msgid "save"
+msgstr ""
+
+msgid "save-as"
+msgstr ""
+
+msgid "select-all"
+msgstr ""
+
+msgid "split-horizontal"
+msgstr ""
+
+msgid "split-vertical"
+msgstr ""
+
+msgid "switch-to-previous-terminal"
+msgstr ""
+
+msgid "switch-to-session-0"
+msgstr ""
+
+msgid "switch-to-session-1"
+msgstr ""
+
+msgid "switch-to-session-2"
+msgstr ""
+
+msgid "switch-to-session-3"
+msgstr ""
+
+msgid "switch-to-session-4"
+msgstr ""
+
+msgid "switch-to-session-5"
+msgstr ""
+
+msgid "switch-to-session-6"
+msgstr ""
+
+msgid "switch-to-session-7"
+msgstr ""
+
+msgid "switch-to-session-8"
+msgstr ""
+
+msgid "switch-to-session-9"
+msgstr ""
+
+msgid "switch-to-terminal-0"
+msgstr ""
+
+msgid "switch-to-terminal-1"
+msgstr ""
+
+msgid "switch-to-terminal-2"
+msgstr ""
+
+msgid "switch-to-terminal-3"
+msgstr ""
+
+msgid "switch-to-terminal-4"
+msgstr ""
+
+msgid "switch-to-terminal-5"
+msgstr ""
+
+msgid "switch-to-terminal-6"
+msgstr ""
+
+msgid "switch-to-terminal-7"
+msgstr ""
+
+msgid "switch-to-terminal-8"
+msgstr ""
+
+msgid "switch-to-terminal-9"
+msgstr ""
+
+msgid "synchronize-input"
+msgstr ""
+
+msgid "switch-to-next-terminal"
+msgstr ""
+
+msgid "title"
+msgstr ""
+
+msgid "zoom-in"
+msgstr ""
+
+msgid "zoom-out"
+msgstr ""
+
+msgid "zoom-normal"
+msgstr ""
+
+msgid "maximize"
+msgstr ""
+
+msgid "fullscreen"
+msgstr "Vollbild"
+
+msgid "view-sidebar"
+msgstr ""
+
+# ******************
+# Nautilus extension
+# ******************
+msgid "Open in Terminix"
+msgstr "In Terminix öffnen …"
+
+msgid "Open Terminix Here"
+msgstr "Terminix hier öffnen …"
+
+msgid "Open Terminix In This Directory"
+msgstr "Terminix in diesem Verzeichnis öffnen"
+
+#, c-format
+msgid "Open Terminix In %s"
+msgstr "Terminix in %s öffnen"


### PR DESCRIPTION
This adds a nearly complete German translation. No translated are the shortcut actions. Not sure how the other translations handled those, I will take a look.

I tried to follow the guidelines of the German Gnome localization team as close as possible and used a translation memory of the existing Gnome translations to ensure consistency with the rest of the system.

I will try to keep the translation up to date with future changes.