### PR TITLE
Fix sidebar transparent background

### DIFF
--- a/data/resources/css/terminix.adwaita.css
+++ b/data/resources/css/terminix.adwaita.css
@@ -36,6 +36,10 @@
     font-size: smaller;
 }
 
+.terminix-session-sidebar {
+    background-color: @theme_fg_color;
+}
+
 .terminix-session-name {
     color: @theme_bg_color;
     background-color: @theme_fg_color;

--- a/source/gx/terminix/sidebar.d
+++ b/source/gx/terminix/sidebar.d
@@ -104,6 +104,7 @@ public:
         lbSessions.setSelectionMode(SelectionMode.BROWSE);
         lbSessions.getStyleContext().addClass("notebook");
         lbSessions.getStyleContext().addClass("header");
+        lbSessions.getStyleContext().addClass("terminix-session-sidebar");
         lbSessions.addOnRowActivated(&onRowActivated);
 
         ScrolledWindow sw = new ScrolledWindow(lbSessions);


### PR DESCRIPTION
As of the current master branch the sidebar background on Ubuntu 16.04 is transparent:
![session-switcher](https://cloud.githubusercontent.com/assets/422013/14042606/5cf6f49c-f273-11e5-85c3-37fed7354a75.png)

This pull request adds a background colour to the sidebar.
