### PR TITLE
Add support for building with Meson

### DIFF
--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,0 +1,14 @@
+
+icon_sizes = ['16x16', '22x22', '24x24', '32x32', '48x48', '256x256', '512x512']
+
+# install bitmap icons
+foreach size : icon_sizes
+    install_data('hicolor/' + size + '/apps/com.gexperts.Terminix.png',
+                 install_dir: 'share/icons/hicolor/' + size + '/apps/'
+    )
+endforeach
+
+# install scalable symbolic icon
+install_data('hicolor/scalable/apps/com.gexperts.Terminix-symbolic.svg',
+             install_dir: 'share/icons/hicolor/scalable/apps/'
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,164 @@
+project('Terminix', 'd')
+
+if meson.get_compiler('d').get_id() == 'gcc'
+    error('Terminix can not be compiled with GDC at time, since the standard library version of all GDC versions is currently (2016) too old. Sorry.')
+endif
+
+glib = import('gnome')
+i18n = import('i18n')
+
+terminix_sources = ['source/app.d',
+    'source/gx/gtk/actions.d',
+    'source/gx/gtk/cairo.d',
+    'source/gx/gtk/clipboard.d',
+    'source/gx/gtk/dialog.d',
+    'source/gx/gtk/resource.d',
+    'source/gx/gtk/threads.d',
+    'source/gx/gtk/util.d',
+    'source/gx/gtk/vte.d',
+    'source/gx/i18n/l10n.d',
+    'source/gx/terminix/application.d',
+    'source/gx/terminix/appwindow.d',
+    'source/gx/terminix/cmdparams.d',
+    'source/gx/terminix/colorschemes.d',
+    'source/gx/terminix/common.d',
+    'source/gx/terminix/constants.d',
+    'source/gx/terminix/encoding.d',
+    'source/gx/terminix/preferences.d',
+    'source/gx/terminix/prefwindow.d',
+    'source/gx/terminix/profilewindow.d',
+    'source/gx/terminix/session.d',
+    'source/gx/terminix/shortcuts.d',
+    'source/gx/terminix/sidebar.d',
+    'source/gx/terminix/terminal/actions.d',
+    'source/gx/terminix/terminal/layout.d',
+    'source/gx/terminix/terminal/search.d',
+    'source/gx/terminix/terminal/terminal.d',
+    'source/gx/terminix/terminal/vtenotification.d',
+    'source/gx/util/array.d',
+    'source/gx/util/string.d'
+]
+
+source_root = meson.source_root()
+sources_dir = include_directories('source/')
+
+#
+# Dependencies
+#
+gtkd_dep = dependency('gtkd-3 >= 3.3.0')
+vted_dep = dependency('vted-3 >= 3.3.0')
+gcr = find_program('glib-compile-resources')
+msgfmt = find_program('msgfmt')
+
+# install target for arch-indep data
+terminix_share = 'share/terminix'
+
+#
+# Build resources and metadata files
+#
+gresource = custom_target('glib-resource',
+    input: 'data/resources/terminix.gresource.xml',
+    output: 'terminix.gresource',
+    command: [gcr, '@INPUT@',
+        '--sourcedir', source_root + '/data/resources',
+        '--target', '@OUTPUT@'],
+    install: true,
+    install_dir: terminix_share + '/resources'
+)
+
+desktop_target = custom_target('desktop-file',
+    input: 'data/pkg/desktop/com.gexperts.Terminix.desktop.in',
+    output: 'com.gexperts.Terminix.desktop',
+    command: [msgfmt, '--desktop',
+        '-d', source_root + '/po',
+        '--template', '@INPUT@',
+        '-o', '@OUTPUT@'],
+    install: true,
+    install_dir: 'share/applications'
+)
+
+metainfo_target = custom_target('metainfo',
+    input: 'data/appdata/com.gexperts.Terminix.appdata.xml.in',
+    output: 'com.gexperts.Terminix.appdata.xml',
+    command: [msgfmt, '--xml',
+        '-d', source_root + '/po',
+        '--template', '@INPUT@',
+        '-o', '@OUTPUT@'],
+    install: true,
+    install_dir: 'share/metainfo'
+)
+
+#
+# Build & Test
+#
+terminix_exe = executable('terminix',
+    [terminix_sources],
+    include_directories : [sources_dir],
+    dependencies : [gtkd_dep,
+                    vted_dep],
+    install : true
+)
+
+terminix_test_exe = executable('terminix_test',
+    [terminix_sources],
+    include_directories : [sources_dir],
+    dependencies : [gtkd_dep,
+                    vted_dep],
+    d_args: [meson.get_compiler('d').get_unittest_flag()]
+)
+test('terminix_test', terminix_test_exe)
+
+# Validate things
+desktop_file_validate = find_program('desktop-file-validate', required: false)
+appstreamcli = find_program('appstreamcli', required: false)
+
+if desktop_file_validate.found()
+    test('desktopfile_test',
+         desktop_file_validate,
+         args: [desktop_target.full_path()]
+    )
+endif
+if appstreamcli.found()
+    test('appstream_test',
+         appstreamcli,
+         args: ['--no-color',
+             'validate', metainfo_target.full_path()],
+         should_fail: true # FIXME: the <kudos/> tag isn't in the spec and therefore this validation fails
+    )
+endif
+
+#
+# Install
+#
+
+color_schemes = [
+    'data/schemes/base16-twilight-dark.json',
+    'data/schemes/linux.json',
+    'data/schemes/material.json',
+    'data/schemes/monokai.json',
+    'data/schemes/orchis.json',
+    'data/schemes/solarized-dark.json',
+    'data/schemes/solarized-light.json',
+    'data/schemes/tango.json',
+]
+
+# GSettings schema
+install_data('data/gsettings/com.gexperts.Terminix.gschema.xml', install_dir: 'share/glib-2.0/schemas')
+
+# Color schemes
+install_data(color_schemes, install_dir: terminix_share + '/schemes')
+
+# Scripts
+install_data('data/scripts/terminix_int.sh', install_dir: terminix_share + '/scripts')
+
+# Copying Nautilus extension
+install_data('data/nautilus/open-terminix.py', install_dir: 'share/nautilus-python/extensions/')
+
+# Copy D-Bus service descriptor
+install_data('data/dbus/com.gexperts.Terminix.service', install_dir: 'share/dbus-1/services/')
+
+#
+# Subdirectories
+#
+subdir('po')
+subdir('data/icons')

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,31 @@
+
+langs = [
+    'bg',
+    'de',
+    'el',
+    'en',
+    'es',
+    'fr',
+    'he',
+    'id',
+    'it',
+    'ko',
+    'lt',
+    'pl',
+    'pt_BR',
+    'ru',
+    'sv',
+    'tr',
+    'zh_CN',
+    'zh_TW'
+]
+
+# really hacky way to generate the LINGUAS file.
+# this is done mainly to not break the other build systems,
+# actually the LINGUAS file and 'langs' list above should be maintained by hand.
+linguas_cmd = run_command('bash', '-c', 'find' + ' ' + source_root + '/po' + ' ' + '-name "*\.po" -printf "%f\\n" | sed "s/\.po//g" | sort > ' + source_root + '/po/LINGUAS')
+if linguas_cmd.returncode() != 0
+    error('Could not generate LINGUAS file!\n' + linguas_cmd.stdout() + '\n' + linguas_cmd.stderr())
+endif
+
+i18n.gettext('terminix', languages: langs)


### PR DESCRIPTION
Hi!
I am not sure if you actually want this patch, because Terminix has two build systems already, but since I wrote it already, making a PR out of it and ask for feedback won't hurt.

So, what is Meson and why should you use it?
Meson is a fast, Ninja-based buildsystem where I recently added D support to (currently under review at https://github.com/mesonbuild/meson/pull/685). It is much more powerful than dub and also compiles much faster than dub.
In spirit, it is comparable to CMake/Autotools, but without all the craziness and following a very clean and simple design.

See https://ninja-build.org/ for information on Ninja (which also compiles stuff like e.g. Google Chrome) and http://mesonbuild.com/ for Meson.

To give a few numbers, a compilation of Terminix using dub takes about 8.6s on my system, while compiling it with Ninja takes only roughly 6s (the difference becomes really huge if you have a lot of D sources). This is using the LDC D compiler, creating a non-optimized debug build.

Meson is seen as one of the potential replacements of Autotools in GNOME and other projects.
I think, when D support is upstreamed, Terminix could very well drop the Autotools support and be Meson only - but that's up to you and whoever maintains the Autotools stuff right now.
(I myself prefer it over dub, even)

To test this, you can Git-clone my Meson fork[1], install Ninja from your distributor, and then run:
```
mkdir b && cd b
./path/to/meson.py ..
ninja
```
[1]: https://github.com/ximion/meson
Missing in the implementation is currently support for downloading GtkD from Github or DUB, so this relies on GtkD being installed system-wide. This auto-download support with preferring system copies can be added to the build definitions later though, via Meson subprojects and wrapfiles (which is pretty cool).
So far, I primarily used the Terminix case as one of my more complex tests for Meson's D support.

I hope you find this useful!
Cheers,
    Matthias