### PR TITLE
Add double click in sidebar to open new session

### DIFF
--- a/source/gx/terminix/appwindow.d
+++ b/source/gx/terminix/appwindow.d
@@ -147,6 +147,7 @@ private:
         }, ConnectFlags.AFTER);
 
         sb = new SideBar();
+        sb.setAppWindow(this);
         sb.addOnSessionSelected(delegate(string sessionUUID) {
             trace("Session selected " ~ sessionUUID);
             saViewSideBar.activate(null);

--- a/source/gx/terminix/sidebar.d
+++ b/source/gx/terminix/sidebar.d
@@ -28,6 +28,7 @@ import gtk.Widget;
 import gx.gtk.cairo;
 import gx.gtk.util;
 
+import gx.terminix.appwindow;
 import gx.terminix.common;
 import gx.terminix.session;
 
@@ -42,6 +43,8 @@ alias OnSessionSelected = void delegate(string sessionUUID);
  */
 class SideBar : Revealer {
 private:
+    AppWindow appWindow;
+
     ListBox lbSessions;
 
     OnSessionSelected[] sessionSelectedDelegates;
@@ -66,6 +69,11 @@ private:
         //If button press happened outside of sidebar close it
         if (event.getWindow() !is null && lbSessions.getWindow() !is null) { 
             if (event.getWindow().getWindowStruct() != getWindow().getWindowStruct() && event.getWindow().getWindowStruct() != lbSessions.getWindow().getWindowStruct()) {
+                notifySessionSelected(null);
+            }
+            else if (event.isDoubleClick(event.button())) {
+                // Create new session
+                appWindow.createSession();
                 notifySessionSelected(null);
             }
         }
@@ -119,6 +127,10 @@ public:
         });
 
         add(sw);
+    }
+
+    void setAppWindow(AppWindow _appWindow) {
+        appWindow = _appWindow;
     }
 
     void populateSessions(Session[] sessions, string currentSessionUUID, SessionNotification[string] notifications, int width, int height) {


### PR DESCRIPTION
With this change, double clicking in the empty space of the sidebar will open a new session.

Wasn't sure if there is a better way to get the AppWindow instance to be able to call `createSession` but if there is I can make the change.