### PR TITLE
Shortcuts help: Mark section titles as translatable.

### DIFF
--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -7,7 +7,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>
         <property name="section-name">app</property>
-        <property name="title">Application</property>
+        <property name="title" translatable="yes">Application</property>
         <property name="max-height">12</property>
         <child>
           <object class="GtkShortcutsGroup">
@@ -135,7 +135,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>
         <property name="section-name">session</property>
-        <property name="title">Session</property>
+        <property name="title" translatable="yes">Session</property>
         <property name="max-height">12</property>
         <child>
           <object class="GtkShortcutsGroup">
@@ -165,7 +165,7 @@
                 <property name="title" translatable="yes" context="shortcut window">Open a saved session</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
@@ -195,7 +195,7 @@
                 <property name="title" translatable="yes" context="shortcut window">Resize the terminal right</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
@@ -305,7 +305,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>
         <property name="section-name">terminal</property>
-        <property name="title">Terminal</property>
+        <property name="title" translatable="yes">Terminal</property>
         <property name="max-height">12</property>
         <child>
           <object class="GtkShortcutsGroup">
@@ -323,7 +323,7 @@
                 <property name="title" translatable="yes" context="shortcut window">Split vertical</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
@@ -347,7 +347,7 @@
                 <property name="title" translatable="yes" context="shortcut window">Find previous</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
@@ -371,7 +371,7 @@
                 <property name="title" translatable="yes" context="shortcut window">Select all</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
@@ -395,7 +395,7 @@
                 <property name="title" translatable="yes" context="shortcut window">Zoom normal size</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
@@ -437,9 +437,9 @@
                 <property name="title" translatable="yes" context="shortcut window">Layout options</property>
               </object>
             </child>
-          </object>            
+          </object>
         </child>
       </object>
-    </child>  
+    </child>
   </object>
-</interface>                         
+</interface>


### PR DESCRIPTION
This makes the section titles in the shortcut overview translatable (the dropdown in the header bar).

To actually take effect this requires an update of the pot/po files.