### PR TITLE
Fixed shortcut pref disabled string

### DIFF
--- a/source/gx/gtk/actions.d
+++ b/source/gx/gtk/actions.d
@@ -29,7 +29,11 @@ string acceleratorNameToLabel(string acceleratorName) {
     uint acceleratorKey; 
     GdkModifierType acceleratorMods;
     AccelGroup.acceleratorParse(acceleratorName, acceleratorKey, acceleratorMods);
-    return AccelGroup.acceleratorGetLabel(acceleratorKey, acceleratorMods); 
+    string label = AccelGroup.acceleratorGetLabel(acceleratorKey, acceleratorMods);
+    if (label == "") {
+      label = _(SHORTCUT_DISABLED);
+    }
+    return label;
 }
 
 /**

--- a/source/gx/terminix/prefwindow.d
+++ b/source/gx/terminix/prefwindow.d
@@ -218,7 +218,7 @@ private:
             tsShortcuts.getIter(iter, new TreePath(path));
             tsShortcuts.setValue(iter, COLUMN_SHORTCUT, _(SHORTCUT_DISABLED));
             //Note accelerator changed by app which is monitoring gsetting changes
-            gsShortcuts.setString(tsShortcuts.getValueString(iter, COLUMN_ACTION_NAME), _(SHORTCUT_DISABLED));
+            gsShortcuts.setString(tsShortcuts.getValueString(iter, COLUMN_ACTION_NAME), SHORTCUT_DISABLED);
         });
         craShortcut.addOnAccelEdited(delegate(string path, uint accelKey, GdkModifierType accelMods, uint, CellRendererAccel) {
             string label = AccelGroup.acceleratorGetLabel(accelKey, accelMods);


### PR DESCRIPTION
This fixes actually two issues:

1. When using Terminix with a non English locale, the localized string for "disabled" got saved to the preferences. This lead to errors while loading the preferences. This PR fixes this by not localizing the value actually saved.  Introduced by myself in bd75e68db72cdd5864b13923db1de2815e114e33, sorry for that.

2. The disabled string was not displayed anymore.