### PR TITLE
Fix reading the shortcut localization with correct context.

### DIFF
--- a/extract-strings.sh
+++ b/extract-strings.sh
@@ -13,6 +13,7 @@ find ${BASEDIR}/source -name '*.d' | xgettext \
   --files-from=- \
   --directory=$BASEDIR \
   --language=Vala \
+  --keyword=C_:1c,2 \
   --from-code=utf-8
 
 xgettext \

--- a/source/gx/i18n/l10n.d
+++ b/source/gx/i18n/l10n.d
@@ -66,6 +66,15 @@ string _(string text) {
 }
 
 /**
+ * Uses gettext to get the translation for text in the given context.
+ * This is mainly useful for short strings which may need different
+ * translations, depending on the context in which they are used.
+ */
+string C_(string context, string text) {
+    return Internationalization.dpgettext2(_textdomain, context, text);
+}
+
+/**
  * Only marks a string for translation. This is useful in situations where the
  * translated strings can't be directly used, e.g. in string array initializers.
  * To get the translated string, call _() at runtime.

--- a/source/gx/terminix/constants.d
+++ b/source/gx/terminix/constants.d
@@ -81,3 +81,4 @@ enum APPLICATION_RESOURCE_ROOT = "/com/gexperts/Terminix";
 immutable string[] APPLICATION_CSS_RESOURCES = ["css/terminix.base.css"];
 
 immutable string SHORTCUT_UI_RESOURCE = APPLICATION_RESOURCE_ROOT ~ "/ui/shortcuts.ui";
+immutable string SHORTCUT_LOCALIZATION_CONTEXT = "shortcut window";

--- a/source/gx/terminix/prefwindow.d
+++ b/source/gx/terminix/prefwindow.d
@@ -325,7 +325,7 @@ private:
                     string id = xml.tag.attr["id"];
                     xml.onEndTag["property"] = (in Element e) {
                         if (e.tag.attr["name"] == "title") {
-                            labels[id] = e.text;
+                            labels[id] = C_(SHORTCUT_LOCALIZATION_CONTEXT, e.text);
                         } 
                     };
                     xml.parse();
@@ -334,10 +334,10 @@ private:
             parser.parse();
             // While you could use sections to get prefixes, not all sections are there
             // and it's not inutituve from a localization perspective. Just add them manually
-            prefixes["win"] = _("Window");
-            prefixes["app"] = _("Application");
-            prefixes["terminal"] = _("Terminal");
-            prefixes["session"] = _("Session");
+            prefixes["win"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Window");
+            prefixes["app"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Application");
+            prefixes["terminal"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Terminal");
+            prefixes["session"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Session");
         } catch (XMLException e) {
             error("Failed to parse shortcuts.ui", e);
         }


### PR DESCRIPTION
This fixes the shortcut labels to be localized with the proper localization context defined inside `shortcuts.ui` and finalizes the changes introduced for #301 .

Another solution could have been to remove the localization context, but I saw that some of the strings are also used as menu labels, and it is actually useful to be able to have a different (maybe longer) translation in the help text. So I opted for keeping the context but make sure it gets used.

I named the function `C_()` to follow the naming of the C macro commonly used for this.

On a side note the file saving workaround in `l10n.d`can probably be removed. Since it is only used in `_()` and not in the `N_()` and now `C_()` functions it isn't working properly anyway.