### PR TITLE
Recompile schema when uninstalling

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,6 +15,7 @@ echo "Uninstalling from prefix ${PREFIX}"
 
 rm ${PREFIX}/bin/terminix
 rm ${PREFIX}/share/glib-2.0/schemas/com.gexperts.Terminix.gschema.xml
+glib-compile-schemas ${PREFIX}/share/glib-2.0/schemas/
 rm -rf ${PREFIX}/share/terminix
 
 find ${PREFIX}/share/locale -type f -name "terminix.mo" -delete


### PR DESCRIPTION
This fixes the issue that the schema would remain on the system even though the XML was removed. A wrong / outdated schema present in e.g. /usr/local can make the app crash on start.