### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: d
+d:
+ - dmd-2.071.0
+ - dmd-2.070.2
+ - ldc-1.0.0-beta2
+script:
+ - dub build


### PR DESCRIPTION
It's pretty easy to automatically test for various compilers.
See:

https://travis-ci.org/wilzbach/terminix

You need to enable Travis after this is merged.
It's currently failing because of one line

```
source/gx/terminix/prefwindow.d(314): Error: no property 'clear' for type 'string[string]'
```