### PR TITLE
Create appdata folder in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,7 @@ cp -r data/icons/hicolor/. ${PREFIX}/share/icons/hicolor
 mkdir -p ${PREFIX}/bin
 cp terminix ${PREFIX}/bin/terminix
 mkdir -p ${PREFIX}/share/applications
+mkdir -p ${PREFIX}/share/appdata
 cp data/pkg/desktop/com.gexperts.Terminix.desktop ${PREFIX}/share/applications
 cp data/appdata/com.gexperts.Terminix.appdata.xml ${PREFIX}/share/appdata
 


### PR DESCRIPTION
The current installer copies the terminix appdata file to a file named appdata. Fixed creating appdata folder prior to that.