### PR TITLE
Add semi colon to Actions attribute in .desktop

### DIFF
--- a/data/pkg/desktop/com.gexperts.Terminix.desktop.in
+++ b/data/pkg/desktop/com.gexperts.Terminix.desktop.in
@@ -9,7 +9,7 @@ StartupNotify=true
 Categories=System;TerminalEmulator;X-GNOME-Utilities;
 Icon=com.gexperts.Terminix
 DBusActivatable=true
-Actions=new-window;new-session
+Actions=new-window;new-session;
 
 [Desktop Action new-window]
 Name=New Window


### PR DESCRIPTION
Fixes the following errors when running the installer:
```
/usr/share/applications/com.gexperts.Terminix.desktop: error: value "new-window;new-session" for string list key "Actions" in group "Desktop Entry" does not have a semicolon (';') as trailing character
/usr/share/applications/com.gexperts.Terminix.desktop: error: action group "Desktop Action new-window" exists, but there is no matching action "new-window"
/usr/share/applications/com.gexperts.Terminix.desktop: error: action group "Desktop Action new-session" exists, but there is no matching action "new-session"
```