### PR TITLE
autotools: install all files under icons/hicolor

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -1,4 +1,4 @@
 
 iconsdir = $(datadir)/icons
-nobase_dist_icons_DATA = $(shell find $(srcdir)/hicolor -name '*\.png')
+nobase_dist_icons_DATA = $(shell find $(srcdir)/hicolor -type f)
 


### PR DESCRIPTION
SVG icon was being left out here too.