### PR TITLE
i18n: Removed fuzzy marker from German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2391,25 +2391,21 @@ msgid "Application"
 msgstr "Anwendung"
 
 #: data/resources/ui/shortcuts.ui:19
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open a new window"
 msgstr "Neues Fenster öffnen"
 
 #: data/resources/ui/shortcuts.ui:25
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open a new session"
 msgstr "Neue Sitzung erstellen"
 
 #: data/resources/ui/shortcuts.ui:31
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open preferences"
 msgstr "Einstellungsdialog öffnen"
 
 #: data/resources/ui/shortcuts.ui:37
-#, fuzzy
 msgctxt "shortcut window"
 msgid "View configured shortcuts"
 msgstr "Konfigurierte Tastenkombinationen anzeigen"
@@ -2420,7 +2416,6 @@ msgid "Window"
 msgstr "Fenster"
 
 #: data/resources/ui/shortcuts.ui:49
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Toggle fullscreen mode"
 msgstr "Vollbildmodus ein-/ausschalten"
@@ -2431,73 +2426,61 @@ msgid "View session sidebar"
 msgstr "Sitzungs-Seitenleiste anzeigen"
 
 #: data/resources/ui/shortcuts.ui:61
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Zur nächsten Sitzung wechseln"
 
 #: data/resources/ui/shortcuts.ui:67
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Zur vorherigen Sitzung wechseln"
 
 #: data/resources/ui/shortcuts.ui:73
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Zu Sitzung 1 wechseln"
 
 #: data/resources/ui/shortcuts.ui:79
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Zu Sitzung 2 wechseln"
 
 #: data/resources/ui/shortcuts.ui:85
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Zu Sitzung 3 wechseln"
 
 #: data/resources/ui/shortcuts.ui:91
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Zu Sitzung 4 wechseln"
 
 #: data/resources/ui/shortcuts.ui:97
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Zu Sitzung 5 wechseln"
 
 #: data/resources/ui/shortcuts.ui:103
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Zu Sitzung 6 wechseln"
 
 #: data/resources/ui/shortcuts.ui:109
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Zu Sitzung 7 wechseln"
 
 #: data/resources/ui/shortcuts.ui:115
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Zu Sitzung 8 wechseln"
 
 #: data/resources/ui/shortcuts.ui:121
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Zu Sitzung 9 wechseln"
 
 #: data/resources/ui/shortcuts.ui:127
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Zu Sitzung 10 wechseln"
@@ -2508,45 +2491,38 @@ msgid "Session"
 msgstr "Sitzung"
 
 #: data/resources/ui/shortcuts.ui:143
-#, fuzzy
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Datei"
 
 #: data/resources/ui/shortcuts.ui:147
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Aktuelle Sitzung schließen"
 
 #: data/resources/ui/shortcuts.ui:153
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Aktuelle Sitzung speichern"
 
 #: data/resources/ui/shortcuts.ui:159
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Aktuelle Sitzung unter neuem Dateinamen speichern"
 
 #: data/resources/ui/shortcuts.ui:165
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Gespeicherte Sitzung öffnen"
 
 #: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
 #: data/resources/ui/shortcuts.ui:173,
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Größe ändern"
 
 #: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:177,
-#, fuzzy
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Terminalgröße aufwärts verändern"


### PR DESCRIPTION
For some reason Weblate does not show these strings as fuzzy and does not allow to change it. I tried fixing this in Weblate by pulling and rebasing, but something is broken, so fixing manually.