### PR TITLE
Add directional terminal switching

### DIFF
--- a/data/gsettings/com.gexperts.Terminix.gschema.xml
+++ b/data/gsettings/com.gexperts.Terminix.gschema.xml
@@ -514,6 +514,22 @@
       <default>'&lt;Alt&gt;9'</default>
       <summary>Keyboard shortcut to switch to terminal 9</summary>
     </key>
+    <key name="session-switch-to-terminal-up" type="s">
+      <default>'&lt;Alt&gt;Up'</default>
+      <summary>Keyboard shortcut to switch to terminal above</summary>
+    </key>
+    <key name="session-switch-to-terminal-down" type="s">
+      <default>'&lt;Alt&gt;Down'</default>
+      <summary>Keyboard shortcut to switch to terminal below</summary>
+    </key>
+    <key name="session-switch-to-terminal-left" type="s">
+      <default>'&lt;Alt&gt;Left'</default>
+      <summary>Keyboard shortcut to switch to terminal left</summary>
+    </key>
+    <key name="session-switch-to-terminal-right" type="s">
+      <default>'&lt;Alt&gt;Right'</default>
+      <summary>Keyboard shortcut to switch to terminal right</summary>
+    </key>
     <key name="win-view-sidebar" type="s">
       <default>'&lt;Ctrl&gt;s'</default>
       <summary>Keyboard shortcut to view session sidebar</summary>

--- a/source/gx/terminix/appwindow.d
+++ b/source/gx/terminix/appwindow.d
@@ -12,6 +12,7 @@ import std.file;
 import std.math;
 import std.format;
 import std.json;
+import std.string;
 
 import cairo.Context;
 
@@ -313,6 +314,20 @@ private:
                 }
             });
         }
+
+        //Create directional Switch to Terminal actions
+        const string[] directions = ["up", "down", "left", "right"];
+        foreach (string direction; directions) {
+            registerActionWithSettings(sessionActions, ACTION_PREFIX, ACTION_SESSION_TERMINAL_X ~ direction, gsShortcuts, delegate(GVariant, SimpleAction sa) {
+                Session session = getCurrentSession();
+                if (session !is null) {
+                    string actionName = sa.getName();
+                    string direction = actionName[lastIndexOf(actionName, '-') + 1 .. $];
+                    session.focusDirection(direction);
+                }
+            });
+        }
+
         /* TODO - GTK doesn't support settings Tab for accelerators, need to look into this more */
         registerActionWithSettings(sessionActions, ACTION_PREFIX, ACTION_SESSION_NEXT_TERMINAL, gsShortcuts, delegate(GVariant, SimpleAction) {
             Session session = getCurrentSession();

--- a/source/gx/terminix/session.d
+++ b/source/gx/terminix/session.d
@@ -998,6 +998,61 @@ public:
     }
 
     /**
+     * Focus terminal in the session by direction
+     */
+    void focusDirection(string direction) {
+        trace("Focusing ", direction);
+
+        Widget appWindow = lastFocused.getToplevel();
+        GtkAllocation appWindowAllocation;
+        appWindow.getClip(appWindowAllocation);
+
+        // Start at the top left of the current terminal
+        int xPos, yPos;
+        lastFocused.translateCoordinates(appWindow, 0, 0, xPos, yPos);
+
+        // While still in the application window, move 20 pixels per loop
+        while (xPos >= 0 && xPos < appWindowAllocation.width && yPos >= 0 && yPos < appWindowAllocation.height) {
+            switch (direction) {
+                case "up":
+                    yPos -= 20;
+                    break;
+
+                case "down":
+                    yPos += 20;
+                    break;
+
+                case "left":
+                    xPos -= 20;
+                    break;
+
+                case "right":
+                    xPos += 20;
+                    break;
+
+                default: break;
+            }
+
+            // If the x/y position lands in another terminal, focus it
+            foreach (terminal; terminals) {
+                if (terminal == lastFocused)
+                    continue;
+
+                int termX, termY;
+                terminal.translateCoordinates(appWindow, 0, 0, termX, termY);
+
+                GtkAllocation termAllocation;
+                terminal.getClip(termAllocation);
+
+                if (xPos >= termX && yPos >= termY && xPos <= (termX + termAllocation.width) && yPos <= (termY + termAllocation.height)) {
+                    focusTerminal(terminal.terminalUUID);
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
      * Focus the terminal designated by the ID
      */
     bool focusTerminal(ulong terminalID) {


### PR DESCRIPTION
Implements #136. This adds directional terminal switching using Alt+Up/Down/Left/Right.

The "next" terminal is determined by moving from the top left coordinates of the currently focused terminal rather than the position of the cursor.