### PR TITLE
Overwrite file on save, fixes #417

### DIFF
--- a/source/gx/terminix/terminal/terminal.d
+++ b/source/gx/terminix/terminal/terminal.d
@@ -1953,7 +1953,7 @@ private:
         }
         //Do work here
         GFileIF file = GFile.parseName(outputFilename);
-        gio.OutputStream.OutputStream stream = file.create(GFileCreateFlags.NONE, null);
+        gio.OutputStream.OutputStream stream = file.replace(null, false, GFileCreateFlags.NONE, null);
         scope (exit) {
             stream.close(null);
         }


### PR DESCRIPTION
`create()` will throw an error if the file already exists.  `replace()` will overwrite the file, or create it if it doesn't already exist.

Fixes #417 