### PR TITLE
Fixed setting the app name in about dialog.

### DIFF
--- a/source/gx/terminix/application.d
+++ b/source/gx/terminix/application.d
@@ -192,7 +192,7 @@ private:
 
             setWrapLicense(true);
             setLogoIconName(null);
-            setName(APPLICATION_NAME);
+            setProgramName(APPLICATION_NAME);
             setComments(_(APPLICATION_COMMENTS));
             setVersion(APPLICATION_VERSION);
             setCopyright(APPLICATION_COPYRIGHT);


### PR DESCRIPTION
Previously it was just setting the widget name