### PR TITLE
Update translations

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-07 20:02+0000\n"
 "Last-Translator: Ivaylo Kuzev <ivkuzev@gmail.com>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/terminix/"
@@ -640,70 +640,72 @@ msgstr "Изход"
 msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Задаване работната директория на терминала"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Задаване на стартов профил"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Отваряне на определена сесия"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Изпращане на действие до текущата инстанция на Terminix"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Максимизирай прозореца на терминала"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 #, fuzzy
 msgid "Full-screen the terminal window"
 msgstr "На цял екран прозореца на терминала"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "Фокусирай съществуващия прозорец"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -711,13 +713,13 @@ msgid ""
 msgstr ""
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 #, fuzzy
 msgid "Configuration Issue Detected"
 msgstr "Открита е грешка със конфигурацията"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 #, fuzzy
 msgid "Do not show this message again"
 msgstr "Не показвай отново това съобщение"
@@ -933,6 +935,8 @@ msgstr "Фокусирай Прозорец"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Поставяне"
 
@@ -956,6 +960,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Отменете"
 
@@ -1009,6 +1015,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Терминал"
 
@@ -1019,6 +1026,7 @@ msgstr "Терминал"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Затваряне"
 
@@ -1031,6 +1039,8 @@ msgstr "Затваряне"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Максимизиране"
 
@@ -1107,18 +1117,22 @@ msgstr "Разделяне"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Възстановяване"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr ""
 
@@ -1128,6 +1142,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Копиране"
 
@@ -1137,12 +1153,15 @@ msgstr "Копиране"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Избиране на всичко"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 #, fuzzy
 msgid "Clipboard"
 msgstr "Клипборд"
@@ -1150,6 +1169,7 @@ msgstr "Клипборд"
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 #, fuzzy
 msgid "Synchronize input"
 msgstr "Синхронизация вход"
@@ -1157,12 +1177,14 @@ msgstr "Синхронизация вход"
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1170,12 +1192,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Всички текстови Файлове"
 
@@ -1184,12 +1208,14 @@ msgstr "Всички текстови Файлове"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Всички файлове"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1197,6 +1223,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1204,18 +1231,21 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 #, fuzzy
 msgid "This command is asking for Administrative access to your computer"
 msgstr "Тази команда изисква права на администратор за компютъра"
@@ -1223,6 +1253,7 @@ msgstr "Тази команда изисква права на админист�
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 #, fuzzy
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "Копиране на команди от интернет може да бъде опасно. "
@@ -1230,6 +1261,7 @@ msgstr "Копиране на команди от интернет може да
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 #, fuzzy
 msgid "Be sure you understand what each part of this command does."
 msgstr "Бъдете сигурни че разбирате всяка част от тази команда какво прави."
@@ -1237,12 +1269,14 @@ msgstr "Бъдете сигурни че разбирате всяка част 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr ""
 
@@ -1285,6 +1319,8 @@ msgid "Open…"
 msgstr "Отваряне…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Запазване"
 
@@ -1315,18 +1351,22 @@ msgid "Filename '%s' does not exist"
 msgstr "Името на файла '%s' не съществува"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 #, fuzzy
 msgid "Save Session"
 msgstr "Запазване на Сесия"
@@ -1334,7 +1374,7 @@ msgstr "Запазване на Сесия"
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr ""
 
@@ -1347,11 +1387,11 @@ msgstr ""
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "Грешка: "
 
@@ -1827,12 +1867,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1857,3 +1897,13 @@ msgstr "Синхронизация вход"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Сесия"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Запазване Като…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Отваряне…"

--- a/po/de.po
+++ b/po/de.po
@@ -2,11 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-10 16:24+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German "
-"<https://hosted.weblate.org/projects/terminix/translations/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/terminix/"
+"translations/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -635,68 +635,70 @@ msgstr "Beenden"
 msgid "Credits"
 msgstr "Mitwirkende"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Arbeitsordner des Terminals wählen"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "ORDNER"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Als Startprofil festlegen"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "PROFIL_NAME"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Die angegebene Sitzung öffnen"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "SITZUNGS_NAME"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "AKTIONS_NAME"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Übergebenen Befehl ausführen"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "BEFEHL"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Terminalfenster maximieren"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "Terminalfenster im Vollbildmodus anzeigen"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 msgid "Focus the existing window"
 msgstr "Vorhandenes Fenster fokussieren"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "TERMINAL_UUID"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -707,12 +709,12 @@ msgstr ""
 "Klicken Sie auf den unten stehenden Link für weitere Informationen:"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Probleme mit der Konfiguration entdeckt"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Diese Meldung nicht mehr anzeigen"
 
@@ -921,6 +923,8 @@ msgstr "Fenster fokussieren"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Einfügen"
 
@@ -945,6 +949,8 @@ msgid "OK"
 msgstr "OK"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -1000,6 +1006,7 @@ msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1010,6 +1017,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Schließen"
 
@@ -1022,6 +1030,8 @@ msgstr "Schließen"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Maximieren"
 
@@ -1095,18 +1105,22 @@ msgstr "Teilen"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Wiederherstellen"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Link öffnen"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Link-Adresse kopieren"
 
@@ -1116,6 +1130,8 @@ msgstr "Link-Adresse kopieren"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -1125,24 +1141,29 @@ msgstr "Kopieren"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Alles markieren"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr "Zwischenablage"
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr "Eingabe synchronisieren"
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 "Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
@@ -1150,6 +1171,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "Unerwarteter Fehler aufgetreten: %s"
@@ -1157,12 +1179,14 @@ msgstr "Unerwarteter Fehler aufgetreten: %s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Terminalausgabe speichern"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Alle Textdateien"
 
@@ -1171,12 +1195,14 @@ msgstr "Alle Textdateien"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Alle Dateien"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "Der Kindprozess wurde normal mit Status %d beendet."
@@ -1184,6 +1210,7 @@ msgstr "Der Kindprozess wurde normal mit Status %d beendet."
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "Der Kindprozess wurde mit Signal %d beendet."
@@ -1191,30 +1218,35 @@ msgstr "Der Kindprozess wurde mit Signal %d beendet."
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "Der Kindprozess wurde beendet."
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Neustart"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 "Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
@@ -1223,12 +1255,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Nicht einfügen"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "Trotzdem einfügen"
 
@@ -1272,6 +1306,8 @@ msgid "Open…"
 msgstr "Öffnen …"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Speichern"
 
@@ -1301,26 +1337,30 @@ msgid "Filename '%s' does not exist"
 msgstr "Dateiname »%s« existiert nicht"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Sitzung laden"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr ""
 "Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Fehler beim Laden der Sitzung"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Sitzung speichern"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1335,11 +1375,11 @@ msgstr ""
 "Die installierte GTK-Version ist zu alt, es ist mindestens GTK %d.%d.%d "
 "erforderlich!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr "Unerwartete Ausnahme aufgetreten"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "Fehler:"
 
@@ -1813,13 +1853,13 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix wurde mit GNOME und Unity getestet."
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 "Fenstergröße setzen, z.B. 80x24 oder 80x24+200+200 (SPALTENxZEILEN+X+Y)"
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr "GEOMETRIE"
 
@@ -1841,3 +1881,13 @@ msgstr "Eingabe synchronisieren"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sitzung"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Speichern unter …"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Öffnen …"

--- a/po/en.po
+++ b/po/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-07 02:09+0000\n"
 "Last-Translator: Gerald Nunn <gerald.b.nunn@gmail.com>\n"
 "Language-Team: English <https://hosted.weblate.org/projects/terminix/"
@@ -642,71 +642,73 @@ msgstr "Quit"
 msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Set the working directory of the terminal"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Set the starting profile"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Open the specified session"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Send an action to current Terminix instance"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Execute the passed command"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 #, fuzzy
 msgid "Maximize the terminal window"
 msgstr "Hold the terminal open"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 #, fuzzy
 msgid "Full-screen the terminal window"
 msgstr "Hold the terminal open"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "Hold the terminal open"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -717,12 +719,12 @@ msgstr ""
 "the link below for more information:"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Configuration Issue Detected"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Do not show this message again"
 
@@ -934,6 +936,8 @@ msgstr "New Window"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Paste"
 
@@ -956,6 +960,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr ""
 
@@ -1009,6 +1015,7 @@ msgstr "Wrap around"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1019,6 +1026,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Close"
 
@@ -1031,6 +1039,8 @@ msgstr "Close"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 #, fuzzy
 msgid "Maximize"
 msgstr "Maximize"
@@ -1106,18 +1116,22 @@ msgstr "Split Down"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr ""
 
@@ -1127,6 +1141,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Copy"
 
@@ -1136,18 +1152,22 @@ msgstr "Copy"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Select All"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 #, fuzzy
 msgid "Synchronize input"
 msgstr "Synchronize Input"
@@ -1155,12 +1175,14 @@ msgstr "Synchronize Input"
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1168,12 +1190,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr ""
 
@@ -1182,12 +1206,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1195,6 +1221,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1202,42 +1229,49 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Don't Paste"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr ""
 
@@ -1278,6 +1312,8 @@ msgid "Open…"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Save"
 
@@ -1307,25 +1343,29 @@ msgid "Filename '%s' does not exist"
 msgstr "Filename '%s' does not exist"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Load Session"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "Could not load session due to unexpected error."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Error Loading Session"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Save Session"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1338,11 +1378,11 @@ msgstr "disabled"
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr ""
 
@@ -1861,12 +1901,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1891,3 +1931,12 @@ msgstr "Synchronize Input"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Session"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Save As…"
+
+#: source/gx/terminix/appwindow.d:765
+msgid "Open"
+msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-04-30 07:41+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/terminix/"
@@ -637,69 +637,71 @@ msgstr "Salir"
 msgid "Credits"
 msgstr "Créditos"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Establecer directorio de trabajo de la terminal"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Establecer perfil de inicio"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Abrir la sesión especificada"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Enviar una acción a la instancia de Terminix actual"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Maximizar la ventana de la terminal"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "Poner a pantalla completa la ventana de la terminal"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "Poner a pantalla completa la ventana de la terminal"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -707,12 +709,12 @@ msgid ""
 msgstr ""
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr ""
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr ""
 
@@ -921,6 +923,8 @@ msgstr "Nueva ventana"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Pegar"
 
@@ -943,6 +947,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -996,6 +1002,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1006,6 +1013,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Cerrar"
 
@@ -1018,6 +1026,8 @@ msgstr "Cerrar"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Maximinar"
 
@@ -1091,18 +1101,22 @@ msgstr "Dividir"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Restaurar"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Abrir enlace"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Copiar dirección del enlace"
 
@@ -1112,6 +1126,8 @@ msgstr "Copiar dirección del enlace"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1121,30 +1137,36 @@ msgstr "Copiar"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Seleccionar todo"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr "Portapapeles"
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr "Sincronizar entrada"
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1152,12 +1174,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Guardar salida de la terminal"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Todos los ficheros de texto"
 
@@ -1166,12 +1190,14 @@ msgstr "Todos los ficheros de texto"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Todos los ficheros"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1179,6 +1205,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1186,42 +1213,49 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Relanzar"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "No pegar"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "Pegar igualmente"
 
@@ -1262,6 +1296,8 @@ msgid "Open…"
 msgstr "Abrir…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Guardar"
 
@@ -1291,25 +1327,29 @@ msgid "Filename '%s' does not exist"
 msgstr "El fichero '%s' no existe"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Cargar sesión"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "No se pudo cargar la sesión debido a un error inesperado."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Error cargando la sesión"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Guardar sesión"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1322,11 +1362,11 @@ msgstr ""
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr ""
 
@@ -1784,12 +1824,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1814,3 +1854,13 @@ msgstr "Sincronizar entrada"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sesión"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Guardar como…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Abrir…"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-05 16:49+0000\n"
 "Last-Translator: boiethios <fdaudre-@student.42.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/terminix/"
@@ -637,68 +637,70 @@ msgstr "Quitter"
 msgid "Credits"
 msgstr "Crédits"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Définir le répertoire de travail pour le terminal"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "DOSSIER"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Définir le profil de démarrage"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "NOM_PROFIL"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Ouvrir la session specifiée"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "NOM_SESSION"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Envoyer une action à l'instance actuelle Terminix"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "NOM_ACTION"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Exécuter la commande passée"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "EXECUTER"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Maximiser la fenêtre du terminal"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "Mettre la fenêtre du terminal en plein écran"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 msgid "Focus the existing window"
 msgstr "Donner le focus à la fenêtre existante"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "Hidden argument to pass terminal UUID"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "UUID_TERMINAL"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -710,12 +712,12 @@ msgstr ""
 "Cliquez sur le lien ci-dessous pour plus d'informations :"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Problème de configuration détecté"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Ne pas réafficher ce message"
 
@@ -925,6 +927,8 @@ msgstr "Donner le focus à la fenêtre"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Coller"
 
@@ -949,6 +953,8 @@ msgid "OK"
 msgstr "Ok"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -1006,6 +1012,7 @@ msgstr "Recherche circulaire"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1016,6 +1023,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Fermer"
 
@@ -1028,6 +1036,8 @@ msgstr "Fermer"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Maximiser"
 
@@ -1101,18 +1111,22 @@ msgstr "Diviser"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Restaurer"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Ouvrir le lien"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Copier l'adresse du lien"
 
@@ -1122,6 +1136,8 @@ msgstr "Copier l'adresse du lien"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Copier"
 
@@ -1131,24 +1147,29 @@ msgstr "Copier"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Tout sélectionner"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr "Presse-papier"
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr "Synchroniser l'entrée"
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 "Une erreur inattendue est survenue, aucune information supplémentaire n'est "
@@ -1157,6 +1178,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "Une erreur inattendue est survenue : %s"
@@ -1164,12 +1186,14 @@ msgstr "Une erreur inattendue est survenue : %s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Sauvegarder la sortie du terminal"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Tous les fichiers texte"
 
@@ -1178,12 +1202,14 @@ msgstr "Tous les fichiers texte"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Tous les fichiers"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "Les processus fils a quitté normalement avec le status %d"
@@ -1191,6 +1217,7 @@ msgstr "Les processus fils a quitté normalement avec le status %d"
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "Le processus fils a été interrompu par le signal %d."
@@ -1198,18 +1225,21 @@ msgstr "Le processus fils a été interrompu par le signal %d."
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "Le processus fils a été interrompu."
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Relancer"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 "Cette commande demande les droits d'administrateur sur votre ordinateur"
@@ -1217,24 +1247,28 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "Copier des commandes depuis l'internet peut être dangereux. "
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr "Soyez sûr de comprendre ce que fait chaque partie de la commande."
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Ne pas coller"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "Copier quand même"
 
@@ -1278,6 +1312,8 @@ msgid "Open…"
 msgstr "Ouvrir…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -1307,25 +1343,29 @@ msgid "Filename '%s' does not exist"
 msgstr "Le nom de fichier « %s » n'existe pas"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Charger la session"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "Impossible de charger la session en raison d'une erreur inattendue."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Erreur lors du chargement de la session"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Sauvegarder la session"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1340,11 +1380,11 @@ msgstr ""
 "Votre version de GTK est trop vieille, vous avez besoin au moins de GTK %d."
 "%d.%d !"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr "Une exception inattendue est survenue"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "Erreur : "
 
@@ -1822,12 +1862,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix a été testé sous GNOME et sous Unity."
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1852,3 +1892,13 @@ msgstr "Synchroniser l'entrée"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Session"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Enregistrer sous…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Ouvrir…"

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-08 14:10+0000\n"
 "Last-Translator: Aan <cacaddv@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/terminix/"
@@ -636,69 +636,71 @@ msgstr "Keluar"
 msgid "Credits"
 msgstr "Kredit"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Atur direktori kerja terminal"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "DIREKTORI"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Atur profil awalan"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "NAMA_PROFIL"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Buka sesi spesifik"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "NAMA_SESI"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Kirim aksi ke Terminix yang sekarang saat ini"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "NAMA_AKSI"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Eksekusi perintah yang terlewati"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "EKSEKUSI"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Maksimalkan jendela terminal"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "Layar-penuh jendela terminal"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "Layar-penuh jendela terminal"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "Sembunyikan argumentasi untuk melewati UUID terminal"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "UUID_TERMINAL"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -709,12 +711,12 @@ msgstr ""
 "Klik tautan dibawah untuk info selanjutnya:"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Isu Konfigurasi Terdeteksi"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Jangan tampilkan pesan ini lagi"
 
@@ -923,6 +925,8 @@ msgstr "Jendela Baru"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Tempel"
 
@@ -945,6 +949,8 @@ msgid "OK"
 msgstr "Ok"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Batal"
 
@@ -1000,6 +1006,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1010,6 +1017,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Tutup"
 
@@ -1022,6 +1030,8 @@ msgstr "Tutup"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Maksimalkan"
 
@@ -1095,18 +1105,22 @@ msgstr "Pisah"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Pulihkan"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Buka Tautan"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Salin Alamat Tautan"
 
@@ -1116,6 +1130,8 @@ msgstr "Salin Alamat Tautan"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Salin"
 
@@ -1125,30 +1141,36 @@ msgstr "Salin"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Pilih Semua"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr "Papan Klip"
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr "Sinkronisasi masukan"
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr "Terjadi galat tak terduga, tidak ada informasi tambahan yang tersedia"
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "Terjadi galat tak terduga: %s"
@@ -1156,12 +1178,14 @@ msgstr "Terjadi galat tak terduga: %s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Simpan Keluaran Terminal"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Semua Berkas Teks"
 
@@ -1170,12 +1194,14 @@ msgstr "Semua Berkas Teks"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Semua Berkas"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "Proses anak keluar secara normal dengan status %d"
@@ -1183,6 +1209,7 @@ msgstr "Proses anak keluar secara normal dengan status %d"
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "Proses anak dibatalkan dengan sinyal %d."
@@ -1190,42 +1217,49 @@ msgstr "Proses anak dibatalkan dengan sinyal %d."
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "Proses anak telah dibatalkan."
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Jalankan ulang"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr "Perintah ini meminta akses Administrasi ke komputer kamu"
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "Menyalin perintah dari internet bisa jadi berbahaya. "
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr "Pastikan anda mengerti apa yang dilakukan setiap bagian perintah ini."
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Jangan Tempel"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "Tempel Saja"
 
@@ -1266,6 +1300,8 @@ msgid "Open…"
 msgstr "Buka…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Simpan"
 
@@ -1295,25 +1331,29 @@ msgid "Filename '%s' does not exist"
 msgstr "Nama Berkas '%s' tidak ada"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Muat Sesi"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "Tidak dapat memuat sesi dikarenakan galat tak terduga."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Galat Memuat Sesi"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Simpan Sesi"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1326,11 +1366,11 @@ msgstr ""
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr ""
 
@@ -1788,12 +1828,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1819,3 +1859,13 @@ msgstr "Sinkronisasi masukan"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sesi"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Simpan Sebagai…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Buka…"

--- a/po/it.po
+++ b/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-04-30 23:39+0000\n"
 "Last-Translator: Luigi Maselli <luigix@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/terminix/"
@@ -642,68 +642,70 @@ msgstr "Esci"
 msgid "Credits"
 msgstr "Riconoscimenti"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Impostare la directory di lavoro del terminale"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "DIRECTORY"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Impostare il profilo di partenza"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "PROFILE_NAME"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Aprire la sessione specificata"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "SESSION_NAME"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Inviare un'azione all'istanza corrente di Terminix"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "ACTION_NAME"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Eseguire il comando passato"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "ESEGUIRE"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Massimizzare la finestra del terminale"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "Schermo intero la finestra del terminale"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 msgid "Focus the existing window"
 msgstr "Messa a fuoco finestra esistente"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "TERMINAL_UUID"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -714,12 +716,12 @@ msgstr ""
 "Clicca sul link qui sotto per ulteriori informazioni:"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Problema di configurazione rilevato"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Non mostrare più questo messaggio"
 
@@ -927,6 +929,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr ""
 
@@ -949,6 +953,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr ""
 
@@ -1002,6 +1008,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr ""
 
@@ -1012,6 +1019,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr ""
 
@@ -1024,6 +1032,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr ""
 
@@ -1097,18 +1107,22 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr ""
 
@@ -1118,6 +1132,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr ""
 
@@ -1127,30 +1143,36 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1158,12 +1180,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr ""
 
@@ -1172,12 +1196,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1185,6 +1211,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1192,42 +1219,49 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr ""
 
@@ -1268,6 +1302,8 @@ msgid "Open…"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr ""
 
@@ -1297,25 +1333,29 @@ msgid "Filename '%s' does not exist"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr ""
 
@@ -1328,11 +1368,11 @@ msgstr ""
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr ""
 
@@ -1787,12 +1827,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1817,3 +1857,11 @@ msgstr "sincronizza input"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "sessione"
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:765
+msgid "Open"
+msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Youngbin Han <sukso96100@gmail.com>\n"
 "Language-Team: sukso96100@gmail.com\n"
@@ -643,71 +643,73 @@ msgstr "끝내기"
 msgid "Credits"
 msgstr "크레딧"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "터미널 작업 디렉터리 설정"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "시작 프로파일 설정"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "특정 세션 열기"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "현재 Terminix 인스턴스로 동작 보내기"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "전달된 명령어 실행"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 #, fuzzy
 msgid "Maximize the terminal window"
 msgstr "터미널 열림 유지"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 #, fuzzy
 msgid "Full-screen the terminal window"
 msgstr "터미널 열림 유지"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "터미널 열림 유지"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -718,12 +720,12 @@ msgstr ""
 "자세한 정보는 아래 링크를 누르세요."
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "설정 이슈 감지됨"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "이 메시지 다시 보지 않기"
 
@@ -935,6 +937,8 @@ msgstr "새 창"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "붙여넣기"
 
@@ -957,6 +961,8 @@ msgid "OK"
 msgstr "확인"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "취소"
 
@@ -1012,6 +1018,7 @@ msgstr "주변 감싸기"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "터미널"
 
@@ -1022,6 +1029,7 @@ msgstr "터미널"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "닫기"
 
@@ -1034,6 +1042,8 @@ msgstr "닫기"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "최대화"
 
@@ -1109,18 +1119,22 @@ msgstr "아래로 분할"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "복원"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr ""
 
@@ -1130,6 +1144,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "복사"
 
@@ -1139,18 +1155,22 @@ msgstr "복사"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "모두 선택"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 #, fuzzy
 msgid "Synchronize input"
 msgstr "입력 동기화"
@@ -1158,6 +1178,7 @@ msgstr "입력 동기화"
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 "예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다."
@@ -1165,6 +1186,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "예상하지 못한 오류가 발생했습니다. %s"
@@ -1172,12 +1194,14 @@ msgstr "예상하지 못한 오류가 발생했습니다. %s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "터미널 출력 저장"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "모든 텍스트 파일"
 
@@ -1186,12 +1210,14 @@ msgstr "모든 텍스트 파일"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "모든 파일"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
@@ -1199,6 +1225,7 @@ msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다. %d"
@@ -1206,42 +1233,49 @@ msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "자식 프로세스가 중지되었습니다."
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "다시 시작"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "붙여넣지 마세요"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "어떻게든 붙여넣기"
 
@@ -1284,6 +1318,8 @@ msgid "Open…"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "저장"
 
@@ -1313,25 +1349,29 @@ msgid "Filename '%s' does not exist"
 msgstr "파일 이름 '%s'이(가) 없습니다."
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "세션 불러오기"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "세션 불러오기 오류"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "세션 저장"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1345,11 +1385,11 @@ msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "GTK 버전이 너무 오래 되었습니다, 적어도 GTK %d.%d.%d 버전이 필요합니다!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr "예상하지 못한 예외 발생"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "오류: "
 
@@ -1875,12 +1915,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1905,3 +1945,12 @@ msgstr "입력 동기화"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "세션"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "다른 이름으로 저장…"
+
+#: source/gx/terminix/appwindow.d:765
+msgid "Open"
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.55\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-08 12:50+0200\n"
 "Last-Translator: Piotr Sokół <psokol.l10n@gmail.com>\n"
 "Language-Team: polski <>\n"
@@ -632,68 +632,70 @@ msgstr "Zakończ"
 msgid "Credits"
 msgstr "Zasługi"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Ustala katalog roboczy terminala"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "KATALOG"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Używa zdefiniowanego profilu"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "NAZWA_PROFILU"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Otwiera określoną sesję"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "NAZWA_SESJI"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "NAZWA_CZYNNOŚCI"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Wykonuje określone polecenie"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "POLECENIE"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Maksymalizuje rozmiar okna"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "Przełącza tryb pełnego ekranu"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 msgid "Focus the existing window"
 msgstr "Uaktywnia otwarte okno"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "UUID_TERMINALA"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -704,12 +706,12 @@ msgstr ""
 "Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Wykryto błąd konfiguracji"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
 
@@ -918,6 +920,8 @@ msgstr "Uaktywnienie okna"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Wklejanie"
 
@@ -942,6 +946,8 @@ msgid "OK"
 msgstr "Gotowe"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -997,6 +1003,7 @@ msgstr "Przeszukanie od początku po osiągnięciu końca"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1007,6 +1014,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Zamknij"
 
@@ -1019,6 +1027,8 @@ msgstr "Zamknij"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Zmaksymalizuj"
 
@@ -1092,18 +1102,22 @@ msgstr "Dzielenie"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Przywróć"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Otwórz odnośnik"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Skopiuj adres odnośnika"
 
@@ -1113,6 +1127,8 @@ msgstr "Skopiuj adres odnośnika"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Skopiuj"
 
@@ -1122,30 +1138,36 @@ msgstr "Skopiuj"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr "Schowek"
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr "Synchronizowanie wprowadzania"
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "Wystąpił nieoczekiwany błąd: %s"
@@ -1153,12 +1175,14 @@ msgstr "Wystąpił nieoczekiwany błąd: %s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Zapisywanie zawartości terminala"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Wszystkie pliki tekstowe"
 
@@ -1167,12 +1191,14 @@ msgstr "Wszystkie pliki tekstowe"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Wszystkie pliki"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "Proces podrzędny został zakończony w zwykły sposób, ze stanem %d"
@@ -1180,6 +1206,7 @@ msgstr "Proces podrzędny został zakończony w zwykły sposób, ze stanem %d"
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "Przerwano proces podrzędny sygnałem %d."
@@ -1187,24 +1214,28 @@ msgstr "Przerwano proces podrzędny sygnałem %d."
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "Przerwano proces podrzędny."
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Uruchom ponownie"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 "Wklejanie do terminala poleceń opublikowanych w sieci może być niebezpieczne."
@@ -1212,6 +1243,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 "Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
@@ -1219,12 +1251,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Nie wklejaj"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "Wklej mimo to"
 
@@ -1267,6 +1301,8 @@ msgid "Open…"
 msgstr "Otwórz…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Zapisz"
 
@@ -1296,25 +1332,29 @@ msgid "Filename '%s' does not exist"
 msgstr "Plik „%s” nie istnieje"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Wczytywanie sesji"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Błąd wczytywania sesji"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Zapisywanie sesji"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1329,11 +1369,11 @@ msgstr ""
 "Zainstalowana wersja GTK jest przestarzała. Wymagana jest co najmniej wersja "
 "GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr "Wystąpił nieoczekiwany błąd"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "Błąd:"
 
@@ -1792,12 +1832,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1822,3 +1862,13 @@ msgstr "Synchronizowanie wprowadzania"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sesja"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Zapisz jako…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Otwórz…"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-05-07 15:14-0300\n"
 "Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -638,68 +638,70 @@ msgstr "Sair"
 msgid "Credits"
 msgstr "Créditos"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Definir o diretório de trabalho para o terminal"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "DIRETÓRIO"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Definir o perfil de início"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "NOME_DO_PERFIL"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Abrir a sessão especificada"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "NOME_DA_SESSÃO"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "Enviar uma ação para a instância atual do Terminix"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "NOME_DA_AÇÃO"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "Executar o comando passado"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "EXECUTAR"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "Maximizar a janela do terminal"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "A janela do terminal em tela cheia"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 msgid "Focus the existing window"
 msgstr "Focar a janela existente"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "Argumento oculto para passar o UUID terminal"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "UUID_DO_TERMINAL"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -710,12 +712,12 @@ msgstr ""
 "Clique no link a seguir para maiores informações:"
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Detectado problema de configuração"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Não exibir esta mensagem novamente"
 
@@ -924,6 +926,8 @@ msgstr "Janela de foco"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Colar"
 
@@ -948,6 +952,8 @@ msgid "OK"
 msgstr "OK"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1004,6 +1010,7 @@ msgstr "Voltar ao início"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -1014,6 +1021,7 @@ msgstr "Terminal"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Fechar"
 
@@ -1026,6 +1034,8 @@ msgstr "Fechar"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Maximizar"
 
@@ -1099,18 +1109,22 @@ msgstr "Dividir"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Restaurar"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Abrir link"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Copiar endereço do link"
 
@@ -1120,6 +1134,8 @@ msgstr "Copiar endereço do link"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1129,30 +1145,36 @@ msgstr "Copiar"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Selecionar tudo"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr "Área de transferência"
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr "Sincronizar entrada"
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "Ocorreu um erro inesperado: %s"
@@ -1160,12 +1182,14 @@ msgstr "Ocorreu um erro inesperado: %s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Salvar saída do terminal"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Todos os arquivos texto"
 
@@ -1174,12 +1198,14 @@ msgstr "Todos os arquivos texto"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Todos os arquivos"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "O processo filho encerrou normalmente com o estado %d"
@@ -1187,6 +1213,7 @@ msgstr "O processo filho encerrou normalmente com o estado %d"
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "O processo filho foi abortado pelo sinal %d."
@@ -1194,42 +1221,49 @@ msgstr "O processo filho foi abortado pelo sinal %d."
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "O processo filho foi abortado."
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Recarregar"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr "Este comando está solicitando acesso administrativo ao seu computador"
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "Copiar comandos da internet pode ser perigoso. "
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr "Tenha o conhecimento de cada parte que o comando faz."
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Não colar"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "Colar mesmo assim"
 
@@ -1272,6 +1306,8 @@ msgid "Open…"
 msgstr "Abrir…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Salvar"
 
@@ -1301,25 +1337,29 @@ msgid "Filename '%s' does not exist"
 msgstr "O nome do arquivo '%s' não existe"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Carregar sessão"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Erro ao carregar sessão"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Salvar sessão"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1333,11 +1373,11 @@ msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "Sua versão do GTK é muito antiga, você precisa pelo menos do GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr "Ocorreu uma exceção inesperada"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "Erro: "
 
@@ -1816,12 +1856,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "O Terminix foi testado com GNOME e o Unity."
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1846,3 +1886,13 @@ msgstr "Sincronizar entrada"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sessão"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Salvar como…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Abrir…"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: 2016-04-21 00:10+0000\n"
 "Last-Translator: Iryna Pruitt <jdpruitt2807@prodigy.net>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/terminix/"
@@ -644,71 +644,73 @@ msgstr "Выход"
 msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "Установить рабочую папку терминала"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "Установить стартовый профиль"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "Открыть специальную сессию"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 #, fuzzy
 msgid "Maximize the terminal window"
 msgstr "Держать терминал открытым"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 #, fuzzy
 msgid "Full-screen the terminal window"
 msgstr "Держать терминал открытым"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "Держать терминал открытым"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -716,12 +718,12 @@ msgid ""
 msgstr ""
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "Найдена ошибка конфигурации"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "Больше не показывать это сообщение"
 
@@ -933,6 +935,8 @@ msgstr "Новое окно"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "Вставить"
 
@@ -955,6 +959,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "Отменить"
 
@@ -1008,6 +1014,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "Терминал"
 
@@ -1018,6 +1025,7 @@ msgstr "Терминал"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "Закрыть..."
 
@@ -1030,6 +1038,8 @@ msgstr "Закрыть..."
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "Распахнуть"
 
@@ -1105,18 +1115,22 @@ msgstr "Разделить снизу"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "Восстановить"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "Открыть ссылку"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "Копировать адрес ссылки"
 
@@ -1126,6 +1140,8 @@ msgstr "Копировать адрес ссылки"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "Копировать"
 
@@ -1135,18 +1151,22 @@ msgstr "Копировать"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "Выбрать всё"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 #, fuzzy
 msgid "Synchronize input"
 msgstr "Синхронизировать ввод"
@@ -1154,12 +1174,14 @@ msgstr "Синхронизировать ввод"
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1167,12 +1189,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "Сохранить вывод терминала"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "Все текстовые файлы"
 
@@ -1181,12 +1205,14 @@ msgstr "Все текстовые файлы"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "Все файлы"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1194,6 +1220,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1201,42 +1228,49 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "Перезапустить"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "Не вставлять"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr ""
 
@@ -1277,6 +1311,8 @@ msgid "Open…"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "Сохранить"
 
@@ -1306,25 +1342,29 @@ msgid "Filename '%s' does not exist"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "Загрузить сеанс"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "Ошибка загрузки сеанса"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "Сохранить сеанс"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr ""
 
@@ -1337,11 +1377,11 @@ msgstr "выключен"
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "Ваш GTK слишком стар, нужно поставить версию %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "Ошибка:"
 
@@ -1862,12 +1902,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1893,3 +1933,13 @@ msgstr "Синхронизировать ввод"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "сеанс"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "Сохранить как"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "Открыть ссылку"

--- a/po/terminix.pot
+++ b/po/terminix.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -630,68 +630,70 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr ""
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr ""
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr ""
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 msgid "Focus the existing window"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -699,12 +701,12 @@ msgid ""
 msgstr ""
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr ""
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr ""
 
@@ -911,6 +913,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr ""
 
@@ -933,6 +937,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr ""
 
@@ -986,6 +992,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr ""
 
@@ -996,6 +1003,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr ""
 
@@ -1008,6 +1016,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr ""
 
@@ -1081,18 +1091,22 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr ""
 
@@ -1102,6 +1116,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr ""
 
@@ -1111,30 +1127,36 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 msgid "Synchronize input"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1142,12 +1164,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr ""
 
@@ -1156,12 +1180,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1169,6 +1195,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1176,42 +1203,49 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr ""
 
@@ -1252,6 +1286,8 @@ msgid "Open…"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr ""
 
@@ -1281,25 +1317,29 @@ msgid "Filename '%s' does not exist"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
 msgid "Terminix"
 msgstr ""
@@ -1313,11 +1353,11 @@ msgstr ""
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr ""
 
@@ -1786,12 +1826,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1812,4 +1852,12 @@ msgstr ""
 #: data/resources/ui/shortcuts.ui:138
 msgctxt "shortcut window"
 msgid "Session"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:765
+msgid "Open"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jeff Bai <jeffbai@aosc.xyz>\n"
 "Language-Team: AOSC zh_CN <aosc@member.fsf.org>\n"
@@ -643,69 +643,71 @@ msgstr "退出"
 msgid "Credits"
 msgstr "感谢名单"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "设置终端的工作目录"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr "DIRECTORY"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "设置启动配置文件"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr "PROFILE_NAME"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "打开指定会话"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr "SESSION_NAME"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "向当前 Terminix 实例发送动作"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr "ACTION_NAME"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "执行传入的命令"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr "EXECUTE"
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 msgid "Maximize the terminal window"
 msgstr "最大化终端窗口"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 msgid "Full-screen the terminal window"
 msgstr "全屏终端窗口"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "全屏终端窗口"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr "传入终端 UUID 的隐藏参数"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr "TERMINAL_UUID"
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -715,12 +717,12 @@ msgstr ""
 "点击如下链接以获取更多信息："
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "检测到配置问题"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "不再显示该信息"
 
@@ -931,6 +933,8 @@ msgstr "窗口"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "粘贴"
 
@@ -953,6 +957,8 @@ msgid "OK"
 msgstr "确定"
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr "取消"
 
@@ -1008,6 +1014,7 @@ msgstr "换行"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "终端"
 
@@ -1018,6 +1025,7 @@ msgstr "终端"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "关闭"
 
@@ -1030,6 +1038,8 @@ msgstr "关闭"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Maximize"
 msgstr "最大化"
 
@@ -1105,18 +1115,22 @@ msgstr "分割"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr "恢复"
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr "打开链接"
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr "复制链接地址"
 
@@ -1126,6 +1140,8 @@ msgstr "复制链接地址"
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "复制"
 
@@ -1135,12 +1151,15 @@ msgstr "复制"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "全选"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 #, fuzzy
 msgid "Clipboard"
 msgstr "剪贴板"
@@ -1148,6 +1167,7 @@ msgstr "剪贴板"
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 #, fuzzy
 msgid "Synchronize input"
 msgstr "同步输入"
@@ -1155,12 +1175,14 @@ msgstr "同步输入"
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr "发生未知错误，无其他可用信息"
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr "发生未知错误：%s"
@@ -1168,12 +1190,14 @@ msgstr "发生未知错误：%s"
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr "保存终端输出"
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr "所有文本文件"
 
@@ -1182,12 +1206,14 @@ msgstr "所有文本文件"
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr "所有文件"
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr "子进程以 %d 状态正常退出"
@@ -1195,6 +1221,7 @@ msgstr "子进程以 %d 状态正常退出"
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr "子进程被 %d 信号中止。"
@@ -1202,42 +1229,49 @@ msgstr "子进程被 %d 信号中止。"
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr "子进程已被中止。"
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr "重新启动"
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr "命令正在请求计算机的管理员权限"
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr "从互联网复制命令有一定危险性。"
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr "你应当确认命令每个部分的作用。"
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 msgid "Don't Paste"
 msgstr "不要粘贴"
 
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr "依然粘贴"
 
@@ -1280,6 +1314,8 @@ msgid "Open…"
 msgstr "打开…"
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "保存"
 
@@ -1309,25 +1345,29 @@ msgid "Filename '%s' does not exist"
 msgstr "文件名“%s”不存在"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "载入会话"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "发生未知错误，无法载入会话。"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Error Loading Session"
 msgstr "载入会话出错"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "保存会话"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1340,11 +1380,11 @@ msgstr "已禁用"
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "你的 GTK 版本太老，需要至少 GTK %d.%d.%d！"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr "发生未预期错误"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr "错误："
 
@@ -1816,12 +1856,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1847,3 +1887,13 @@ msgstr "同步输入"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "会话"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "另存为…"
+
+#: source/gx/terminix/appwindow.d:765
+#, fuzzy
+msgid "Open"
+msgstr "打开…"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-10 15:29+0200\n"
+"POT-Creation-Date: 2016-05-11 08:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mingye Wang (Arthur2e5) <arthur200126@gmail.com>\n"
 "Language-Team: AOSC zh_TW <aosc@member.fsf.org>\n"
@@ -646,71 +646,73 @@ msgstr "退出"
 msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "Set the working directory of the terminal"
 msgstr "設定終端的工作目錄"
 
-#: source/gx/terminix/application.d:466
+#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
 msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "Set the starting profile"
 msgstr "設定啟動配置檔"
 
-#: source/gx/terminix/application.d:467
+#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
 msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "Open the specified session"
 msgstr "開啟指定的會話"
 
-#: source/gx/terminix/application.d:468
+#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
 msgid "SESSION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "Send an action to current Terminix instance"
 msgstr "向當前 Terminix 例項傳送動作"
 
-#: source/gx/terminix/application.d:469
+#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
 msgid "ACTION_NAME"
 msgstr ""
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "Execute the passed command"
 msgstr "執行傳入的指令"
 
-#: source/gx/terminix/application.d:470
+#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
 msgid "EXECUTE"
 msgstr ""
 
-#: source/gx/terminix/application.d:471
+#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
 #, fuzzy
 msgid "Maximize the terminal window"
 msgstr "保持終端開啟"
 
-#: source/gx/terminix/application.d:472
+#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
 #, fuzzy
 msgid "Full-screen the terminal window"
 msgstr "保持終端開啟"
 
-#: source/gx/terminix/application.d:473
+#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
 #, fuzzy
 msgid "Focus the existing window"
 msgstr "保持終端開啟"
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "Hidden argument to pass terminal UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
+#: source/gx/terminix/application.d:490
 msgid "TERMINAL_UUID"
 msgstr ""
 
 #: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624
+#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
 msgid ""
 "There appears to be an issue with the configuration of the terminal.\n"
 "This issue is not serious, but correcting it will improve your experience.\n"
@@ -720,12 +722,12 @@ msgstr ""
 "點選如下連結以獲取更多資訊："
 
 #: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625
+#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
 msgid "Configuration Issue Detected"
 msgstr "檢測到配置問題"
 
 #: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637
+#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
 msgid "Do not show this message again"
 msgstr "不再顯示該資訊"
 
@@ -937,6 +939,8 @@ msgstr "新建視窗"
 #: source/gx/terminix/terminal/terminal.d:956
 #: source/gx/terminix/terminal/terminal.d:967
 #: source/gx/terminix/prefwindow.d:652
+#: source/gx/terminix/terminal/terminal.d:961
+#: source/gx/terminix/terminal/terminal.d:972
 msgid "Paste"
 msgstr "貼上"
 
@@ -960,6 +964,8 @@ msgid "OK"
 msgstr ""
 
 #: source/gx/terminix/terminal/layout.d:28
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
 msgid "Cancel"
 msgstr ""
 
@@ -1016,6 +1022,7 @@ msgstr "折列"
 #: source/gx/terminix/terminal/terminal.d:322
 #: source/gx/terminix/terminal/terminal.d:653
 #: source/gx/terminix/terminal/terminal.d:816
+#: source/gx/terminix/terminal/terminal.d:821
 msgid "Terminal"
 msgstr "終端"
 
@@ -1026,6 +1033,7 @@ msgstr "終端"
 #: source/gx/terminix/terminal/terminal.d:988
 #: source/gx/terminix/terminal/terminal.d:353
 #: source/gx/terminix/terminal/terminal.d:985
+#: source/gx/terminix/terminal/terminal.d:990
 msgid "Close"
 msgstr "關閉"
 
@@ -1038,6 +1046,8 @@ msgstr "關閉"
 #: source/gx/terminix/terminal/terminal.d:362
 #: source/gx/terminix/terminal/terminal.d:847
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:852
+#: source/gx/terminix/terminal/terminal.d:989
 #, fuzzy
 msgid "Maximize"
 msgstr "最大化"
@@ -1113,18 +1123,22 @@ msgstr "向下分割"
 #: source/gx/terminix/terminal/terminal.d:987
 #: source/gx/terminix/terminal/terminal.d:844
 #: source/gx/terminix/terminal/terminal.d:984
+#: source/gx/terminix/terminal/terminal.d:849
+#: source/gx/terminix/terminal/terminal.d:989
 msgid "Restore"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:927
 #: source/gx/terminix/terminal/terminal.d:946
 #: source/gx/terminix/terminal/terminal.d:943
+#: source/gx/terminix/terminal/terminal.d:948
 msgid "Open Link"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:928
 #: source/gx/terminix/terminal/terminal.d:947
 #: source/gx/terminix/terminal/terminal.d:944
+#: source/gx/terminix/terminal/terminal.d:949
 msgid "Copy Link Address"
 msgstr ""
 
@@ -1134,6 +1148,8 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:965
 #: source/gx/terminix/terminal/terminal.d:955
 #: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:960
+#: source/gx/terminix/terminal/terminal.d:967
 msgid "Copy"
 msgstr "複製"
 
@@ -1143,18 +1159,22 @@ msgstr "複製"
 #: source/gx/terminix/terminal/terminal.d:975
 #: source/gx/terminix/terminal/terminal.d:957
 #: source/gx/terminix/terminal/terminal.d:972
+#: source/gx/terminix/terminal/terminal.d:962
+#: source/gx/terminix/terminal/terminal.d:977
 msgid "Select All"
 msgstr "全選"
 
 #: source/gx/terminix/terminal/terminal.d:959
 #: source/gx/terminix/terminal/terminal.d:978
 #: source/gx/terminix/terminal/terminal.d:975
+#: source/gx/terminix/terminal/terminal.d:980
 msgid "Clipboard"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:973
 #: source/gx/terminix/terminal/terminal.d:992
 #: source/gx/terminix/terminal/terminal.d:989
+#: source/gx/terminix/terminal/terminal.d:994
 #, fuzzy
 msgid "Synchronize input"
 msgstr "同步輸入"
@@ -1162,12 +1182,14 @@ msgstr "同步輸入"
 #: source/gx/terminix/terminal/terminal.d:1410
 #: source/gx/terminix/terminal/terminal.d:1429
 #: source/gx/terminix/terminal/terminal.d:1425
+#: source/gx/terminix/terminal/terminal.d:1431
 msgid "Unexpected error occurred, no additional information available"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1416
 #: source/gx/terminix/terminal/terminal.d:1435
 #: source/gx/terminix/terminal/terminal.d:1431
+#: source/gx/terminix/terminal/terminal.d:1437
 #, c-format
 msgid "Unexpected error occurred: %s"
 msgstr ""
@@ -1175,12 +1197,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1730
 #: source/gx/terminix/terminal/terminal.d:1749
 #: source/gx/terminix/terminal/terminal.d:1747
+#: source/gx/terminix/terminal/terminal.d:1754
 msgid "Save Terminal Output"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:1736
 #: source/gx/terminix/terminal/terminal.d:1755
 #: source/gx/terminix/terminal/terminal.d:1753
+#: source/gx/terminix/terminal/terminal.d:1763
 msgid "All Text Files"
 msgstr ""
 
@@ -1189,12 +1213,14 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:1759
 #: source/gx/terminix/appwindow.d:725
 #: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/terminal/terminal.d:1767
 msgid "All Files"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2055
 #: source/gx/terminix/terminal/terminal.d:2078
 #: source/gx/terminix/terminal/terminal.d:2076
+#: source/gx/terminix/terminal/terminal.d:2086
 #, c-format
 msgid "The child process exited normally with status %d"
 msgstr ""
@@ -1202,6 +1228,7 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2056
 #: source/gx/terminix/terminal/terminal.d:2079
 #: source/gx/terminix/terminal/terminal.d:2077
+#: source/gx/terminix/terminal/terminal.d:2087
 #, c-format
 msgid "The child process was aborted by signal %d."
 msgstr ""
@@ -1209,36 +1236,42 @@ msgstr ""
 #: source/gx/terminix/terminal/terminal.d:2057
 #: source/gx/terminix/terminal/terminal.d:2080
 #: source/gx/terminix/terminal/terminal.d:2078
+#: source/gx/terminix/terminal/terminal.d:2088
 msgid "The child process was aborted."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2063
 #: source/gx/terminix/terminal/terminal.d:2086
 #: source/gx/terminix/terminal/terminal.d:2084
+#: source/gx/terminix/terminal/terminal.d:2094
 msgid "Relaunch"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2103
 #: source/gx/terminix/terminal/terminal.d:2126
 #: source/gx/terminix/terminal/terminal.d:2124
+#: source/gx/terminix/terminal/terminal.d:2134
 msgid "This command is asking for Administrative access to your computer"
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2104
 #: source/gx/terminix/terminal/terminal.d:2127
 #: source/gx/terminix/terminal/terminal.d:2125
+#: source/gx/terminix/terminal/terminal.d:2135
 msgid "Copying commands from the internet can be dangerous. "
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2105
 #: source/gx/terminix/terminal/terminal.d:2128
 #: source/gx/terminix/terminal/terminal.d:2126
+#: source/gx/terminix/terminal/terminal.d:2136
 msgid "Be sure you understand what each part of this command does."
 msgstr ""
 
 #: source/gx/terminix/terminal/terminal.d:2107
 #: source/gx/terminix/terminal/terminal.d:2130
 #: source/gx/terminix/terminal/terminal.d:2128
+#: source/gx/terminix/terminal/terminal.d:2138
 #, fuzzy
 msgid "Don't Paste"
 msgstr "貼上"
@@ -1246,6 +1279,7 @@ msgstr "貼上"
 #: source/gx/terminix/terminal/terminal.d:2108
 #: source/gx/terminix/terminal/terminal.d:2131
 #: source/gx/terminix/terminal/terminal.d:2129
+#: source/gx/terminix/terminal/terminal.d:2139
 msgid "Paste Anyway"
 msgstr ""
 
@@ -1287,6 +1321,8 @@ msgid "Open…"
 msgstr ""
 
 #: source/gx/terminix/appwindow.d:405
+#: source/gx/terminix/terminal/terminal.d:1757
+#: source/gx/terminix/appwindow.d:797
 msgid "Save"
 msgstr "儲存"
 
@@ -1316,26 +1352,30 @@ msgid "Filename '%s' does not exist"
 msgstr "檔名「%s」不存在"
 
 #: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
+#: source/gx/terminix/appwindow.d:762
 msgid "Load Session"
 msgstr "載入會話"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 msgid "Could not load session due to unexpected error."
 msgstr "發生未知錯誤，無法載入會話。"
 
 #: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
+#: source/gx/terminix/appwindow.d:778
 #, fuzzy
 msgid "Error Loading Session"
 msgstr "載入會話"
 
 #: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
+#: source/gx/terminix/appwindow.d:794
 msgid "Save Session"
 msgstr "儲存會話"
 
 #: source/gx/terminix/appwindow.d:809
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824
+#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
 msgid "Terminix"
 msgstr "Terminix"
 
@@ -1349,11 +1389,11 @@ msgstr "已啟用"
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96
+#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97
+#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
 msgid "Error: "
 msgstr ""
 
@@ -1880,12 +1920,12 @@ msgstr ""
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid ""
 "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
 
-#: source/gx/terminix/application.d:474
+#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
 msgid "GEOMETRY"
 msgstr ""
 
@@ -1911,3 +1951,12 @@ msgstr "同步輸入"
 msgctxt "shortcut window"
 msgid "Session"
 msgstr "會話"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, fuzzy
+msgid "Save Output…"
+msgstr "另存為…"
+
+#: source/gx/terminix/appwindow.d:765
+msgid "Open"
+msgstr ""

--- a/source/gx/terminix/terminal/terminal.d
+++ b/source/gx/terminix/terminal/terminal.d
@@ -632,7 +632,7 @@ private:
      */
     void createPopoverMenuItems(GMenu model) {
         GMenu menuSection = new GMenu();
-        menuSection.append(_("Save…"), ACTION_SAVE);
+        menuSection.append(_("Save Output…"), ACTION_SAVE);
         menuSection.append(_("Find…"), ACTION_FIND);
         menuSection.append(_("Layout Options…"), ACTION_LAYOUT);
         model.appendSection(null, menuSection);


### PR DESCRIPTION
This updates the translation files to prepare for the 1.0 release (only 2 new strings not yet in the po files). I have also changed the label for the save terminal output action from "Save..." to "Save Output...". I struggled understanding the function of this menu entry when I started using Terminix and confused it with the session "Save...".