### PR TITLE
Make install script more robust

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,14 @@
 
 if [ -z  "$1" ]; then
     export PREFIX=/usr
-    # Make sure only root can run our script
-    if [ "$(id -u)" != "0" ]; then
-        echo "This script must be run as root" 1>&2
-        exit 1
-    fi
 else
     export PREFIX=$1
+fi
+
+if [ "$PREFIX" = "/usr" ] && [ "$(id -u)" != "0" ]; then
+    # Make sure only root can run our script
+    echo "This script must be run as root" 1>&2
+    exit 1
 fi
 
 if [ ! -f terminix ]; then
@@ -20,31 +21,30 @@ echo "Installing to prefix ${PREFIX}"
 
 # Copy and compile schema
 echo "Copying and compiling schema..."
-mkdir -p ${PREFIX}/share/glib-2.0/schemas
-cp data/gsettings/com.gexperts.Terminix.gschema.xml ${PREFIX}/share/glib-2.0/schemas/
+install -d ${PREFIX}/share/glib-2.0/schemas
+install -m 644 data/gsettings/com.gexperts.Terminix.gschema.xml ${PREFIX}/share/glib-2.0/schemas/
 glib-compile-schemas ${PREFIX}/share/glib-2.0/schemas/
 
 export TERMINIX_SHARE=${PREFIX}/share/terminix
 
-mkdir -p ${TERMINIX_SHARE}/resources
-mkdir -p ${TERMINIX_SHARE}/schemes
-mkdir -p ${TERMINIX_SHARE}/scripts
+install -d ${TERMINIX_SHARE}/resources ${TERMINIX_SHARE}/schemes ${TERMINIX_SHARE}/scripts
 
 # Copy and compile icons
-cd data/resources
+pushd data/resources
 
 echo "Building and copy resources..."
 glib-compile-resources terminix.gresource.xml
-cp terminix.gresource ${TERMINIX_SHARE}/resources/terminix.gresource
-cd ../..
+install -m 644 terminix.gresource ${TERMINIX_SHARE}/resources/
+
+popd
 
 # Copy shell integration script
 echo "Copying scripts..."
-cp data/scripts/* ${TERMINIX_SHARE}/scripts
+install -m 755 data/scripts/* ${TERMINIX_SHARE}/scripts/
 
 # Copy color schemes
 echo "Copying color schemes..."
-cp data/schemes/* ${TERMINIX_SHARE}/schemes
+install -m 644 data/schemes/* ${TERMINIX_SHARE}/schemes/
 
 # Create/Update LINGUAS file
 find po -name "*\.po" -printf "%f\\n" | sed "s/\.po//g" | sort > po/LINGUAS
@@ -54,8 +54,9 @@ echo "Copying and installing localization files"
 for f in po/*.po; do
     echo "Processing $f"
     LOCALE=$(basename "$f" .po)
-    mkdir -p ${PREFIX}/share/locale/${LOCALE}/LC_MESSAGES
-    msgfmt $f -o ${PREFIX}/share/locale/${LOCALE}/LC_MESSAGES/terminix.mo
+    msgfmt $f -o "${LOCALE}.mo"
+    install -d ${PREFIX}/share/locale/${LOCALE}/LC_MESSAGES
+    install -m 644 "${LOCALE}.mo" ${PREFIX}/share/locale/${LOCALE}/LC_MESSAGES/terminix.mo
 done
 
 # Generate desktop file
@@ -74,29 +75,38 @@ fi
 
 # Copying Nautilus extension
 echo "Copying Nautilus extension"
-mkdir -p ${PREFIX}/share/nautilus-python/extensions/
-cp data/nautilus/open-terminix.py ${PREFIX}/share/nautilus-python/extensions/open-terminix.py
+install -d ${PREFIX}/share/nautilus-python/extensions/
+install -m 644 data/nautilus/open-terminix.py ${PREFIX}/share/nautilus-python/extensions/
 
 # Copy D-Bus service descriptor
-mkdir -p ${PREFIX}/share/dbus-1/services
-cp data/dbus/com.gexperts.Terminix.service ${PREFIX}/share/dbus-1/services
+install -d ${PREFIX}/share/dbus-1/services
+install -m 644 data/dbus/com.gexperts.Terminix.service ${PREFIX}/share/dbus-1/services/
 
 # Copy Icons
-mkdir -p ${PREFIX}/share/icons/hicolor
-cp -r data/icons/hicolor/. ${PREFIX}/share/icons/hicolor
+pushd data/icons/hicolor
+
+find -type f | while read f; do
+    install -d "${PREFIX}/share/icons/hicolor/$(dirname "$f")"
+    install -m 644 "$f" "${PREFIX}/share/icons/hicolor/${f}"
+done
+
+popd
 
 # Copy executable, desktop and appdata file
-mkdir -p ${PREFIX}/bin
-cp terminix ${PREFIX}/bin/terminix
-mkdir -p ${PREFIX}/share/applications
-mkdir -p ${PREFIX}/share/metainfo
-cp data/pkg/desktop/com.gexperts.Terminix.desktop ${PREFIX}/share/applications
-cp data/appdata/com.gexperts.Terminix.appdata.xml ${PREFIX}/share/metainfo
+install -d ${PREFIX}/bin
+install -m 755 terminix ${PREFIX}/bin/
+
+install -d ${PREFIX}/share/applications ${PREFIX}/share/metainfo/
+install -m 644 data/pkg/desktop/com.gexperts.Terminix.desktop ${PREFIX}/share/applications/
+install -m 644 data/appdata/com.gexperts.Terminix.appdata.xml ${PREFIX}/share/metainfo/
 
 desktop-file-validate ${PREFIX}/share/applications/com.gexperts.Terminix.desktop
 
 # Update icon cache if Prefix is /usr
-if [ "$PREFIX" = '/usr' ]; then
+if [ "$PREFIX" = '/usr' ] || [ "$PREFIX" = "/usr/local" ]; then
+    echo "Updating desktop file cache"
+    xdg-desktop-menu forceupdate --mode system
+
     echo "Updating icon cache"
-    sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/
+    gtk-update-icon-cache -f ${PREFIX}/share/icons/hicolor/
 fi


### PR DESCRIPTION
Using plain `cp` and `mkdir` will fail when using a non-standard umask
for either compiling Terminix or running the installation script. Fix that
by using the `install` command with explicit modes when necessary.

Additionally, ensure the desktop file cache and icon cache are properly
updated when either /usr or /usr/share is chosen as PREFIX.