### PR TITLE
i18n: Localize the about dialog.

### DIFF
--- a/source/gx/terminix/application.d
+++ b/source/gx/terminix/application.d
@@ -193,16 +193,22 @@ private:
             setWrapLicense(true);
             setLogoIconName(null);
             setName(APPLICATION_NAME);
-            setComments(APPLICATION_COMMENTS);
+            setComments(_(APPLICATION_COMMENTS));
             setVersion(APPLICATION_VERSION);
             setCopyright(APPLICATION_COPYRIGHT);
             setAuthors(APPLICATION_AUTHORS.dup);
             setArtists(APPLICATION_ARTISTS.dup);
             setDocumenters(APPLICATION_DOCUMENTERS.dup);
             setTranslatorCredits(APPLICATION_TRANSLATORS);
-            setLicense(APPLICATION_LICENSE);
-            addCreditSection(_("Credits"), APPLICATION_CREDITS);
+            setLicense(_(APPLICATION_LICENSE));
             setLogoIconName(APPLICATION_ICON_NAME);
+
+            string[] localizedCredits;
+            localizedCredits.length = APPLICATION_CREDITS.length;
+            foreach (i, credit; APPLICATION_CREDITS) {
+                localizedCredits[i] = _(credit);
+            }
+            addCreditSection(_("Credits"), localizedCredits);
 
             addOnResponse(delegate(int responseId, Dialog sender) {
                 if (responseId == ResponseType.CANCEL || responseId == ResponseType.DELETE_EVENT)

--- a/source/gx/terminix/constants.d
+++ b/source/gx/terminix/constants.d
@@ -4,6 +4,7 @@
  */
 module gx.terminix.constants;
 
+import std.format;
 import std.path;
 
 import gx.i18n.l10n;
@@ -34,13 +35,15 @@ enum APPLICATION_NAME = "Terminix";
 enum APPLICATION_VERSION = "0.55.0";
 enum APPLICATION_AUTHOR = "Gerald Nunn";
 enum APPLICATION_COPYRIGHT = "Copyright \xc2\xa9 2016 " ~ APPLICATION_AUTHOR;
-enum APPLICATION_COMMENTS = "A VTE based terminal emulator for Linux";
-enum APPLICATION_LICENSE = "This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.";
+enum APPLICATION_COMMENTS = N_("A VTE based terminal emulator for Linux");
+enum APPLICATION_LICENSE = N_("This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.");
 enum APPLICATION_ICON_NAME = "utilities-terminal";
 
-immutable string[] APPLICATION_AUTHORS = ["Gerald Nunn"];
+immutable string[] APPLICATION_AUTHORS = [APPLICATION_AUTHOR];
 string[] APPLICATION_CREDITS = [
-    "GTK VTE widget team, Terminix would not be possible without their work", "GtkD for providing such an excellent GTK wrapper", "Dlang.org for such an excellent language, D"
+    N_("GTK VTE widget team, Terminix would not be possible without their work"),
+    N_("GtkD for providing such an excellent GTK wrapper"),
+    N_("Dlang.org for such an excellent language, D")
 ];
 immutable string[] APPLICATION_ARTISTS = [];
 immutable string[] APPLICATION_DOCUMENTERS = [""];


### PR DESCRIPTION
This makes the relevant texts in the about dialog translatable. I haven't run extract-strings in this branch, I suggest doing that after the merge (and after the open translation PRs are merged, too) to avoid conflicts.