### PR TITLE
I18n fixes: Nautilus extension and extraction order

### DIFF
--- a/data/nautilus/open-terminix.py
+++ b/data/nautilus/open-terminix.py
@@ -16,38 +16,38 @@ gi.require_version('Nautilus', '3.0')
 from gi.repository import Nautilus, GObject, Gio
 
 class OpenTerminixExtension(GObject.GObject, Nautilus.MenuProvider):
-        
+
     def _open_terminal(self, file):
         gfile = Gio.File.new_for_uri(file.get_uri())
         filename = gfile.get_path();
         terminal = "terminix"
 
-        #print "Opening file:", filename 
+        #print "Opening file:", filename
         os.system('%s -w "%s" &' % (terminal, filename))
-        
+
     def menu_activate_cb(self, menu, file):
         self._open_terminal(file)
-        
-    def menu_background_activate_cb(self, menu, file): 
+
+    def menu_background_activate_cb(self, menu, file):
         self._open_terminal(file)
-       
+
     def get_file_items(self, window, files):
         if len(files) != 1:
             return
-        
+
         file = files[0]
         if not file.is_directory() or file.get_uri_scheme() != 'file':
             return
-        
+
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                 label=_('Open in Terminix…'),
-                                 tip=_('Open Terminix In %s') % file.get_name())
+                                 label=_(u'Open in Terminix…'),
+                                 tip=_(u'Open Terminix In %s') % file.get_name())
         item.connect('activate', self.menu_activate_cb, file)
         return item,
 
     def get_background_items(self, window, file):
         item = Nautilus.MenuItem(name='NautilusPython::openterminal_item',
-                                 label=_('Open Terminix Here…'),
-                                 tip=_('Open Terminix In This Directory'))
+                                 label=_(u'Open Terminix Here…'),
+                                 tip=_(u'Open Terminix In This Directory'))
         item.connect('activate', self.menu_background_activate_cb, file)
         return item,

--- a/extract-strings.sh
+++ b/extract-strings.sh
@@ -33,6 +33,15 @@ xgettext \
   --directory=$BASEDIR \
   ${BASEDIR}/data/nautilus/open-terminix.py
 
+# Glade UI Files
+find ${BASEDIR}/data/resources/ui -name '*.ui' | xgettext \
+  --join-existing \
+  --output $OUTPUT_FILE \
+  --files-from=- \
+  --directory=$BASEDIR \
+  --language=Glade \
+  --from-code=utf-8
+
 xgettext \
   --join-existing \
   --output $OUTPUT_FILE \
@@ -42,15 +51,6 @@ xgettext \
   --foreign-user \
   --language=Desktop \
   ${BASEDIR}/data/pkg/desktop/com.gexperts.Terminix.desktop.in
-  
-# Glade UI Files
-find ${BASEDIR}/data/resources/ui -name '*.ui' | xgettext \
-  --join-existing \
-  --output $OUTPUT_FILE \
-  --files-from=- \
-  --directory=$BASEDIR \
-  --language=Glade \
-  --from-code=utf-8
 
 # Merge the messages with existing po files
 echo "Merging with existing translations... "

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
 "Language-Team: \n"
@@ -216,14 +216,416 @@ msgstr "Ansicht verkleinern"
 msgid "zoom-normal"
 msgstr "Ansicht Standardvergrößerung"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Die Datei %s ist keine konforme Farbschema-Datei"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "Suchoptionen"
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
-msgstr "Die Palette des Farbschemas erfordert 16 Farben"
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "Groß-/Kleinschreibung beachten"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "Nur vollständige Wörter berücksichtigen"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "Als regulären Ausdruck verarbeiten"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "Schließen"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr "Maximieren"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr "Eingabesynchronisierung für dieses Terminal deaktivieren"
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "Profil bearbeiten"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "Es gibt noch laufende Prozesse, trotzdem beenden?"
+
+#: source/gx/terminix/terminal/terminal.d:553
+msgid "Enable input synchronization for this terminal"
+msgstr "Eingabesynchronisierung für dieses Terminal aktivieren"
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "Speichern …"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "Suchen …"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr "Layout-Optionen …"
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "Nur lesen"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "Profile"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "Zeichenkodierung"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "Nach rechts teilen"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "Nach unten teilen"
+
+#: source/gx/terminix/terminal/terminal.d:640
+msgid "Split"
+msgstr "Teilen"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr "Wiederherstellen"
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr "Link öffnen"
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr "Link-Adresse kopieren"
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "Kopieren"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "Einfügen"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "Alles markieren"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr "Zwischenablage"
+
+#: source/gx/terminix/terminal/terminal.d:925
+msgid "Synchronize input"
+msgstr "Eingabe synchronisieren"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Unerwarteter Fehler aufgetreten: %s"
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr "Terminalausgabe speichern"
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr "Alle Textdateien"
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr "Alle Dateien"
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Der Kindprozess wurde normal mit Status %d beendet."
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Der Kindprozess wurde mit Signal %d beendet."
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr "Der Kindprozess wurde beendet."
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr "Neustart"
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+"Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
+"macht."
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "Nicht einfügen"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr "Trotzdem einfügen"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Layout-Optionen"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Aktiv"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Sitzung"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "Befehl"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktive Optionen sind immer aktiv und werden sofort angewendet. Sitzungs-"
+"Optionen werden nur beim Laden der Sitzung angewendet."
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "Standard"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "Sitzungs-Seitenleiste anzeigen"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "Neue Sitzung erstellen"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "Sitzungsnamen ändern"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr "Öffnen …"
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "Speichern"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "Speichern unter …"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "Name …"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "Eingabe synchronisieren"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr "Alle JSON-Dateien"
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Dateiname »%s« existiert nicht"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "Sitzung laden"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr ""
+"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "Fehler beim Laden der Sitzung"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "Sitzung speichern"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "Neue Sitzung"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "Neues Fenster"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "Tastenkombinationen"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "Info"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "Beenden"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr "Mitwirkende"
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "Arbeitsordner des Terminals wählen"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr "ORDNER"
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "Als Startprofil festlegen"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr "PROFIL_NAME"
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "Die angegebene Sitzung öffnen"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr "SITZUNGS_NAME"
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr "AKTIONS_NAME"
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "Übergebenen Befehl ausführen"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr "BEFEHL"
+
+#: source/gx/terminix/application.d:404
+msgid "Maximize the terminal window"
+msgstr "Terminalfenster maximieren"
+
+#: source/gx/terminix/application.d:405
+msgid "Full-screen the terminal window"
+msgstr "Terminalfenster im Vollbildmodus anzeigen"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
+"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
+"Klicken Sie auf den unten stehenden Link für weitere Informationen:"
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "Probleme mit der Konfiguration entdeckt"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "Diese Meldung nicht mehr anzeigen"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -237,11 +639,6 @@ msgstr "Neues Profil"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "Allgemein"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "Befehl"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -473,12 +870,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "Entfernen-Taste erzeugt"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "Zeichenkodierung"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "Zeichen mit unbekannter Breite:"
@@ -514,6 +905,31 @@ msgstr "Befehl neu starten"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "Terminal geöffnet lassen"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Die Datei %s ist keine konforme Farbschema-Datei"
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr "Die Palette des Farbschemas erfordert 16 Farben"
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "Das abgelegte Terminal konnte nicht gefunden werden"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "Die Sitzung für das abgelegte Terminal konnte nicht gefunden werden"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "Name"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "Profil"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -679,133 +1095,9 @@ msgstr "Vietnamesisch"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "Neue Sitzung"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "Neues Fenster"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "Tastenkombinationen"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "Info"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "Beenden"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr "Mitwirkende"
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "Arbeitsordner des Terminals wählen"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr "ORDNER"
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "Als Startprofil festlegen"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr "PROFIL_NAME"
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "Die angegebene Sitzung öffnen"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr "SITZUNGS_NAME"
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr "AKTIONS_NAME"
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "Übergebenen Befehl ausführen"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr "BEFEHL"
-
-#: source/gx/terminix/application.d:404
-msgid "Maximize the terminal window"
-msgstr "Terminalfenster maximieren"
-
-#: source/gx/terminix/application.d:405
-msgid "Full-screen the terminal window"
-msgstr "Terminalfenster im Vollbildmodus anzeigen"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
-"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
-"Klicken Sie auf den unten stehenden Link für weitere Informationen:"
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "Probleme mit der Konfiguration entdeckt"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "Diese Meldung nicht mehr anzeigen"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "Das abgelegte Terminal konnte nicht gefunden werden"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "Die Sitzung für das abgelegte Terminal konnte nicht gefunden werden"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "Name"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "Profil"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "Global"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "Profile"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -822,11 +1114,6 @@ msgstr "Aktion"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "Tastenkombination"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "Standard"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -871,12 +1158,6 @@ msgstr "Horizontal teilen"
 #: source/gx/terminix/prefwindow.d:490
 msgid "Split Vertical"
 msgstr "Vertikal teilen"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "Einfügen"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -928,215 +1209,6 @@ msgstr "Dunkel"
 msgid "Use a wide handle for splitters"
 msgstr "Breiten Griff für Fenstertrenner verwenden"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Layout-Optionen"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Aktiv"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Sitzung"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktive Optionen sind immer aktiv und werden sofort angewendet. Sitzungs-"
-"Optionen werden nur beim Laden der Sitzung angewendet."
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "Suchoptionen"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "Groß-/Kleinschreibung beachten"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "Nur vollständige Wörter berücksichtigen"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "Als regulären Ausdruck verarbeiten"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "Schließen"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr "Maximieren"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr "Eingabesynchronisierung für dieses Terminal deaktivieren"
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "Profil bearbeiten"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "Es gibt noch laufende Prozesse, trotzdem beenden?"
-
-#: source/gx/terminix/terminal/terminal.d:553
-msgid "Enable input synchronization for this terminal"
-msgstr "Eingabesynchronisierung für dieses Terminal aktivieren"
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "Speichern …"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "Suchen …"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr "Layout-Optionen …"
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "Nur lesen"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "Nach rechts teilen"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "Nach unten teilen"
-
-#: source/gx/terminix/terminal/terminal.d:640
-msgid "Split"
-msgstr "Teilen"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr "Wiederherstellen"
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr "Link öffnen"
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr "Link-Adresse kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "Kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "Alles markieren"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr "Zwischenablage"
-
-#: source/gx/terminix/terminal/terminal.d:925
-msgid "Synchronize input"
-msgstr "Eingabe synchronisieren"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Unerwarteter Fehler aufgetreten: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr "Terminalausgabe speichern"
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr "Alle Textdateien"
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr "Alle Dateien"
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Der Kindprozess wurde normal mit Status %d beendet."
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Der Kindprozess wurde mit Signal %d beendet."
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr "Der Kindprozess wurde beendet."
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr "Neustart"
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-"Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
-"macht."
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "Nicht einfügen"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr "Trotzdem einfügen"
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1155,77 +1227,6 @@ msgstr ""
 "Sie können keine Sitzung laden und gleichzeitig ein Profil / einen "
 "Arbeitsordner setzen oder eine Befehlsoption ausführen. Bitte wählen Sie das "
 "eine oder das andere."
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "Sitzungs-Seitenleiste anzeigen"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "Neue Sitzung erstellen"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "Sitzungsnamen ändern"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr "Öffnen …"
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "Speichern"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "Speichern unter …"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "Name …"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "Eingabe synchronisieren"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr "Alle JSON-Dateien"
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Dateiname »%s« existiert nicht"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "Sitzung laden"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr ""
-"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "Fehler beim Laden der Sitzung"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "Sitzung speichern"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 msgid "disabled"
@@ -1266,13 +1267,9 @@ msgstr "Terminix hier öffnen …"
 msgid "Open Terminix In This Directory"
 msgstr "Terminix in diesem Ordner öffnen"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr "Ein Terminal für Gnome mit Kacheldarstellung"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+msgid "Application"
+msgstr "Anwendung"
 
 #: data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
@@ -1373,6 +1370,10 @@ msgstr "Zu Sitzung 9 wechseln"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Zu Sitzung 10 wechseln"
+
+#: data/resources/ui/shortcuts.ui:138
+msgid "Session"
+msgstr "Sitzung"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1618,6 +1619,14 @@ msgstr "Nur lesend umschalten"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Layout-Optionen"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr "Ein Terminal für Gnome mit Kacheldarstellung"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "Horizontal teilen"

--- a/po/en.po
+++ b/po/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
 "Language-Team: \n"
@@ -214,14 +214,415 @@ msgstr "Zoom Out"
 msgid "zoom-normal"
 msgstr "Zoom Normal"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "Search Options"
+
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "Match case"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "Match entire word only"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "Match as regular expression"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "Wrap around"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "Close"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+#, fuzzy
+msgid "Maximize"
+msgstr "Maximize"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "Edit Profile"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
 msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:553
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "Save…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "Find…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "Read-Only"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "Profiles"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "Encoding"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "Split Right"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "Split Down"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "Split Down"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "Copy"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "Paste"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "Select All"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Synchronize Input"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "Don't Paste"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Layout Options"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "Command"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "Default"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "View session sidebar"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "Create a new session"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "Change Session Name"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "Enter a new name for the session"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "Save"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "Save As…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "Name…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "Synchronize Input"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Filename '%s' does not exist"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "Load Session"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "Could not load session due to unexpected error."
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "Error Loading Session"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "Save Session"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "New Session"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "New Window"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "Preferences"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "About"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "Quit"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "Set the starting profile"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "Open the specified session"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "Send an action to current Terminix instance"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "Execute the passed command"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr ""
+
+#: source/gx/terminix/application.d:404
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:405
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"There appears to be an issue with the configuration of the terminal. This\n"
+"issue is not serious, but correcting it will improve your experience. Click\n"
+"the link below for more information:"
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "Configuration Issue Detected"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "Do not show this message again"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -235,11 +636,6 @@ msgstr "New Profile"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "General"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "Command"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -471,12 +867,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "Delete key generates"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "Encoding"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "Ambiguous-width characters"
@@ -512,6 +902,31 @@ msgstr "Restart the command"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "Hold the terminal open"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "Could not locate dropped terminal"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "Could not locate session for dropped terminal"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "Name"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "Profile"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -674,135 +1089,9 @@ msgstr "Vietnamese"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "New Session"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "New Window"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "Preferences"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "Shortcuts"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "About"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "Quit"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "Set the starting profile"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "Open the specified session"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "Send an action to current Terminix instance"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "Execute the passed command"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:404
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:405
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"There appears to be an issue with the configuration of the terminal. This\n"
-"issue is not serious, but correcting it will improve your experience. Click\n"
-"the link below for more information:"
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "Configuration Issue Detected"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "Do not show this message again"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "Could not locate dropped terminal"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "Could not locate session for dropped terminal"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "Name"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "Profile"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "Global"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "Profiles"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -819,11 +1108,6 @@ msgstr "Action"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "Shortcut Key"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "Default"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -868,12 +1152,6 @@ msgstr "Split Horizontal"
 #: source/gx/terminix/prefwindow.d:490
 msgid "Split Vertical"
 msgstr "Split Vertical"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "Paste"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -924,213 +1202,6 @@ msgstr "Dark"
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Layout Options"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "Search Options"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "Match case"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "Match entire word only"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "Match as regular expression"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "Wrap around"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "Close"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-#, fuzzy
-msgid "Maximize"
-msgstr "Maximize"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "Edit Profile"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:553
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "Save…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "Find…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "Read-Only"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "Split Right"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "Split Down"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "Split Down"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "Copy"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "Select All"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Synchronize Input"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "Don't Paste"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1146,76 +1217,6 @@ msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "View session sidebar"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "Create a new session"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "Change Session Name"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "Enter a new name for the session"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "Save"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "Save As…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "Name…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "Synchronize Input"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Filename '%s' does not exist"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "Load Session"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "Could not load session due to unexpected error."
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "Error Loading Session"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "Save Session"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 msgid "disabled"
@@ -1251,13 +1252,10 @@ msgstr ""
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "Action"
 
 #: data/resources/ui/shortcuts.ui:15
 #, fuzzy
@@ -1377,6 +1375,11 @@ msgstr "Switch To Session 9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Switch To Session 10"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "Session"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1656,6 +1659,14 @@ msgstr "Read-only"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Options"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr ""
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "Split Horizontal"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -230,14 +230,420 @@ msgstr "Zoom arrière"
 msgid "zoom-normal"
 msgstr "Réinitialiser le niveau de zoom"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "Options de recherche"
+
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "Respecter la case"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "Mots entiers seulement"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "Utiliser comme expression régulière"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "Recherche circulaire"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "Fermer"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
 msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "Modifier Profil"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:553
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "Enregistrer…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "Rechercher…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "Lecture-Seule"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "Profils"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "Codage"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "Division droite"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "Division basse"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "Division basse"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "Copier"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "Coller"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "Tout Séléctionner"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Synchroniser l'entrée"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1964
+#, fuzzy
+msgid "Don't Paste"
+msgstr "Coller"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+#, fuzzy
+msgid "Layout Options"
+msgstr "Options"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+#, fuzzy
+msgid "Active"
+msgstr "Action"
+
+#: source/gx/terminix/terminal/layout.d:49
+#, fuzzy
+msgid "Title"
+msgstr "Titre"
+
+#: source/gx/terminix/terminal/layout.d:57
+#, fuzzy
+msgid "Session Load"
+msgstr "Session"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "Commande"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "Par défaut"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "Créer une nouvelle session"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "Changer le nom de la sesssion"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "Entrer un nouveau nom pour la session"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "Enregistrer"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "Enregistrer Sous…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "Nom…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "Synchroniser l'entrée"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Nom de fichier '%s' n'existe pas"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "Charger Session"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "Impossible de charger session en raison de l'erreur inattendue ."
+
+#: source/gx/terminix/appwindow.d:727
+#, fuzzy
+msgid "Error Loading Session"
+msgstr "Charger Session"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "Sauvegarder Session"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "Nouvelle Session"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "Nouvelle Fenêtre"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "Préférences"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "À propos"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "Quitter"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "Définir le répertoire de travail pour le terminal"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "Définir le profil de démarrage"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "Ouvrir la session specifiée"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "Envoyer une action à l'instance actuelle Terminix"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "Exécuter la commande passée"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr ""
+
+#: source/gx/terminix/application.d:404
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "Conserver le terminal ouvert"
+
+#: source/gx/terminix/application.d:405
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "Conserver le terminal ouvert"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Il semble y avoir un problème avec la configuration du terminal. Ce problème "
+"n'est pas grave, mais en les corrigeant çela permettra d'améliorer votre "
+"expérience. Cliquez sur le lien ci-dessous pour plus d'informations:"
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "Problème de configuration détecté"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "Ne pas réafficher ce message"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -252,11 +658,6 @@ msgstr "Profil"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "Général"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "Commande"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -488,12 +889,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "La touche « Suppr » émet"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "Codage"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "Caractères de largeur ambigüe"
@@ -530,6 +925,31 @@ msgstr "Relancer la commande"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "Conserver le terminal ouvert"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "Impossible de localiser le terminal chuté"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "Impossible de localiser la session pour le terminal chuté"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "Nom"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "Profil"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -693,135 +1113,9 @@ msgstr "Vietnamese"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "Nouvelle Session"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "Nouvelle Fenêtre"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "Préférences"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "Raccourcis"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "À propos"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "Quitter"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "Définir le répertoire de travail pour le terminal"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "Définir le profil de démarrage"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "Ouvrir la session specifiée"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "Envoyer une action à l'instance actuelle Terminix"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "Exécuter la commande passée"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:404
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "Conserver le terminal ouvert"
-
-#: source/gx/terminix/application.d:405
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "Conserver le terminal ouvert"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Il semble y avoir un problème avec la configuration du terminal. Ce problème "
-"n'est pas grave, mais en les corrigeant çela permettra d'améliorer votre "
-"expérience. Cliquez sur le lien ci-dessous pour plus d'informations:"
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "Problème de configuration détecté"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "Ne pas réafficher ce message"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "Impossible de localiser le terminal chuté"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "Impossible de localiser la session pour le terminal chuté"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "Nom"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "Profil"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "Général"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "Profils"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -838,11 +1132,6 @@ msgstr "Action"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "Touche de raccourci"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "Par défaut"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -889,12 +1178,6 @@ msgstr "Division horizontale"
 #, fuzzy
 msgid "Split Vertical"
 msgstr "Division verticale"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "Coller"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -947,217 +1230,6 @@ msgstr "Sombre"
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#, fuzzy
-msgid "Layout Options"
-msgstr "Options"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-#, fuzzy
-msgid "Active"
-msgstr "Action"
-
-#: source/gx/terminix/terminal/layout.d:49
-#, fuzzy
-msgid "Title"
-msgstr "Titre"
-
-#: source/gx/terminix/terminal/layout.d:57
-#, fuzzy
-msgid "Session Load"
-msgstr "Session"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "Options de recherche"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "Respecter la case"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "Mots entiers seulement"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "Utiliser comme expression régulière"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "Recherche circulaire"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "Fermer"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "Modifier Profil"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:553
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "Enregistrer…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "Rechercher…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "Lecture-Seule"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "Division droite"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "Division basse"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "Division basse"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "Copier"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "Tout Séléctionner"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Synchroniser l'entrée"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1964
-#, fuzzy
-msgid "Don't Paste"
-msgstr "Coller"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1173,77 +1245,6 @@ msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "Créer une nouvelle session"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "Changer le nom de la sesssion"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "Entrer un nouveau nom pour la session"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "Enregistrer"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "Enregistrer Sous…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "Nom…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "Synchroniser l'entrée"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Nom de fichier '%s' n'existe pas"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "Charger Session"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "Impossible de charger session en raison de l'erreur inattendue ."
-
-#: source/gx/terminix/appwindow.d:727
-#, fuzzy
-msgid "Error Loading Session"
-msgstr "Charger Session"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "Sauvegarder Session"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 #, fuzzy
@@ -1280,13 +1281,10 @@ msgstr ""
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "Action"
 
 #: data/resources/ui/shortcuts.ui:15
 #, fuzzy
@@ -1404,6 +1402,11 @@ msgstr "Basculer vers la session 9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Basculer vers la session 10"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "Session"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1688,6 +1691,14 @@ msgstr "Lecture-seul"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Options"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr ""
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "Division horizontale"

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Youngbin Han <sukso96100@gmail.com>\n"
 "Language-Team: sukso96100@gmail.com\n"
@@ -229,14 +229,418 @@ msgstr "축소"
 msgid "zoom-normal"
 msgstr "확대 원래대로"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "파일 %s은(는) 색상 스키마 호환 JSON 파일이 아닙니다"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "검색 옵션"
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
-msgstr "색상표에 16 가지 색상이 필요합니다"
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "일치 경우"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "전체 단어 일치만"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "정규 표현식으로 일치"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "주변 감싸기"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "터미널"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "닫기"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr "최대화"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "프로파일 편집"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
+
+#: source/gx/terminix/terminal/terminal.d:553
+#, fuzzy
+msgid "Enable input synchronization for this terminal"
+msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "저장…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "찾기…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr "레이아웃 옵션…"
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "읽기전용"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "프로파일"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "인코딩"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "오른쪽으로 분할"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "아래로 분할"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "아래로 분할"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr "복원"
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "복사"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "붙여넣기"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "모두 선택"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "입력 동기화"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다."
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "예상하지 못한 오류가 발생했습니다. %s"
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr "터미널 출력 저장"
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr "모든 텍스트 파일"
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr "모든 파일"
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다. %d"
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr "자식 프로세스가 중지되었습니다."
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr "다시 시작"
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "붙여넣지 마세요"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr "어떻게든 붙여넣기"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "레이아웃 옵션"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "확인"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr "취소"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "동작"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "제목"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "세션"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "명령어"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"활성 옵션은 항상 영향을 주며 바로 적용됩니다.\n"
+"세션 불러오기 옵션은 세션 파일을 불러올 때만 적용됩니다."
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "기본값"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "세션 사이드바 보기"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "새 세션 만들기"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "세션 이름 바꾸기"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "새 세션 이름 입력"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "저장"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "다른 이름으로 저장…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "이름…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "입력 동기화"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr "모든 JSON 파일"
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "파일 이름 '%s'이(가) 없습니다."
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "세션 불러오기"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "세션 불러오기 오류"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "세션 저장"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "새 세션"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "새 창"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "기본 설정"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "바로 가기"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "정보"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "끝내기"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr "크레딧"
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "터미널 작업 디렉터리 설정"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "시작 프로파일 설정"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "특정 세션 열기"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "현재 Terminix 인스턴스로 동작 보내기"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "전달된 명령어 실행"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr ""
+
+#: source/gx/terminix/application.d:404
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "터미널 열림 유지"
+
+#: source/gx/terminix/application.d:405
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "터미널 열림 유지"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"터미널 설정에 이슈가 있는 것으로 보입니다.\n"
+"이 이슈는 심각하지 않습니다. 그러나 고친다면 사용 경험이 향상됩니다\n"
+"자세한 정보는 아래 링크를 누르세요."
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "설정 이슈 감지됨"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "이 메시지 다시 보지 않기"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -250,11 +654,6 @@ msgstr "새 프로파일"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "일반"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "명령어"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -486,12 +885,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "Delete 키 누를 때 생성할 것"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "인코딩"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "모호한 폭의 문자"
@@ -527,6 +920,31 @@ msgstr "명령어 다시 시작"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "터미널 열림 유지"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "파일 %s은(는) 색상 스키마 호환 JSON 파일이 아닙니다"
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr "색상표에 16 가지 색상이 필요합니다"
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "중단된 터미널을 위치시킬 수 없습니다"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "중단된 터미널을 위한 세션을 위치시킬 수 없습니다"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "이름"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "프로파일"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -689,135 +1107,9 @@ msgstr "베트남어"
 msgid "Thai"
 msgstr "태국어"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "새 세션"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "새 창"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "기본 설정"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "바로 가기"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "정보"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "끝내기"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr "크레딧"
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "터미널 작업 디렉터리 설정"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "시작 프로파일 설정"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "특정 세션 열기"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "현재 Terminix 인스턴스로 동작 보내기"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "전달된 명령어 실행"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:404
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "터미널 열림 유지"
-
-#: source/gx/terminix/application.d:405
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "터미널 열림 유지"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"터미널 설정에 이슈가 있는 것으로 보입니다.\n"
-"이 이슈는 심각하지 않습니다. 그러나 고친다면 사용 경험이 향상됩니다\n"
-"자세한 정보는 아래 링크를 누르세요."
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "설정 이슈 감지됨"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "이 메시지 다시 보지 않기"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "중단된 터미널을 위치시킬 수 없습니다"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "중단된 터미널을 위한 세션을 위치시킬 수 없습니다"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "이름"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "프로파일"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "전역"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "프로파일"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -834,11 +1126,6 @@ msgstr "동작"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "단축키"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "기본값"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -885,12 +1172,6 @@ msgstr "수평으로 분할"
 #, fuzzy
 msgid "Split Vertical"
 msgstr "수직으로 분할"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "붙여넣기"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -941,216 +1222,6 @@ msgstr "어두움"
 msgid "Use a wide handle for splitters"
 msgstr "스플라이터에 대해 넓은 핸들 사용하기"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "레이아웃 옵션"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr "확인"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr "취소"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "동작"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "제목"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "세션"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"활성 옵션은 항상 영향을 주며 바로 적용됩니다.\n"
-"세션 불러오기 옵션은 세션 파일을 불러올 때만 적용됩니다."
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "검색 옵션"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "일치 경우"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "전체 단어 일치만"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "정규 표현식으로 일치"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "주변 감싸기"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "터미널"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "닫기"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr "최대화"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "프로파일 편집"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
-
-#: source/gx/terminix/terminal/terminal.d:553
-#, fuzzy
-msgid "Enable input synchronization for this terminal"
-msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "저장…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "찾기…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr "레이아웃 옵션…"
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "읽기전용"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "오른쪽으로 분할"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "아래로 분할"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "아래로 분할"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr "복원"
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "복사"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "모두 선택"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "입력 동기화"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다."
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "예상하지 못한 오류가 발생했습니다. %s"
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr "터미널 출력 저장"
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr "모든 텍스트 파일"
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr "모든 파일"
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다. %d"
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr "자식 프로세스가 중지되었습니다."
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr "다시 시작"
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "붙여넣지 마세요"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr "어떻게든 붙여넣기"
-
 #: source/gx/terminix/cmdparams.d:71
 #, fuzzy, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1168,76 +1239,6 @@ msgid ""
 msgstr ""
 "세션 불러오기와 프로파일/작업 디렉터리/실행 명령어 설정을 하실 수 없습니다. "
 "하나 또는 다른것을 선택하세요."
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "세션 사이드바 보기"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "새 세션 만들기"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "세션 이름 바꾸기"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "새 세션 이름 입력"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "저장"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "다른 이름으로 저장…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "이름…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "입력 동기화"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr "모든 JSON 파일"
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "파일 이름 '%s'이(가) 없습니다."
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "세션 불러오기"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "세션 불러오기 오류"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "세션 저장"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 msgid "disabled"
@@ -1274,13 +1275,10 @@ msgstr "여기서 Terminix 열기…"
 msgid "Open Terminix In This Directory"
 msgstr "이 디렉터리에서 Terminix 열기"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr "그놈을 위한 타일링 터미널"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "동작"
 
 #: data/resources/ui/shortcuts.ui:15
 #, fuzzy
@@ -1400,6 +1398,11 @@ msgstr "세션 9번으로 전환"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "세션 10번으로 전환"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "세션"
 
 #: data/resources/ui/shortcuts.ui:143
 #, fuzzy
@@ -1685,6 +1688,14 @@ msgstr "읽기전용"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "레이아웃 옵션"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr "그놈을 위한 타일링 터미널"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "수평으로 분할"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.55\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: 2016-03-30 12:03+0200\n"
 "Last-Translator: Piotr Sokół <psokol.l10n@gmail.com>\n"
 "Language-Team: polski <>\n"
@@ -216,14 +216,420 @@ msgstr "Pomniejszenie zawartości"
 msgid "zoom-normal"
 msgstr "Przywrócenie zwykłego rozmiaru"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Plik %s nie jest zgodny z formatem pliku JSON zestawu kolorów"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "Opcje wyszukiwania"
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
-msgstr "Paleta zestawu kolorów wymaga 16 kolorów"
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "Uwzględnianie wielkości liter"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "Dopasowanie całych słów"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "Dopasowanie do wyrażenia regularnego"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "Przeszukanie od początku po osiągnięciu końca"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "Zamknij"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr "Zmaksymalizuj"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "Zmodyfikuj profil"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "Pewne procesy wciąż działają. Zamknąć mimo to?"
+
+#: source/gx/terminix/terminal/terminal.d:553
+#, fuzzy
+msgid "Enable input synchronization for this terminal"
+msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "Zapisz…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "Wyszukaj…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr "Opcje układu…"
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "Tylko do odczytu"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "Profile"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "Kodowanie znaków"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "Podziel w poziomie"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "Podziel w pionie"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "Dzielenie"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr "Przywróć"
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr "Otwórz odnośnik"
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr "Skopiuj adres odnośnika"
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "Skopiuj"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "Wklej"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "Zaznacz wszystko"
+
+#: source/gx/terminix/terminal/terminal.d:911
+#, fuzzy
+msgid "Clipboard"
+msgstr "Schowek"
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Synchronizowanie wprowadzania"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Wystąpił nieoczekiwany błąd: %s"
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr "Zapisywanie zawartości terminala"
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr "Wszystkie pliki tekstowe"
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr "Wszystkie pliki"
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Proces podrzędny został zakończony w zwykły sposób, ze stanem %d"
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Przerwano proces podrzędny sygnałem %d."
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr "Przerwano proces podrzędny."
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr "Uruchom ponownie"
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+"Wklejanie do terminala poleceń opublikowanych w sieci może być niebezpieczne."
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+"Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "Nie wklejaj"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr "Wklej mimo to"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opcje układu"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Bieżące"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Tytuł"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Wczytywanie sesji"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "Polecenie"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Bieżące opcje działają cały czas i są wprowadzane natychmiastowo.\n"
+"Opcje wczytywania sesji są wprowadzane tylko podczas wczytywania pliku sesji."
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "Domyślny"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "Wyświetla pasek boczny sesji"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "Tworzy nową sesję"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "Zmiana nazwy sesji"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "Proszę wprowadzić nazwę sesji"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "Zapisz"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "Zapisz jako…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "Nadaj nazwę…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "Synchronizowanie wprowadzania"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr "Wszystkie pliki JSON"
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Plik „%s” nie istnieje"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "Wczytywanie sesji"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "Błąd wczytywania sesji"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "Zapisywanie sesji"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "Nowa sesja"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "Nowe okno"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "Skróty klawiszowe"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "O programie"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "Zakończ"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr "Zasługi"
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "Ustala katalog roboczy terminala"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr "KATALOG"
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "Używa zdefiniowanego profilu"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr "NAZWA_PROFILU"
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "Otwiera określoną sesję"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr "NAZWA_SESJI"
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr "NAZWA_CZYNNOŚCI"
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "Wykonuje określone polecenie"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr "POLECENIE"
+
+#: source/gx/terminix/application.d:404
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "Zmienienie rozmiaru terminala w dół"
+
+#: source/gx/terminix/application.d:405
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "Zmienienie rozmiaru terminala w dół"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINALA"
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Natrafiono na problem z konfiguracją terminala.\n"
+"Błąd nie jest poważny, ale naprawienie go ułatwi pracę z programem.\n"
+"Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "Wykryto błąd konfiguracji"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -237,11 +643,6 @@ msgstr "Nowy profil"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "Ogólne"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "Polecenie"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -472,12 +873,6 @@ msgstr "Znak wymazania TTY"
 msgid "Delete key generates"
 msgstr "Działanie klawisza Delete"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "Kodowanie znaków"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "Znaki o zmiennej szerokości"
@@ -513,6 +908,31 @@ msgstr "Ponowne uruchomienie polecenia"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "Pozostawienia terminala otwartego"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Plik %s nie jest zgodny z formatem pliku JSON zestawu kolorów"
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr "Paleta zestawu kolorów wymaga 16 kolorów"
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "Nie można odnaleźć porzuconego terminala"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "Nie można odnaleźć sesji porzuconego terminala"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "Nazwa"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "Profil"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -672,135 +1092,9 @@ msgstr "Wietnamskie"
 msgid "Thai"
 msgstr "Tajskie"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "Nowa sesja"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "Nowe okno"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "Skróty klawiszowe"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "O programie"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "Zakończ"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr "Zasługi"
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "Ustala katalog roboczy terminala"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr "KATALOG"
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "Używa zdefiniowanego profilu"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr "NAZWA_PROFILU"
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "Otwiera określoną sesję"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr "NAZWA_SESJI"
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr "NAZWA_CZYNNOŚCI"
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "Wykonuje określone polecenie"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr "POLECENIE"
-
-#: source/gx/terminix/application.d:404
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "Zmienienie rozmiaru terminala w dół"
-
-#: source/gx/terminix/application.d:405
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "Zmienienie rozmiaru terminala w dół"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINALA"
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Natrafiono na problem z konfiguracją terminala.\n"
-"Błąd nie jest poważny, ale naprawienie go ułatwi pracę z programem.\n"
-"Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "Wykryto błąd konfiguracji"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "Nie można odnaleźć porzuconego terminala"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "Nie można odnaleźć sesji porzuconego terminala"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "Nazwa"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "Profil"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "Ogólne"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "Profile"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -817,11 +1111,6 @@ msgstr "Działanie"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "Klawisz skrótu"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "Domyślny"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -866,12 +1155,6 @@ msgstr "Podzielenie terminala poziomo"
 #: source/gx/terminix/prefwindow.d:490
 msgid "Split Vertical"
 msgstr "Podzielenie terminala pionowo"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "Wklej"
 
 # Notatki:
 # Dodaj notatkę
@@ -925,218 +1208,6 @@ msgstr "Ciemny"
 msgid "Use a wide handle for splitters"
 msgstr "Szerokie uchwyty elementów rozdzielających"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opcje układu"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Bieżące"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Tytuł"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Wczytywanie sesji"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Bieżące opcje działają cały czas i są wprowadzane natychmiastowo.\n"
-"Opcje wczytywania sesji są wprowadzane tylko podczas wczytywania pliku sesji."
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "Opcje wyszukiwania"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "Uwzględnianie wielkości liter"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "Dopasowanie całych słów"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "Dopasowanie do wyrażenia regularnego"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "Przeszukanie od początku po osiągnięciu końca"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "Zamknij"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr "Zmaksymalizuj"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "Zmodyfikuj profil"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "Pewne procesy wciąż działają. Zamknąć mimo to?"
-
-#: source/gx/terminix/terminal/terminal.d:553
-#, fuzzy
-msgid "Enable input synchronization for this terminal"
-msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "Zapisz…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "Wyszukaj…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr "Opcje układu…"
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "Tylko do odczytu"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "Podziel w poziomie"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "Podziel w pionie"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "Dzielenie"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr "Przywróć"
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr "Otwórz odnośnik"
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr "Skopiuj adres odnośnika"
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "Skopiuj"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "Zaznacz wszystko"
-
-#: source/gx/terminix/terminal/terminal.d:911
-#, fuzzy
-msgid "Clipboard"
-msgstr "Schowek"
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Synchronizowanie wprowadzania"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Wystąpił nieoczekiwany błąd: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr "Zapisywanie zawartości terminala"
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr "Wszystkie pliki tekstowe"
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr "Wszystkie pliki"
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Proces podrzędny został zakończony w zwykły sposób, ze stanem %d"
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Przerwano proces podrzędny sygnałem %d."
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr "Przerwano proces podrzędny."
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr "Uruchom ponownie"
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-"Wklejanie do terminala poleceń opublikowanych w sieci może być niebezpieczne."
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-"Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "Nie wklejaj"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr "Wklej mimo to"
-
 #: source/gx/terminix/cmdparams.d:71
 #, fuzzy, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1155,76 +1226,6 @@ msgid ""
 msgstr ""
 "Nie można jednocześnie wczytać sesji i wskazać bieżącego profilu/katalogu "
 "roboczego/wykonywanego polecenia. Proszę wykonać jedną z tych czynności."
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "Wyświetla pasek boczny sesji"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "Tworzy nową sesję"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "Zmiana nazwy sesji"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "Proszę wprowadzić nazwę sesji"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "Zapisz"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "Zapisz jako…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "Nadaj nazwę…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "Synchronizowanie wprowadzania"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr "Wszystkie pliki JSON"
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Plik „%s” nie istnieje"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "Wczytywanie sesji"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "Błąd wczytywania sesji"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "Zapisywanie sesji"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 msgid "disabled"
@@ -1262,14 +1263,10 @@ msgstr "Otwórz Terminix tutaj…"
 msgid "Open Terminix In This Directory"
 msgstr "Otwiera Terminix w tym katalogu"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr ""
-"Emuluje działanie terminala w środowisku GNOME wykorzystując interfejs kafli "
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "Program"
 
 #: data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
@@ -1370,6 +1367,11 @@ msgstr "Przełączenie sesji 9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Przełączenie sesji 10"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "Sesja"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1612,6 +1614,15 @@ msgstr "Ustalenie tylko do odczytu"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Wyświetlenie opcji układu"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr ""
+"Emuluje działanie terminala w środowisku GNOME wykorzystując interfejs kafli "
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "Podzielenie terminala poziomo"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Language-Team: \n"
@@ -218,14 +218,413 @@ msgstr "menos-zoom"
 msgid "zoom-normal"
 msgstr "zoom-normal"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "Opções de pesquisa"
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
-msgstr "A paleta de esquema de cores necessita de 16 cores"
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "Coincidir maiúsculas"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "Coincidir somente palavra inteira"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "Coincidir como expressão regular"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "Voltar ao início"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "Fechar"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr "Maximizar"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr "Desabilitar sincronização de entrada para este terminal"
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "Há processos que ainda estão em execução, fechar mesmo assim?"
+
+#: source/gx/terminix/terminal/terminal.d:553
+msgid "Enable input synchronization for this terminal"
+msgstr "Habilitar sincronização de entrada para este terminal"
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "Salvar…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "Localizar…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr "Opções de layout..."
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "Somente-leitura"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "Perfis"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "Codificação"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "Dividir à direita"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "Dividir abaixo"
+
+#: source/gx/terminix/terminal/terminal.d:640
+msgid "Split"
+msgstr "Dividir"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr "Restaurar"
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr "Abrir link"
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr "Copiar endereço do link"
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "Copiar"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "Colar"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "Selecionar tudo"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: source/gx/terminix/terminal/terminal.d:925
+msgid "Synchronize input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Ocorreu um erro inesperado: %s"
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr "Salvar saída do terminal"
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr "Todos os arquivos texto"
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr "Todos os arquivos"
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "O processo filho encerrou normalmente com o estado %d"
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "O processo filho foi abortado pelo sinal %d."
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr "O processo filho foi abortado."
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr "Recarregar"
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Este comando está solicitando acesso administrativo ao seu computador"
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiar comandos da internet pode ser perigoso. "
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr "Tenha o conhecimento de cada parte que o comando faz."
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "Não colar"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr "Colar mesmo assim"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opções de layout"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Ativo"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Título"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Carregar sessão"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "Comando"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Opções ativas são sempre no efeito e aplicadas imediatamente.\n"
+"Opções de Carregar sessão somente são aplicadas ao carregar um arquivo de "
+"sessão."
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "Padrão"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "Barra lateral de visualização da sessão"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "Criar uma nova sessão"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "Mudar o nome da sessão"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "Digite um novo nome para a sessão"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr "Abrir..."
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "Salvar"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "Salvar como…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "Nome…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr "Todos os arquivos JSON"
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "O nome do arquivo '%s' não existe"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "Carregar sessão"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "Erro ao carregar sessão"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "Salvar sessão"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "Nova sessão"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "Nova janela"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "Preferências"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "Sobre"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "Sair"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr "Créditos"
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "Definir o diretório de trabalho para o terminal"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr "DIRETÓRIO"
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "Definir o perfil de início"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr "NOME_DO_PERFIL"
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "Abrir a sessão especificada"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr "NOME_DA_SESSÃO"
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "Enviar uma ação para a instância atual do Terminix"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr "NOME_DA_AÇÃO"
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "Executar o comando passado"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr "EXECUTAR"
+
+#: source/gx/terminix/application.d:404
+msgid "Maximize the terminal window"
+msgstr "Maximizar a janela do terminal"
+
+#: source/gx/terminix/application.d:405
+msgid "Full-screen the terminal window"
+msgstr "A janela do terminal em tela cheia"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argumento oculto para passar o UUID terminal"
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr "UUID_DO_TERMINAL"
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Parece haver um problema com a configuração do terminal. Isto não é grave, "
+"mas corrigi-lo irá melhorar a sua experiência. Clique no link a seguir para "
+"maiores informações: "
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "Detectado problema de configuração"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "Não exibir esta mensagem novamente"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -239,11 +638,6 @@ msgstr "Novo perfil"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "Geral"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "Comando"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -475,12 +869,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "Tecla Delete gera"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "Codificação"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "Caracteres de largura ambígua"
@@ -516,6 +904,31 @@ msgstr "Reiniciar o comando"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "Manter o terminal aberto"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr "A paleta de esquema de cores necessita de 16 cores"
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "Não foi possível localizar o terminal dropado"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "Não foi possível localizar a sessão para o terminal dropado"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "Nome"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "Perfil"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -683,133 +1096,9 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandês"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "Nova sessão"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "Nova janela"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "Preferências"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "Atalhos"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "Sobre"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "Sair"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr "Créditos"
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "Definir o diretório de trabalho para o terminal"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr "DIRETÓRIO"
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "Definir o perfil de início"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr "NOME_DO_PERFIL"
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "Abrir a sessão especificada"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr "NOME_DA_SESSÃO"
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "Enviar uma ação para a instância atual do Terminix"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr "NOME_DA_AÇÃO"
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "Executar o comando passado"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr "EXECUTAR"
-
-#: source/gx/terminix/application.d:404
-msgid "Maximize the terminal window"
-msgstr "Maximizar a janela do terminal"
-
-#: source/gx/terminix/application.d:405
-msgid "Full-screen the terminal window"
-msgstr "A janela do terminal em tela cheia"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argumento oculto para passar o UUID terminal"
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr "UUID_DO_TERMINAL"
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Parece haver um problema com a configuração do terminal. Isto não é grave, "
-"mas corrigi-lo irá melhorar a sua experiência. Clique no link a seguir para "
-"maiores informações: "
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "Detectado problema de configuração"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "Não foi possível localizar o terminal dropado"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "Não foi possível localizar a sessão para o terminal dropado"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "Nome"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "Perfil"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "Global"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "Perfis"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -826,11 +1115,6 @@ msgstr "Ação"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "Tecla de atalho"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "Padrão"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -875,12 +1159,6 @@ msgstr "Dividir horizontal"
 #: source/gx/terminix/prefwindow.d:490
 msgid "Split Vertical"
 msgstr "Dividir vertical"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "Colar"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -932,213 +1210,6 @@ msgstr "Escuro"
 msgid "Use a wide handle for splitters"
 msgstr "Utilizar uma borda larga para os divisores"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opções de layout"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Ativo"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Título"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Carregar sessão"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Opções ativas são sempre no efeito e aplicadas imediatamente.\n"
-"Opções de Carregar sessão somente são aplicadas ao carregar um arquivo de "
-"sessão."
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "Opções de pesquisa"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "Coincidir maiúsculas"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "Coincidir somente palavra inteira"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "Coincidir como expressão regular"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "Voltar ao início"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "Fechar"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr "Maximizar"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr "Desabilitar sincronização de entrada para este terminal"
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "Há processos que ainda estão em execução, fechar mesmo assim?"
-
-#: source/gx/terminix/terminal/terminal.d:553
-msgid "Enable input synchronization for this terminal"
-msgstr "Habilitar sincronização de entrada para este terminal"
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "Salvar…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "Localizar…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr "Opções de layout..."
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "Somente-leitura"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "Dividir à direita"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "Dividir abaixo"
-
-#: source/gx/terminix/terminal/terminal.d:640
-msgid "Split"
-msgstr "Dividir"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr "Restaurar"
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr "Abrir link"
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr "Copiar endereço do link"
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "Copiar"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "Selecionar tudo"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr "Área de transferência"
-
-#: source/gx/terminix/terminal/terminal.d:925
-msgid "Synchronize input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Ocorreu um erro inesperado: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr "Salvar saída do terminal"
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr "Todos os arquivos texto"
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr "Todos os arquivos"
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "O processo filho encerrou normalmente com o estado %d"
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "O processo filho foi abortado pelo sinal %d."
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr "O processo filho foi abortado."
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr "Recarregar"
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Este comando está solicitando acesso administrativo ao seu computador"
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiar comandos da internet pode ser perigoso. "
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr "Tenha o conhecimento de cada parte que o comando faz."
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "Não colar"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr "Colar mesmo assim"
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1156,76 +1227,6 @@ msgid ""
 msgstr ""
 "Você não pode carregar uma sessão e definir um perfil / diretório de "
 "trabalho / opção de executar comando, escolha por favor um ou outro"
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "Barra lateral de visualização da sessão"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "Criar uma nova sessão"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "Mudar o nome da sessão"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "Digite um novo nome para a sessão"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr "Abrir..."
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "Salvar"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "Salvar como…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "Nome…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr "Todos os arquivos JSON"
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "O nome do arquivo '%s' não existe"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "Carregar sessão"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "Erro ao carregar sessão"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "Salvar sessão"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 msgid "disabled"
@@ -1265,13 +1266,10 @@ msgstr "Abrir Terminix aqui…"
 msgid "Open Terminix In This Directory"
 msgstr "Abrir Terminix neste diretório"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr "Um terminal em mosaico para o GNOME"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "Aplicação"
 
 #: data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
@@ -1372,6 +1370,11 @@ msgstr "Alternar para a sessão 9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Alternar para a sessão 10"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "sessão"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1617,6 +1620,14 @@ msgstr "Alternar para somente leitura"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Opções de layout"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr "Um terminal em mosaico para o GNOME"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "dividir-horizontal"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: 2016-03-22 15:34+0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -221,14 +221,412 @@ msgstr "отдалить"
 msgid "zoom-normal"
 msgstr "норма"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "Параметры поиска"
+
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
-msgstr "Палитре цветовой схемы нужно 16 цветов"
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "Терминал"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "Закрыть..."
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr "Распахнуть"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr "Выключить синхронизацию ввода для этого терминала"
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "Изменить профиль"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "Работает процесс. Все равно закрыть?"
+
+#: source/gx/terminix/terminal/terminal.d:553
+#, fuzzy
+msgid "Enable input synchronization for this terminal"
+msgstr "Выключить синхронизацию ввода для этого терминала"
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "Сохранить..."
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "Найти..."
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr "Параметры оформления"
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "Только для чтения"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "Профили"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "Кодировка"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "Разделить справа"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "Разделить снизу"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "Разделить снизу"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr "Восстановить"
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr "Открыть ссылку"
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr "Копировать адрес ссылки"
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "Копировать"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "Вставить"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "Выбрать всё"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Синхронизировать ввод"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr "Сохранить вывод терминала"
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr "Все текстовые файлы"
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr "Все файлы"
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr "Перезапустить"
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "Не вставлять"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Параметры оформления"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr "Отменить"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Активный"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Заголовок"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Загрузка сеанса"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "Команда"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "По-умолчанию"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "Показать сеанс в боковой панели"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "Открыть новый сеанс"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "Смена названия сеанса"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "Введите имя сеанса"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "Сохранить"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "Сохранить как"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "Имя..."
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "Синхронизировать ввод"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr "Все jSON файлы"
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "Загрузить сеанс"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "Ошибка загрузки сеанса"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "Сохранить сеанс"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "Новый сеанс"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "Новое окно"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "Параметры"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "Горячие клавиши"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "О программе"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "Выход"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "Установить рабочую папку терминала"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "Установить стартовый профиль"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "Открыть специальную сессию"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr ""
+
+#: source/gx/terminix/application.d:404
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "Держать терминал открытым"
+
+#: source/gx/terminix/application.d:405
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "Держать терминал открытым"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "Найдена ошибка конфигурации"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "Больше не показывать это сообщение"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -242,11 +640,6 @@ msgstr "Новый профиль"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "Основное"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "Команда"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -477,12 +870,6 @@ msgstr ""
 msgid "Delete key generates"
 msgstr "Вызывать Del"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "Кодировка"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "Символы переменной ширины"
@@ -518,6 +905,31 @@ msgstr "Перезапуск команды"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "Держать терминал открытым"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr "Палитре цветовой схемы нужно 16 цветов"
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "Выпадающий терминал не найден"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "Сеанс выпадающего терминала не найден"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "Имя"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "Профиль"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -677,132 +1089,9 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "Новый сеанс"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "Новое окно"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "Параметры"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "Горячие клавиши"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "О программе"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "Выход"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "Установить рабочую папку терминала"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "Установить стартовый профиль"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "Открыть специальную сессию"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:404
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "Держать терминал открытым"
-
-#: source/gx/terminix/application.d:405
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "Держать терминал открытым"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "Найдена ошибка конфигурации"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "Больше не показывать это сообщение"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "Выпадающий терминал не найден"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "Сеанс выпадающего терминала не найден"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "Имя"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "Профиль"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "Основные"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "Профили"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -819,11 +1108,6 @@ msgstr "Действия"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "Горячие клавиши"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "По-умолчанию"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -870,12 +1154,6 @@ msgstr "разделить горизонтально"
 #, fuzzy
 msgid "Split Vertical"
 msgstr "разделить вертикально"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "Вставить"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -926,213 +1204,6 @@ msgstr "Темный"
 msgid "Use a wide handle for splitters"
 msgstr "Использование широких границ"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Параметры оформления"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr "Отменить"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Активный"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Заголовок"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Загрузка сеанса"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "Параметры поиска"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "Терминал"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "Закрыть..."
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr "Распахнуть"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr "Выключить синхронизацию ввода для этого терминала"
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "Изменить профиль"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "Работает процесс. Все равно закрыть?"
-
-#: source/gx/terminix/terminal/terminal.d:553
-#, fuzzy
-msgid "Enable input synchronization for this terminal"
-msgstr "Выключить синхронизацию ввода для этого терминала"
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "Сохранить..."
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "Найти..."
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr "Параметры оформления"
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "Только для чтения"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "Разделить справа"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "Разделить снизу"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "Разделить снизу"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr "Восстановить"
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr "Открыть ссылку"
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr "Копировать адрес ссылки"
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "Копировать"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "Выбрать всё"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Синхронизировать ввод"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr "Сохранить вывод терминала"
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr "Все текстовые файлы"
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr "Все файлы"
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr "Перезапустить"
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "Не вставлять"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1147,76 +1218,6 @@ msgstr ""
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "Показать сеанс в боковой панели"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "Открыть новый сеанс"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "Смена названия сеанса"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "Введите имя сеанса"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "Сохранить"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "Сохранить как"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "Имя..."
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "Синхронизировать ввод"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr "Все jSON файлы"
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "Загрузить сеанс"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "Ошибка загрузки сеанса"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "Сохранить сеанс"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
 msgstr ""
 
 #: source/gx/gtk/actions.d:23
@@ -1253,13 +1254,10 @@ msgstr "Открыть Terminix здесь..."
 msgid "Open Terminix In This Directory"
 msgstr "Открыть terminix в этой папке"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr "Тайлинг терминала в GNOME"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "Действия"
 
 #: data/resources/ui/shortcuts.ui:15
 #, fuzzy
@@ -1379,6 +1377,11 @@ msgstr "на-сеанс-9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "на-сеанс-0"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "сеанс"
 
 #: data/resources/ui/shortcuts.ui:143
 #, fuzzy
@@ -1659,6 +1662,14 @@ msgstr "для чтения"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Параметры оформления"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr "Тайлинг терминала в GNOME"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr ""
 
 #~ msgid "split-horizontal"
 #~ msgstr "разделить горизонтально"

--- a/po/terminix.pot
+++ b/po/terminix.pot
@@ -1,14 +1,13 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -212,13 +211,406 @@ msgstr ""
 msgid "zoom-normal"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:553
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:640
+msgid "Split"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:925
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr ""
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr ""
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr ""
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr ""
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr ""
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr ""
+
+#: source/gx/terminix/application.d:404
+msgid "Maximize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:405
+msgid "Full-screen the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
 msgstr ""
 
 #: source/gx/terminix/profilewindow.d:64
@@ -232,11 +624,6 @@ msgstr ""
 
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
 msgstr ""
 
 #: source/gx/terminix/profilewindow.d:76
@@ -468,12 +855,6 @@ msgstr ""
 msgid "Delete key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr ""
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr ""
@@ -508,6 +889,31 @@ msgstr ""
 
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
 msgstr ""
 
 #: source/gx/terminix/constants.d:38
@@ -668,129 +1074,8 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr ""
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr ""
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr ""
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr ""
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr ""
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:404
-msgid "Maximize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:405
-msgid "Full-screen the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr ""
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr ""
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
 msgstr ""
 
 #: source/gx/terminix/prefwindow.d:121
@@ -807,11 +1092,6 @@ msgstr ""
 
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
 msgstr ""
 
 #: source/gx/terminix/prefwindow.d:340
@@ -856,12 +1136,6 @@ msgstr ""
 
 #: source/gx/terminix/prefwindow.d:490
 msgid "Split Vertical"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
 msgstr ""
 
 #: source/gx/terminix/prefwindow.d:502
@@ -912,210 +1186,6 @@ msgstr ""
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:553
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:640
-msgid "Split"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:925
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1130,76 +1200,6 @@ msgstr ""
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
 msgstr ""
 
 #: source/gx/gtk/actions.d:23
@@ -1236,12 +1236,8 @@ msgstr ""
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+msgid "Application"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:15
@@ -1342,6 +1338,10 @@ msgstr ""
 #: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:138
+msgid "Session"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:143
@@ -1582,4 +1582,12 @@ msgstr ""
 #: data/resources/ui/shortcuts.ui:437
 msgctxt "shortcut window"
 msgid "Layout options"
+msgstr ""
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr ""
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jeff Bai <jeffbai@aosc.xyz>\n"
 "Language-Team: AOSC zh_CN <aosc@member.fsf.org>\n"
@@ -220,14 +220,415 @@ msgstr "缩小"
 msgid "zoom-normal"
 msgstr "正常缩放"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "文件 %s 不是兼容的 JSON 颜色主题文件"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "搜索选项"
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
-msgstr "颜色主题色板需要 16 个颜色"
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "区分大小写"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "全字匹配"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "使用正则表达式匹配"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "换行"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "终端"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "关闭"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
+msgstr "为此终端关闭输入同步"
+
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "编辑配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "仍有正在运行的进程，依然要关闭吗？"
+
+#: source/gx/terminix/terminal/terminal.d:553
+#, fuzzy
+msgid "Enable input synchronization for this terminal"
+msgstr "为此终端关闭输入同步"
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "保存…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "查找…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr "布局选项…"
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "只读"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "编码"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "向下分割"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "分割"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr "恢复"
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr "打开链接"
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr "复制链接地址"
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "复制"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "粘贴"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "全选"
+
+#: source/gx/terminix/terminal/terminal.d:911
+#, fuzzy
+msgid "Clipboard"
+msgstr "剪贴板"
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "同步输入"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr "发生未知错误，无其他可用信息"
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "发生未知错误：%s"
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr "保存终端输出"
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr "所有文本文件"
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr "所有文件"
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "子进程以 %d 状态正常退出"
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "子进程被 %d 信号中止。"
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr "子进程已被中止。"
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr "重新启动"
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr "命令正在请求计算机的管理员权限"
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "从互联网复制命令有一定危险性。"
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr "你应当确认命令每个部分的作用。"
+
+#: source/gx/terminix/terminal/terminal.d:1964
+msgid "Don't Paste"
+msgstr "不要粘贴"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr "依然粘贴"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "布局选项"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "确定"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr "取消"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "会话活动"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "标题"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "载入会话"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "命令"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"会话活动选项一直生效且立即应用。\n"
+"会话载入选项仅在载入会话文件时生效。"
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "默认"
+
+#: source/gx/terminix/appwindow.d:181
+msgid "View session sidebar"
+msgstr "显示会话侧边栏"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "创建会话"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "更改会话名称"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "为会话新建名称"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr "打开…"
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "保存"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "另存为…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "名称…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "同步输入"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr "所有 JSON 文件"
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "文件名“%s”不存在"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "载入会话"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "发生未知错误，无法载入会话。"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Error Loading Session"
+msgstr "载入会话出错"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "保存会话"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "新建会话"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "新建窗口"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "首选项"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "快捷键"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "关于"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "退出"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr "感谢名单"
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "设置终端的工作目录"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr "DIRECTORY"
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "设置启动配置文件"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "打开指定会话"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "向当前 Terminix 实例发送动作"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "执行传入的命令"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr "EXECUTE"
+
+#: source/gx/terminix/application.d:404
+msgid "Maximize the terminal window"
+msgstr "最大化终端窗口"
+
+#: source/gx/terminix/application.d:405
+msgid "Full-screen the terminal window"
+msgstr "全屏终端窗口"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr "传入终端 UUID 的隐藏参数"
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"终端配置似乎存在问题。这并不是严重问题，但是更正这些问题将改善你的使用体验。"
+"点击如下链接以获取更多信息："
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "检测到配置问题"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "不再显示该信息"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -241,11 +642,6 @@ msgstr "新建配置方案"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "常规"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "命令"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -476,12 +872,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "按 Delete 键产生"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "编码"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "模糊宽度字符"
@@ -517,6 +907,31 @@ msgstr "重启命令"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "保持终端开启"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "文件 %s 不是兼容的 JSON 颜色主题文件"
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr "颜色主题色板需要 16 个颜色"
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "无法定位放置的终端"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "无法定位放置的终端的会话"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "名称"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "配置方案"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -679,132 +1094,9 @@ msgstr "越南语"
 msgid "Thai"
 msgstr "泰语"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "新建会话"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "新建窗口"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "首选项"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "快捷键"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "关于"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "退出"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr "感谢名单"
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "设置终端的工作目录"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr "DIRECTORY"
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "设置启动配置文件"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "打开指定会话"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "向当前 Terminix 实例发送动作"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "执行传入的命令"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr "EXECUTE"
-
-#: source/gx/terminix/application.d:404
-msgid "Maximize the terminal window"
-msgstr "最大化终端窗口"
-
-#: source/gx/terminix/application.d:405
-msgid "Full-screen the terminal window"
-msgstr "全屏终端窗口"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr "传入终端 UUID 的隐藏参数"
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"终端配置似乎存在问题。这并不是严重问题，但是更正这些问题将改善你的使用体验。"
-"点击如下链接以获取更多信息："
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "检测到配置问题"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "不再显示该信息"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "无法定位放置的终端"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "无法定位放置的终端的会话"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "名称"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "配置方案"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "全局"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "配置方案"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -821,11 +1113,6 @@ msgstr "动作"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "快捷键"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "默认"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -870,12 +1157,6 @@ msgstr "水平分割"
 #: source/gx/terminix/prefwindow.d:490
 msgid "Split Vertical"
 msgstr "垂直分割"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "粘贴"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -925,216 +1206,6 @@ msgstr "深色"
 msgid "Use a wide handle for splitters"
 msgstr "使用较宽的分割手柄"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "布局选项"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr "确定"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr "取消"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "会话活动"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "标题"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "载入会话"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"会话活动选项一直生效且立即应用。\n"
-"会话载入选项仅在载入会话文件时生效。"
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "搜索选项"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "区分大小写"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "全字匹配"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "使用正则表达式匹配"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "换行"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "终端"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "关闭"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr "为此终端关闭输入同步"
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "编辑配置方案"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "仍有正在运行的进程，依然要关闭吗？"
-
-#: source/gx/terminix/terminal/terminal.d:553
-#, fuzzy
-msgid "Enable input synchronization for this terminal"
-msgstr "为此终端关闭输入同步"
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "保存…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "查找…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr "布局选项…"
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "只读"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "向下分割"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "分割"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr "恢复"
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr "打开链接"
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr "复制链接地址"
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "复制"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "全选"
-
-#: source/gx/terminix/terminal/terminal.d:911
-#, fuzzy
-msgid "Clipboard"
-msgstr "剪贴板"
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "同步输入"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr "发生未知错误，无其他可用信息"
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "发生未知错误：%s"
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr "保存终端输出"
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr "所有文本文件"
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr "所有文件"
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "子进程以 %d 状态正常退出"
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "子进程被 %d 信号中止。"
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr "子进程已被中止。"
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr "重新启动"
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr "命令正在请求计算机的管理员权限"
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "从互联网复制命令有一定危险性。"
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr "你应当确认命令每个部分的作用。"
-
-#: source/gx/terminix/terminal/terminal.d:1964
-msgid "Don't Paste"
-msgstr "不要粘贴"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr "依然粘贴"
-
 #: source/gx/terminix/cmdparams.d:71
 #, fuzzy, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1152,76 +1223,6 @@ msgid ""
 msgstr ""
 "你不能在载入会话时同时设置配置档案、工作目录及执行的命令行选项，请选择其中一"
 "个操作"
-
-#: source/gx/terminix/appwindow.d:181
-msgid "View session sidebar"
-msgstr "显示会话侧边栏"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "创建会话"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "更改会话名称"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "为会话新建名称"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr "打开…"
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "保存"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "另存为…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "名称…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "同步输入"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr "所有 JSON 文件"
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "文件名“%s”不存在"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "载入会话"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "发生未知错误，无法载入会话。"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Error Loading Session"
-msgstr "载入会话出错"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "保存会话"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 msgid "disabled"
@@ -1260,13 +1261,10 @@ msgstr "在此打开 Terminix…"
 msgid "Open Terminix In This Directory"
 msgstr "在此目录打开 Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr "GNOME 的平铺终端模拟器"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "应用程序"
 
 #: data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
@@ -1367,6 +1365,11 @@ msgstr "切换到会话 9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "切换到会话 10"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "会话"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1612,6 +1615,14 @@ msgstr "切换只读模式"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "布局选项"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr "GNOME 的平铺终端模拟器"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "水平分割"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-09 12:57-0400\n"
+"POT-Creation-Date: 2016-04-11 23:37+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mingye Wang (Arthur2e5) <arthur200126@gmail.com>\n"
 "Language-Team: AOSC zh_TW <aosc@member.fsf.org>\n"
@@ -233,14 +233,421 @@ msgstr "縮小"
 msgid "zoom-normal"
 msgstr "正常縮放"
 
-#: source/gx/terminix/colorschemes.d:107
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/terminal/search.d:117
+msgid "Search Options"
+msgstr "搜尋選項"
+
+#: source/gx/terminix/terminal/search.d:183
+msgid "Match case"
+msgstr "區分大小寫"
+
+#: source/gx/terminix/terminal/search.d:184
+msgid "Match entire word only"
+msgstr "只匹配整個單詞"
+
+#: source/gx/terminix/terminal/search.d:185
+msgid "Match as regular expression"
+msgstr "使用正規表示式匹配"
+
+#: source/gx/terminix/terminal/search.d:186
+msgid "Wrap around"
+msgstr "折列"
+
+#: source/gx/terminix/terminal/terminal.d:319
+#: source/gx/terminix/terminal/terminal.d:752
+#: data/resources/ui/shortcuts.ui:308
+msgid "Terminal"
+msgstr "終端"
+
+#: source/gx/terminix/terminal/terminal.d:350
+#: source/gx/terminix/terminal/terminal.d:921
+#: source/gx/terminix/appwindow.d:401
+msgid "Close"
+msgstr "關閉"
+
+#: source/gx/terminix/terminal/terminal.d:359
+#: source/gx/terminix/terminal/terminal.d:783
+#: source/gx/terminix/terminal/terminal.d:920
+#, fuzzy
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:370
+#: source/gx/terminix/terminal/terminal.d:551
+msgid "Disable input synchronization for this terminal"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:140
-msgid "Color scheme palette requires 16 colors"
+#: source/gx/terminix/terminal/terminal.d:409
+msgid "Edit Profile"
+msgstr "編輯配置檔"
+
+#: source/gx/terminix/terminal/terminal.d:526
+#: source/gx/terminix/appwindow.d:622
+msgid "There are processes that are still running, close anyway?"
+msgstr "仍有正在執行的程序，依然要關閉嗎？"
+
+#: source/gx/terminix/terminal/terminal.d:553
+msgid "Enable input synchronization for this terminal"
 msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:609
+msgid "Save…"
+msgstr "儲存…"
+
+#: source/gx/terminix/terminal/terminal.d:610
+msgid "Find…"
+msgstr "查詢…"
+
+#: source/gx/terminix/terminal/terminal.d:611
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:615
+msgid "Read-Only"
+msgstr "只讀"
+
+#: source/gx/terminix/terminal/terminal.d:619
+#: source/gx/terminix/prefwindow.d:83
+msgid "Profiles"
+msgstr "配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:620
+#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
+#: source/gx/terminix/prefwindow.d:159
+msgid "Encoding"
+msgstr "編碼"
+
+#: source/gx/terminix/terminal/terminal.d:630
+msgid "Split Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/terminal/terminal.d:634
+msgid "Split Down"
+msgstr "向下分割"
+
+#: source/gx/terminix/terminal/terminal.d:640
+#, fuzzy
+msgid "Split"
+msgstr "向下分割"
+
+#: source/gx/terminix/terminal/terminal.d:780
+#: source/gx/terminix/terminal/terminal.d:920
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:879
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:880
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:891
+#: source/gx/terminix/terminal/terminal.d:898
+msgid "Copy"
+msgstr "複製"
+
+#: source/gx/terminix/terminal/terminal.d:892
+#: source/gx/terminix/terminal/terminal.d:903
+#: source/gx/terminix/prefwindow.d:496
+msgid "Paste"
+msgstr "貼上"
+
+#: source/gx/terminix/terminal/terminal.d:893
+#: source/gx/terminix/terminal/terminal.d:908
+msgid "Select All"
+msgstr "全選"
+
+#: source/gx/terminix/terminal/terminal.d:911
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:925
+#, fuzzy
+msgid "Synchronize input"
+msgstr "同步輸入"
+
+#: source/gx/terminix/terminal/terminal.d:1277
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1283
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1599
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1605
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1609
+#: source/gx/terminix/appwindow.d:678
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1912
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1913
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1914
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1920
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1960
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1961
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1962
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1964
+#, fuzzy
+msgid "Don't Paste"
+msgstr "貼上"
+
+#: source/gx/terminix/terminal/terminal.d:1965
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+#, fuzzy
+msgid "Layout Options"
+msgstr "選項"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+#, fuzzy
+msgid "Active"
+msgstr "動作"
+
+#: source/gx/terminix/terminal/layout.d:49
+#, fuzzy
+msgid "Title"
+msgstr "標題"
+
+#: source/gx/terminix/terminal/layout.d:57
+#, fuzzy
+msgid "Session Load"
+msgstr "會話"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
+msgid "Command"
+msgstr "指令"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:324
+#: source/gx/terminix/prefwindow.d:536
+msgid "Default"
+msgstr "預設"
+
+#: source/gx/terminix/appwindow.d:181
+#, fuzzy
+msgid "View session sidebar"
+msgstr "顯示側邊列"
+
+#: source/gx/terminix/appwindow.d:193
+msgid "Create a new session"
+msgstr "建立會話"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Change Session Name"
+msgstr "更改會話名稱"
+
+#: source/gx/terminix/appwindow.d:372
+msgid "Enter a new name for the session"
+msgstr "為會話新建名稱"
+
+#: source/gx/terminix/appwindow.d:398
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:399
+msgid "Save"
+msgstr "儲存"
+
+#: source/gx/terminix/appwindow.d:400
+msgid "Save As…"
+msgstr "另存為…"
+
+#: source/gx/terminix/appwindow.d:405
+msgid "Name…"
+msgstr "名稱…"
+
+#: source/gx/terminix/appwindow.d:406
+msgid "Synchronize Input"
+msgstr "同步輸入"
+
+#: source/gx/terminix/appwindow.d:411
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:674
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:687
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "檔名「%s」不存在"
+
+#: source/gx/terminix/appwindow.d:714
+msgid "Load Session"
+msgstr "載入會話"
+
+#: source/gx/terminix/appwindow.d:727
+msgid "Could not load session due to unexpected error."
+msgstr "發生未知錯誤，無法載入會話。"
+
+#: source/gx/terminix/appwindow.d:727
+#, fuzzy
+msgid "Error Loading Session"
+msgstr "載入會話"
+
+#: source/gx/terminix/appwindow.d:742
+msgid "Save Session"
+msgstr "儲存會話"
+
+#: source/gx/terminix/appwindow.d:777
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
+#: source/gx/terminix/prefwindow.d:490
+msgid "New Session"
+msgstr "新建會話"
+
+#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
+msgid "New Window"
+msgstr "新建視窗"
+
+#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
+msgid "Preferences"
+msgstr "偏好"
+
+#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
+msgid "Shortcuts"
+msgstr "快捷鍵"
+
+#: source/gx/terminix/application.d:159
+msgid "About"
+msgstr "關於"
+
+#: source/gx/terminix/application.d:160
+msgid "Quit"
+msgstr "退出"
+
+#: source/gx/terminix/application.d:211
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:399
+msgid "Set the working directory of the terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/application.d:399
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:400
+msgid "Set the starting profile"
+msgstr "設定啟動配置檔"
+
+#: source/gx/terminix/application.d:400
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:401
+msgid "Open the specified session"
+msgstr "開啟指定的會話"
+
+#: source/gx/terminix/application.d:401
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:402
+msgid "Send an action to current Terminix instance"
+msgstr "向當前 Terminix 例項傳送動作"
+
+#: source/gx/terminix/application.d:402
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:403
+msgid "Execute the passed command"
+msgstr "執行傳入的指令"
+
+#: source/gx/terminix/application.d:403
+msgid "EXECUTE"
+msgstr ""
+
+#: source/gx/terminix/application.d:404
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:405
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:408
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:408
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:548
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"終端配置似乎存在問題。這並不是嚴重問題，但是更正這些問題將改善你的使用體驗。"
+"點選如下連結以獲取更多資訊："
+
+#: source/gx/terminix/application.d:549
+msgid "Configuration Issue Detected"
+msgstr "檢測到配置問題"
+
+#: source/gx/terminix/application.d:561
+msgid "Do not show this message again"
+msgstr "不再顯示該資訊"
 
 #: source/gx/terminix/profilewindow.d:64
 #, c-format
@@ -255,11 +662,6 @@ msgstr "配置方案"
 #: source/gx/terminix/profilewindow.d:74
 msgid "General"
 msgstr "常規"
-
-#: source/gx/terminix/profilewindow.d:75 source/gx/terminix/profilewindow.d:630
-#: source/gx/terminix/terminal/layout.d:64
-msgid "Command"
-msgstr "指令"
 
 #: source/gx/terminix/profilewindow.d:76
 msgid "Color"
@@ -490,12 +892,6 @@ msgstr "TTY"
 msgid "Delete key generates"
 msgstr "按 Delete 鍵生成"
 
-#: source/gx/terminix/profilewindow.d:576 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:159
-#: source/gx/terminix/terminal/terminal.d:620
-msgid "Encoding"
-msgstr "編碼"
-
 #: source/gx/terminix/profilewindow.d:591
 msgid "Ambiguous-width characters"
 msgstr "模糊寬度字元"
@@ -531,6 +927,31 @@ msgstr "重啟該指令"
 #: source/gx/terminix/profilewindow.d:642
 msgid "Hold the terminal open"
 msgstr "保持終端開啟"
+
+#: source/gx/terminix/colorschemes.d:107
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:140
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:509
+msgid "Could not locate dropped terminal"
+msgstr "無法定位放置的終端"
+
+#: source/gx/terminix/session.d:514
+msgid "Could not locate session for dropped terminal"
+msgstr "無法定位放置的終端的會話"
+
+#: source/gx/terminix/session.d:1215
+msgid "Name"
+msgstr "名稱"
+
+#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
+msgid "Profile"
+msgstr "配置方案"
 
 #: source/gx/terminix/constants.d:38
 msgid "A VTE based terminal emulator for Linux"
@@ -694,134 +1115,9 @@ msgstr "越南語"
 msgid "Thai"
 msgstr "泰語"
 
-#: source/gx/terminix/application.d:147 source/gx/terminix/session.d:1249
-#: source/gx/terminix/prefwindow.d:490
-msgid "New Session"
-msgstr "新建會話"
-
-#: source/gx/terminix/application.d:148 source/gx/terminix/prefwindow.d:490
-msgid "New Window"
-msgstr "新建視窗"
-
-#: source/gx/terminix/application.d:152 source/gx/terminix/prefwindow.d:70
-msgid "Preferences"
-msgstr "偏好"
-
-#: source/gx/terminix/application.d:154 source/gx/terminix/prefwindow.d:80
-msgid "Shortcuts"
-msgstr "快捷鍵"
-
-#: source/gx/terminix/application.d:159
-msgid "About"
-msgstr "關於"
-
-#: source/gx/terminix/application.d:160
-msgid "Quit"
-msgstr "退出"
-
-#: source/gx/terminix/application.d:211
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:399
-msgid "Set the working directory of the terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/application.d:399
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:400
-msgid "Set the starting profile"
-msgstr "設定啟動配置檔"
-
-#: source/gx/terminix/application.d:400
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:401
-msgid "Open the specified session"
-msgstr "開啟指定的會話"
-
-#: source/gx/terminix/application.d:401
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:402
-msgid "Send an action to current Terminix instance"
-msgstr "向當前 Terminix 例項傳送動作"
-
-#: source/gx/terminix/application.d:402
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:403
-msgid "Execute the passed command"
-msgstr "執行傳入的指令"
-
-#: source/gx/terminix/application.d:403
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:404
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:405
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:408
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:408
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:548
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"終端配置似乎存在問題。這並不是嚴重問題，但是更正這些問題將改善你的使用體驗。"
-"點選如下連結以獲取更多資訊："
-
-#: source/gx/terminix/application.d:549
-msgid "Configuration Issue Detected"
-msgstr "檢測到配置問題"
-
-#: source/gx/terminix/application.d:561
-msgid "Do not show this message again"
-msgstr "不再顯示該資訊"
-
-#: source/gx/terminix/session.d:509
-msgid "Could not locate dropped terminal"
-msgstr "無法定位放置的終端"
-
-#: source/gx/terminix/session.d:514
-msgid "Could not locate session for dropped terminal"
-msgstr "無法定位放置的終端的會話"
-
-#: source/gx/terminix/session.d:1215
-msgid "Name"
-msgstr "名稱"
-
-#: source/gx/terminix/session.d:1226 source/gx/terminix/prefwindow.d:326
-msgid "Profile"
-msgstr "配置方案"
-
 #: source/gx/terminix/prefwindow.d:77
 msgid "Global"
 msgstr "全局"
-
-#: source/gx/terminix/prefwindow.d:83
-#: source/gx/terminix/terminal/terminal.d:619
-msgid "Profiles"
-msgstr "配置方案"
 
 #: source/gx/terminix/prefwindow.d:121
 msgid "Encodings showing in menu:"
@@ -838,11 +1134,6 @@ msgstr "動作"
 #: source/gx/terminix/prefwindow.d:235
 msgid "Shortcut Key"
 msgstr "快捷鍵"
-
-#: source/gx/terminix/prefwindow.d:324 source/gx/terminix/prefwindow.d:536
-#: source/gx/terminix/appwindow.d:91
-msgid "Default"
-msgstr "預設"
 
 #: source/gx/terminix/prefwindow.d:340
 msgid "New"
@@ -889,12 +1180,6 @@ msgstr "水平分割"
 #, fuzzy
 msgid "Split Vertical"
 msgstr "垂直分割"
-
-#: source/gx/terminix/prefwindow.d:496
-#: source/gx/terminix/terminal/terminal.d:892
-#: source/gx/terminix/terminal/terminal.d:903
-msgid "Paste"
-msgstr "貼上"
 
 #: source/gx/terminix/prefwindow.d:502
 msgid "Warn when attempting unsafe paste"
@@ -945,218 +1230,6 @@ msgstr "深色"
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#, fuzzy
-msgid "Layout Options"
-msgstr "選項"
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-#, fuzzy
-msgid "Active"
-msgstr "動作"
-
-#: source/gx/terminix/terminal/layout.d:49
-#, fuzzy
-msgid "Title"
-msgstr "標題"
-
-#: source/gx/terminix/terminal/layout.d:57
-#, fuzzy
-msgid "Session Load"
-msgstr "會話"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:117
-msgid "Search Options"
-msgstr "搜尋選項"
-
-#: source/gx/terminix/terminal/search.d:183
-msgid "Match case"
-msgstr "區分大小寫"
-
-#: source/gx/terminix/terminal/search.d:184
-msgid "Match entire word only"
-msgstr "只匹配整個單詞"
-
-#: source/gx/terminix/terminal/search.d:185
-msgid "Match as regular expression"
-msgstr "使用正規表示式匹配"
-
-#: source/gx/terminix/terminal/search.d:186
-msgid "Wrap around"
-msgstr "折列"
-
-#: source/gx/terminix/terminal/terminal.d:319
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Terminal"
-msgstr "終端"
-
-#: source/gx/terminix/terminal/terminal.d:350
-#: source/gx/terminix/terminal/terminal.d:921
-#: source/gx/terminix/appwindow.d:401
-msgid "Close"
-msgstr "關閉"
-
-#: source/gx/terminix/terminal/terminal.d:359
-#: source/gx/terminix/terminal/terminal.d:783
-#: source/gx/terminix/terminal/terminal.d:920
-#, fuzzy
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:551
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:409
-msgid "Edit Profile"
-msgstr "編輯配置檔"
-
-#: source/gx/terminix/terminal/terminal.d:526
-#: source/gx/terminix/appwindow.d:622
-msgid "There are processes that are still running, close anyway?"
-msgstr "仍有正在執行的程序，依然要關閉嗎？"
-
-#: source/gx/terminix/terminal/terminal.d:553
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:609
-msgid "Save…"
-msgstr "儲存…"
-
-#: source/gx/terminix/terminal/terminal.d:610
-msgid "Find…"
-msgstr "查詢…"
-
-#: source/gx/terminix/terminal/terminal.d:611
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:615
-msgid "Read-Only"
-msgstr "只讀"
-
-#: source/gx/terminix/terminal/terminal.d:630
-msgid "Split Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/terminal/terminal.d:634
-msgid "Split Down"
-msgstr "向下分割"
-
-#: source/gx/terminix/terminal/terminal.d:640
-#, fuzzy
-msgid "Split"
-msgstr "向下分割"
-
-#: source/gx/terminix/terminal/terminal.d:780
-#: source/gx/terminix/terminal/terminal.d:920
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:879
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:880
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:891
-#: source/gx/terminix/terminal/terminal.d:898
-msgid "Copy"
-msgstr "複製"
-
-#: source/gx/terminix/terminal/terminal.d:893
-#: source/gx/terminix/terminal/terminal.d:908
-msgid "Select All"
-msgstr "全選"
-
-#: source/gx/terminix/terminal/terminal.d:911
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:925
-#, fuzzy
-msgid "Synchronize input"
-msgstr "同步輸入"
-
-#: source/gx/terminix/terminal/terminal.d:1277
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1283
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1599
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1605
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1609
-#: source/gx/terminix/appwindow.d:678
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1912
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1913
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1914
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1920
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1960
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1961
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1962
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1964
-#, fuzzy
-msgid "Don't Paste"
-msgstr "貼上"
-
-#: source/gx/terminix/terminal/terminal.d:1965
-msgid "Paste Anyway"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:71
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1172,78 +1245,6 @@ msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
-
-#: source/gx/terminix/appwindow.d:181
-#, fuzzy
-msgid "View session sidebar"
-msgstr "顯示側邊列"
-
-#: source/gx/terminix/appwindow.d:193
-msgid "Create a new session"
-msgstr "建立會話"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Change Session Name"
-msgstr "更改會話名稱"
-
-#: source/gx/terminix/appwindow.d:372
-msgid "Enter a new name for the session"
-msgstr "為會話新建名稱"
-
-#: source/gx/terminix/appwindow.d:398
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:399
-msgid "Save"
-msgstr "儲存"
-
-#: source/gx/terminix/appwindow.d:400
-msgid "Save As…"
-msgstr "另存為…"
-
-#: source/gx/terminix/appwindow.d:405
-msgid "Name…"
-msgstr "名稱…"
-
-#: source/gx/terminix/appwindow.d:406
-msgid "Synchronize Input"
-msgstr "同步輸入"
-
-#: source/gx/terminix/appwindow.d:411
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:674
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:687
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "檔名「%s」不存在"
-
-#: source/gx/terminix/appwindow.d:714
-msgid "Load Session"
-msgstr "載入會話"
-
-#: source/gx/terminix/appwindow.d:727
-msgid "Could not load session due to unexpected error."
-msgstr "發生未知錯誤，無法載入會話。"
-
-#: source/gx/terminix/appwindow.d:727
-#, fuzzy
-msgid "Error Loading Session"
-msgstr "載入會話"
-
-#: source/gx/terminix/appwindow.d:742
-msgid "Save Session"
-msgstr "儲存會話"
-
-#: source/gx/terminix/appwindow.d:777
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-msgid "Terminix"
-msgstr "Terminix"
 
 #: source/gx/gtk/actions.d:23
 #, fuzzy
@@ -1283,13 +1284,10 @@ msgstr "在此開啟 Terminix…"
 msgid "Open Terminix In This Directory"
 msgstr "在此目錄開啟 Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-msgid "utilities-terminal"
-msgstr "utilities-terminal"
+#: data/resources/ui/shortcuts.ui:10
+#, fuzzy
+msgid "Application"
+msgstr "動作"
 
 #: data/resources/ui/shortcuts.ui:15
 #, fuzzy
@@ -1409,6 +1407,11 @@ msgstr "切換到會話 9"
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "切換到會話 10"
+
+#: data/resources/ui/shortcuts.ui:138
+#, fuzzy
+msgid "Session"
+msgstr "會話"
 
 #: data/resources/ui/shortcuts.ui:143
 msgctxt "shortcut window"
@@ -1693,6 +1696,14 @@ msgstr "只讀"
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "選項"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+msgid "A tiling terminal for Gnome"
+msgstr ""
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
+msgid "utilities-terminal"
+msgstr "utilities-terminal"
 
 #~ msgid "split-horizontal"
 #~ msgstr "水平分割"


### PR DESCRIPTION
This fixes two issues with the localization and updates the strings.

* Nautilus extension localization was broken since c1250367426efa4ae7e05169af220d5a1496db41
* When extracting the strings the last command should all the final options like package name