### PR TITLE
Updated German translation for new strings

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -34,9 +34,8 @@ msgstr "Neue Sitzung"
 msgid "preferences"
 msgstr "Einstellungen"
 
-#, fuzzy
 msgid "shortcuts"
-msgstr "Tastenkombinationen"
+msgstr "Hilfe zu Tastenkombinationen"
 
 msgid "session"
 msgstr "Sitzung"
@@ -101,21 +100,17 @@ msgstr "Zum linken Terminal wechseln"
 msgid "switch-to-terminal-right"
 msgstr "Zum rechten Terminal wechseln"
 
-#, fuzzy
 msgid "resize-terminal-up"
-msgstr "Zum oberen Terminal wechseln"
+msgstr "Terminalgröße aufwärts verändern"
 
-#, fuzzy
 msgid "resize-terminal-down"
-msgstr "Zum unteren Terminal wechseln"
+msgstr "Terminalgröße abwärts verändern"
 
-#, fuzzy
 msgid "resize-terminal-left"
-msgstr "Zum linken Terminal wechseln"
+msgstr "Terminalgröße nach links verändern"
 
-#, fuzzy
 msgid "resize-terminal-right"
-msgstr "Zum rechten Terminal wechseln"
+msgstr "Terminalgröße nach rechts verändern"
 
 msgid "win"
 msgstr "Fenster"
@@ -830,15 +825,13 @@ msgstr "Desktop-Benachrichtigung bei Beendigung des Prozesses senden"
 
 #: source/gx/terminix/prefwindow.d:489
 msgid "On new instance"
-msgstr ""
+msgstr "Beim Öffnen einer neuen Instanz:"
 
 #: source/gx/terminix/prefwindow.d:492
-#, fuzzy
 msgid "Split Horizontal"
 msgstr "Horizontal teilen"
 
 #: source/gx/terminix/prefwindow.d:492
-#, fuzzy
 msgid "Split Vertical"
 msgstr "Vertikal teilen"
 
@@ -876,7 +869,7 @@ msgstr "Breiten Griff für Fenstertrenner verwenden"
 
 #: source/gx/terminix/prefwindow.d:539
 msgid "Theme Variant"
-msgstr "Themen-Variante"
+msgstr "Themen-Variante:"
 
 #: source/gx/terminix/prefwindow.d:544
 msgid "Light"
@@ -1010,7 +1003,7 @@ msgstr "Kopieren"
 #: source/gx/terminix/terminal/terminal.d:876
 #: source/gx/terminix/terminal/terminal.d:895
 msgid "Select All"
-msgstr "Alles wählen"
+msgstr "Alles markieren"
 
 #: source/gx/terminix/terminal/terminal.d:1228
 msgid "Unexpected error occurred, no additional information available"
@@ -1213,149 +1206,126 @@ msgid "utilities-terminal"
 msgstr "utilities-terminal"
 
 #: data/resources/ui/shortcuts.ui:15
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Application"
-msgstr "Aktion"
+msgstr "Anwendung:"
 
 #: data/resources/ui/shortcuts.ui:19
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open a new window"
-msgstr "Neues Fenster"
+msgstr "Neues Fenster öffnen"
 
 #: data/resources/ui/shortcuts.ui:25
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open a new session"
 msgstr "Neue Sitzung erstellen"
 
 #: data/resources/ui/shortcuts.ui:31
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open preferences"
-msgstr "Einstellungen"
+msgstr "Einstellungsdialog öffnen"
 
 #: data/resources/ui/shortcuts.ui:37
 msgctxt "shortcut window"
 msgid "View configured shortcuts"
-msgstr ""
+msgstr "Konfigurierte Tastenkombinationen anzeigen"
 
 #: data/resources/ui/shortcuts.ui:45
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Window"
-msgstr "Neues Fenster"
+msgstr "Fenster"
 
 #: data/resources/ui/shortcuts.ui:49
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Toggle fullscreen mode"
-msgstr "Vollbild"
+msgstr "Vollbildmodus ein-/ausschalten"
 
 #: data/resources/ui/shortcuts.ui:55
-#, fuzzy
 msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Sitzungs-Seitenleiste anzeigen"
 
 #: data/resources/ui/shortcuts.ui:61
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Zur nächsten Sitzung wechseln"
 
 #: data/resources/ui/shortcuts.ui:67
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Zur vorherigen Sitzung wechseln"
 
 #: data/resources/ui/shortcuts.ui:73
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Zu Sitzung 1 wechseln"
 
 #: data/resources/ui/shortcuts.ui:79
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Zu Sitzung 2 wechseln"
 
 #: data/resources/ui/shortcuts.ui:85
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Zu Sitzung 3 wechseln"
 
 #: data/resources/ui/shortcuts.ui:91
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Zu Sitzung 4 wechseln"
 
 #: data/resources/ui/shortcuts.ui:97
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Zu Sitzung 5 wechseln"
 
 #: data/resources/ui/shortcuts.ui:103
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Zu Sitzung 6 wechseln"
 
 #: data/resources/ui/shortcuts.ui:109
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Zu Sitzung 7 wechseln"
 
 #: data/resources/ui/shortcuts.ui:115
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Zu Sitzung 8 wechseln"
 
 #: data/resources/ui/shortcuts.ui:121
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Zu Sitzung 9 wechseln"
 
 #: data/resources/ui/shortcuts.ui:127
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Zu Sitzung 10 wechseln"
 
 #: data/resources/ui/shortcuts.ui:143
-#, fuzzy
 msgctxt "shortcut window"
 msgid "File"
-msgstr "Alle Dateien"
+msgstr "Datei"
 
 #: data/resources/ui/shortcuts.ui:147
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Close the current session"
-msgstr "Die angegebene Sitzung öffnen"
+msgstr "Aktuelle Sitzung schließen"
 
 #: data/resources/ui/shortcuts.ui:153
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Save the current session"
-msgstr "Die angegebene Sitzung öffnen"
+msgstr "Aktuelle Sitzung speichern"
 
 #: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
-msgstr ""
+msgstr "Aktuelle Sitzung unter neuem Dateinamen speichern"
 
 #: data/resources/ui/shortcuts.ui:165
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Load the current session"
 msgstr "Sitzung laden"
@@ -1363,159 +1333,134 @@ msgstr "Sitzung laden"
 #: data/resources/ui/shortcuts.ui:173
 msgctxt "shortcut window"
 msgid "Resize"
-msgstr ""
+msgstr "Größe ändern"
 
 #: data/resources/ui/shortcuts.ui:177
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
-msgstr "Terminal verlassen"
+msgstr "Terminalgröße aufwärts verändern"
 
 #: data/resources/ui/shortcuts.ui:183
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
-msgstr "Terminal geöffnet lassen"
+msgstr "Terminalgröße abwärts verändern"
 
 #: data/resources/ui/shortcuts.ui:189
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
-msgstr "Terminal verlassen"
+msgstr "Terminalgröße nach links verändern"
 
 #: data/resources/ui/shortcuts.ui:195
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
-msgstr "Zum rechten Terminal wechseln"
+msgstr "Terminalgröße nach rechts verändern"
 
 #: data/resources/ui/shortcuts.ui:203
 msgctxt "shortcut window"
 msgid "Switch"
-msgstr ""
+msgstr "Wechseln"
 
 #: data/resources/ui/shortcuts.ui:207
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "Zum nächsten Terminal wechseln"
 
 #: data/resources/ui/shortcuts.ui:213
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "Zum vorherigen Terminal wechseln"
 
 #: data/resources/ui/shortcuts.ui:219
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "Zum oberen Terminal wechseln"
 
 #: data/resources/ui/shortcuts.ui:225
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "Zum unteren Terminal wechseln"
 
 #: data/resources/ui/shortcuts.ui:231
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "Zum linken Terminal wechseln"
 
 #: data/resources/ui/shortcuts.ui:237
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "Zum rechten Terminal wechseln"
 
 #: data/resources/ui/shortcuts.ui:243
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "Zu Terminal 1 wechseln"
 
 #: data/resources/ui/shortcuts.ui:249
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "Zu Terminal 2 wechseln"
 
 #: data/resources/ui/shortcuts.ui:255
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "Zu Terminal 3 wechseln"
 
 #: data/resources/ui/shortcuts.ui:261
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "Zu Terminal 4 wechseln"
 
 #: data/resources/ui/shortcuts.ui:267
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "Zu Terminal 5 wechseln"
 
 #: data/resources/ui/shortcuts.ui:273
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "Zu Terminal 6 wechseln"
 
 #: data/resources/ui/shortcuts.ui:279
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "Zu Terminal 7 wechseln"
 
 #: data/resources/ui/shortcuts.ui:285
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "Zu Terminal 8 wechseln"
 
 #: data/resources/ui/shortcuts.ui:291
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "Zu Terminal 9 wechseln"
 
 #: data/resources/ui/shortcuts.ui:297
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "Zu Terminal 10 wechseln"
 
 #: data/resources/ui/shortcuts.ui:313
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Split"
-msgstr "Horizontal teilen"
+msgstr "Teilen"
 
 #: data/resources/ui/shortcuts.ui:317
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Split horizontal"
 msgstr "Horizontal teilen"
 
 #: data/resources/ui/shortcuts.ui:323
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Split Vertical"
 msgstr "Vertikal teilen"
 
 #: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Find"
-msgstr "Suchen …"
+msgstr "Suchen"
 
 #: data/resources/ui/shortcuts.ui:341
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "Nächster Treffer"
@@ -1526,7 +1471,6 @@ msgstr "Nächster Treffer"
 # the shortcut overview if available in Gnome 3.20
 # ***********************************************
 #: data/resources/ui/shortcuts.ui:347
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "Vorheriger Treffer"
@@ -1534,43 +1478,39 @@ msgstr "Vorheriger Treffer"
 #: data/resources/ui/shortcuts.ui:355
 msgctxt "shortcut window"
 msgid "Clipboard"
-msgstr ""
+msgstr "Zwischenablage"
 
 #: data/resources/ui/shortcuts.ui:359
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "Kopieren"
 
 #: data/resources/ui/shortcuts.ui:365
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "Einfügen"
 
 #: data/resources/ui/shortcuts.ui:371
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Select all"
-msgstr "Alles wählen"
+msgstr "Alles markieren"
 
 #: data/resources/ui/shortcuts.ui:379
 msgctxt "shortcut window"
 msgid "Zoom"
-msgstr ""
+msgstr "Vergrößerung"
 
 #: data/resources/ui/shortcuts.ui:383
 msgctxt "shortcut window"
 msgid "Zoom in"
-msgstr ""
+msgstr "Ansicht vergrößern"
 
 #: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Zoom out"
-msgstr ""
+msgstr "Ansicht verkleinern"
 
 #: data/resources/ui/shortcuts.ui:395
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "Ansicht Standardvergrößerung"
@@ -1578,40 +1518,34 @@ msgstr "Ansicht Standardvergrößerung"
 #: data/resources/ui/shortcuts.ui:403
 msgctxt "shortcut window"
 msgid "Other"
-msgstr ""
+msgstr "Sonstige"
 
 #: data/resources/ui/shortcuts.ui:407
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Terminalausgabe speichern"
 
 #: data/resources/ui/shortcuts.ui:413
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Close terminal"
-msgstr "Terminal"
+msgstr "Terminal schließen"
 
 #: data/resources/ui/shortcuts.ui:419
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Maximize terminal"
-msgstr "Terminal verlassen"
+msgstr "Terminal maximieren"
 
 #: data/resources/ui/shortcuts.ui:425
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Current profile preferences"
-msgstr "Profil-Einstellungen"
+msgstr "Aktuelle Profil-Einstellungen"
 
 #: data/resources/ui/shortcuts.ui:431
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Toggle read only"
-msgstr "Nur lesend"
+msgstr "Nur lesend umschalten"
 
 #: data/resources/ui/shortcuts.ui:437
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Layout-Optionen"

--- a/po/de.po
+++ b/po/de.po
@@ -929,7 +929,7 @@ msgstr "Als regulären Ausdruck verarbeiten"
 
 #: source/gx/terminix/terminal/search.d:186
 msgid "Wrap around"
-msgstr "Text umbrechen"
+msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
 
 #: source/gx/terminix/terminal/terminal.d:323
 #: source/gx/terminix/terminal/terminal.d:741


### PR DESCRIPTION
I am not entirely sure about the shortcuts help window, but I can't yet test it. I will update the translations if necessary once Gnome 3.20 hits Arch.