### PR TITLE
Improve metainfo file

### DIFF
--- a/data/appdata/Makefile.am
+++ b/data/appdata/Makefile.am
@@ -1,4 +1,4 @@
-appdatadir = $(datadir)/appdata/
+appdatadir = $(datadir)/metainfo/
 appdata_DATA = com.gexperts.Terminix.appdata.xml
 $(appdata_DATA): $(srcdir)/$(appdata_DATA).in
 	$(MSGFMT) --xml -d $(top_srcdir)/po --template=$< -o $@

--- a/data/appdata/com.gexperts.Terminix.appdata.xml.in
+++ b/data/appdata/com.gexperts.Terminix.appdata.xml.in
@@ -4,8 +4,10 @@
   <id>com.gexperts.Terminix.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
+
   <name>Terminix</name>
   <summary>A tiling terminal for GNOME</summary>
+
   <description>
     <p>
       Terminix is a tiling terminal emulator.
@@ -28,10 +30,18 @@
     </p>
     <p>Terminix has been tested with GNOME and with Unity.</p>
   </description>
+
+  <screenshots>
+​    <screenshot type="default">
+​      <image>http://www.gexperts.com/img/terminix/terminix2.png</image>
+​    </screenshot>
+​  </screenshots>
+
   <kudos>
     <kudo>AppMenu</kudo>
     <kudo>ModernToolkit</kudo>
   </kudos>
+
   <url type="homepage">https://github.com/gnunn1/terminix/</url>
   <project_group>GNOME</project_group>
   <translation type="gettext">terminix</translation>

--- a/data/appdata/com.gexperts.Terminix.appdata.xml.in
+++ b/data/appdata/com.gexperts.Terminix.appdata.xml.in
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2016 Matthias Clasen -->
 <component type="desktop">
-  <id type="desktop">com.gexperts.Terminix.desktop</id>
+  <id>com.gexperts.Terminix.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   <name>Terminix</name>
   <summary>A tiling terminal for GNOME</summary>
   <description>
     <p>
-    Terminix is a tiling terminal emulator.
+      Terminix is a tiling terminal emulator.
     </p>
     <p>It lets you:</p>
     <ul>
@@ -23,8 +23,8 @@
     <li>Supports notifications when processes are completed out of view</li>
     </ul>
     <p>
-     The application was written using GTK 3 and an effort was made to conform to
-     GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-decorations, though it can be disabled if necessary.
+      The application was written using GTK 3 and an effort was made to conform to
+      GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-decorations, though it can be disabled if necessary.
     </p>
     <p>Terminix has been tested with GNOME and with Unity.</p>
   </description>

--- a/install.sh
+++ b/install.sh
@@ -88,9 +88,9 @@ cp -r data/icons/hicolor/. ${PREFIX}/share/icons/hicolor
 mkdir -p ${PREFIX}/bin
 cp terminix ${PREFIX}/bin/terminix
 mkdir -p ${PREFIX}/share/applications
-mkdir -p ${PREFIX}/share/appdata
+mkdir -p ${PREFIX}/share/metainfo
 cp data/pkg/desktop/com.gexperts.Terminix.desktop ${PREFIX}/share/applications
-cp data/appdata/com.gexperts.Terminix.appdata.xml ${PREFIX}/share/appdata
+cp data/appdata/com.gexperts.Terminix.appdata.xml ${PREFIX}/share/metainfo
 
 desktop-file-validate ${PREFIX}/share/applications/com.gexperts.Terminix.desktop
 


### PR DESCRIPTION
Adds more metadata and removes superfluous or outdated attributes/paths.

This kills some hints from the AppStream metadata generator. Please note that changing the install directory requires up-to-date AppStream tools.
At time, the current (development) releases of all major distributions support this, including Arch, Debian, Ubuntu, Fedora, OpenSUSE. Changing the path might affect backports for some distros (Debian, Ubuntu and Arch are safe, so is OpenSUSE, I am not 100% sure about Fedora).

See https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps for more information on how to write good metainfo files for apps.