### PR TITLE
Add option to not close window with last session

### DIFF
--- a/data/gsettings/com.gexperts.Terminix.gschema.xml
+++ b/data/gsettings/com.gexperts.Terminix.gschema.xml
@@ -144,6 +144,11 @@
       <summary>Whether splitters use a narrow (default) or wide handle</summary>
       <description>If true, splitters between terminals use a wide handle. Only supported in GTK 2.16 and later.</description>
     </key>
+    <key name="close-with-last-session" type="b">
+      <default>true</default>
+      <summary>Whether the window should close when the last session is closed</summary>
+      <description>If false, when the last session is closed, a new session is opened.</description>
+    </key>
     <!-- Dark Theme -->
     <key name="theme-variant" enum="com.gexperts.Terminix.ThemeVariant">
       <default>'system'</default>

--- a/source/gx/terminix/appwindow.d
+++ b/source/gx/terminix/appwindow.d
@@ -550,8 +550,12 @@ private:
         updateUIState();
         //Close Window if there are no pages
         if (nb.getNPages() == 0) {
-            trace("No more sessions, closing AppWindow");
-            this.close();
+            if (gsSettings.getBoolean(SETTINGS_CLOSE_WITH_LAST_SESSION_KEY)) {
+                trace("No more sessions, closing AppWindow");
+                this.close();
+            } else {
+                createSession();
+            }
         }
     }
 

--- a/source/gx/terminix/preferences.d
+++ b/source/gx/terminix/preferences.d
@@ -43,6 +43,7 @@ enum SETTINGS_DISABLE_CSD_KEY = "disable-csd";
 enum SETTINGS_AUTO_HIDE_MOUSE_KEY = "auto-hide-mouse";
 enum SETTINGS_PROMPT_ON_NEW_SESSION_KEY = "prompt-on-new-session";
 enum SETTINGS_ENABLE_TRANSPARENCY_KEY = "enable-transparency";
+enum SETTINGS_CLOSE_WITH_LAST_SESSION_KEY = "close-with-last-session";
 
 enum SETTINGS_TERMINAL_TITLE_STYLE_KEY = "terminal-title-style";
 enum SETTINGS_TERMINAL_TITLE_STYLE_VALUE_NORMAL = "normal";

--- a/source/gx/terminix/prefwindow.d
+++ b/source/gx/terminix/prefwindow.d
@@ -704,6 +704,11 @@ private:
         gsSettings.bind(SETTINGS_MIDDLE_CLICK_CLOSE_KEY, cbMiddleClickClose, "active", GSettingsBindFlags.DEFAULT);
         add(cbMiddleClickClose);
 
+        //Closing of last session closes window
+        CheckButton cbCloseWithLastSession = new CheckButton(_("Close window when last session is closed"));
+        gsSettings.bind(SETTINGS_CLOSE_WITH_LAST_SESSION_KEY, cbCloseWithLastSession, "active", GSettingsBindFlags.DEFAULT);
+        add(cbCloseWithLastSession);
+
         //Show Notifications, only show option if notifications are supported
         if (checkVTEFeature(TerminalFeature.EVENT_NOTIFICATION)) {
             CheckButton cbNotify = new CheckButton(_("Send desktop notification on process complete"));


### PR DESCRIPTION
Inspired by an option in Firefox to not close the window when the last tab is closed, I've added the same functionality to terminix.  Quite often I'll hit `Ctrl+d` quickly to close terminals and end up closing terminix.

The default is to close the window so it acts in the same way it previously did, but turned off the option will open a new session in the window when the last session is removed.

The window can still be closed by pressing the close icon in the header bar.