### PR TITLE
Focus previous terminal on terminal close

### DIFF
--- a/source/gx/terminix/session.d
+++ b/source/gx/terminix/session.d
@@ -119,7 +119,7 @@ private:
     Box groupChild;
     MaximizedInfo maximizedInfo;
 
-    Terminal lastFocused;
+    Terminal currentTerminal;
 
     GSettings gsSettings;
 
@@ -135,7 +135,7 @@ private:
     void createUI(Terminal terminal) {
         createBaseUI();
         groupChild.add(terminal);
-        lastFocused = terminal;
+        currentTerminal = terminal;
     }
 
     void createBaseUI() {
@@ -288,8 +288,8 @@ private:
     void removeTerminal(Terminal terminal) {
         int id = to!int(terminal.terminalID);
         trace("Removing terminal " ~ terminal.terminalUUID);
-        if (lastFocused == terminal)
-            lastFocused = null;
+        if (currentTerminal == terminal)
+            currentTerminal = null;
         //Remove delegates
         terminal.removeOnTerminalClose(&onTerminalClose);
         terminal.removeOnTerminalRequestDetach(&onTerminalRequestDetach);
@@ -577,7 +577,7 @@ private:
 
     void onTerminalInFocus(Terminal terminal) {
         //trace("Focus noted");
-        lastFocused = terminal;
+        currentTerminal = terminal;
     }
 
     void onTerminalSyncInput(Terminal originator, SyncInputEvent event) {
@@ -927,15 +927,15 @@ public:
     }
 
     string getActiveTerminalUUID() {
-        if (lastFocused !is null)
-            return lastFocused.terminalUUID;
+        if (currentTerminal !is null)
+            return currentTerminal.terminalUUID;
         else
             return null;
     }
     
     string getActiveTerminalDirectory() {
-        if (lastFocused !is null) {
-            return lastFocused.currentDirectory;
+        if (currentTerminal !is null) {
+            return currentTerminal.currentDirectory;
         } else {
             return null;
         }
@@ -1040,7 +1040,7 @@ public:
      * Resize terminal based on direction
      */
     void resizeTerminal(string direction) {
-        Terminal terminal = lastFocused;
+        Terminal terminal = currentTerminal;
         if (terminal !is null) {
             Container parent = cast(Container) terminal;
             int increment = 10;
@@ -1069,9 +1069,9 @@ public:
      * Restore focus to the terminal that last had focus in the session
      */
     void focusRestore() {
-        if (lastFocused !is null) {
+        if (currentTerminal !is null) {
             trace("Restoring focus to terminal");
-            lastFocused.focusTerminal();
+            currentTerminal.focusTerminal();
         }
     }
 
@@ -1080,8 +1080,8 @@ public:
      */
     void focusNext() {
         ulong id = 1;
-        if (lastFocused !is null) {
-            id = lastFocused.terminalID + 1;
+        if (currentTerminal !is null) {
+            id = currentTerminal.terminalID + 1;
             if (id > terminals.length)
                 id = 1;
         }
@@ -1093,8 +1093,8 @@ public:
      */
     void focusPrevious() {
         ulong id = 1;
-        if (lastFocused !is null) {
-            id = lastFocused.terminalID;
+        if (currentTerminal !is null) {
+            id = currentTerminal.terminalID;
             if (id == 1)
                 id = terminals.length;
             else
@@ -1109,13 +1109,13 @@ public:
     void focusDirection(string direction) {
         trace("Focusing ", direction);
 
-        Widget appWindow = lastFocused.getToplevel();
+        Widget appWindow = currentTerminal.getToplevel();
         GtkAllocation appWindowAllocation;
         appWindow.getClip(appWindowAllocation);
 
         // Start at the top left of the current terminal
         int xPos, yPos;
-        lastFocused.translateCoordinates(appWindow, 0, 0, xPos, yPos);
+        currentTerminal.translateCoordinates(appWindow, 0, 0, xPos, yPos);
 
         // While still in the application window, move 20 pixels per loop
         while (xPos >= 0 && xPos < appWindowAllocation.width && yPos >= 0 && yPos < appWindowAllocation.height) {
@@ -1138,7 +1138,7 @@ public:
 
             // If the x/y position lands in another terminal, focus it
             foreach (terminal; terminals) {
-                if (terminal == lastFocused)
+                if (terminal == currentTerminal)
                     continue;
 
                 int termX, termY;

--- a/source/gx/terminix/session.d
+++ b/source/gx/terminix/session.d
@@ -120,6 +120,7 @@ private:
     MaximizedInfo maximizedInfo;
 
     Terminal currentTerminal;
+    Terminal previousTerminal;
 
     GSettings gsSettings;
 
@@ -322,12 +323,19 @@ private:
         }
         //Update terminal IDs to fill in hole
         sequenceTerminalID();
-        //Fix Issue #33
-        if (id >= terminals.length)
-            id = to!int(terminals.length);
-        if (id > 0 && id <= terminals.length) {
-            focusTerminal(id);
+
+        if (previousTerminal !is null) {
+            focusTerminal(previousTerminal);
         }
+        else {
+            //Fix Issue #33
+            if (id >= terminals.length)
+                id = to!int(terminals.length);
+            if (id > 0 && id <= terminals.length) {
+                focusTerminal(id);
+            }
+        }
+
         if (maximizedTerminal !is null) {
             maximizeTerminal(terminal);
         }
@@ -577,6 +585,7 @@ private:
 
     void onTerminalInFocus(Terminal terminal) {
         //trace("Focus noted");
+        previousTerminal = currentTerminal;
         currentTerminal = terminal;
     }
 


### PR DESCRIPTION
Focuses the previously focused terminal, if there is one, when the current terminal is closed.  This only goes one step back and doesn't keep a list of previously focused terminals so sequentially closing terminals will first focus the previous terminal, then go from `n` down to 1 where `n` is the number of terminals.

This also renames `lastFocused` to `currentTerminal` as I thought that it worked better alongside `previousTerminal`.

Fixes #266 