### PR TITLE
Fixed the .desktop categories

### DIFF
--- a/data/pkg/desktop/com.gexperts.Terminix.desktop.in
+++ b/data/pkg/desktop/com.gexperts.Terminix.desktop.in
@@ -5,6 +5,6 @@ Exec=terminix
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=Utility;X-GNOME-Utilities;
+Categories=System;TerminalEmulator;X-GNOME-Utilities;
 Icon=com.gexperts.Terminix
 DBusActivatable=true


### PR DESCRIPTION
The choice of categories was not adhering to https://freedesktop.org/wiki/Specifications/menu-spec/ which is punished by a failing build in @openSUSE. This should fix it.