### PR TITLE
autotools: check for and link with libx11

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,10 @@
 bin_PROGRAMS = terminix
 terminix_SOURCES = $(shell find $(srcdir)/source -name '*\.d')
 terminix.o: $(terminix_SOURCES)
-	$(DC) $(DCFLAGS) $(DEPS_CFLAGS) $(DEPS_LIBS) -c $^ -of$@
+	$(DC) $(DCFLAGS) $(GTKD_CFLAGS) $(GTKD_LIBS) -c $^ -of$@
+# libx11 is a C library, so we need to precede with -L
 terminix$(EXEEXT): terminix.o
-	$(DC) $(DEPS_LIBS) $^ -of$@
+	$(DC) $(GTKD_LIBS) -L$(X11_LIBS) $^ -of$@
 
 gschemasdir = $(datadir)/glib-2.0/schemas/
 dist_gschemas_DATA = $(srcdir)/data/gsettings/com.gexperts.Terminix.gschema.xml

--- a/configure.ac
+++ b/configure.ac
@@ -26,19 +26,22 @@ PKG_PROG_PKG_CONFIG
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19.7])
 
-GTKD_SUFFIX=
+DC_SUFFIX=
 case $(basename $DC) in
-	dmd) GTKD_SUFFIX=-dmd ;;
-	ldmd) GTKD_SUFFIX=-ldc ;;
-	gdmd) GTKD_SUFFIX=-gdc ;;
+	dmd) DC_SUFFIX=-dmd ;;
+	ldmd) DC_SUFFIX=-ldc ;;
+	gdmd) DC_SUFFIX=-gdc ;;
 esac
 
 # Checks for libraries.
 
 # Use pkg-config to look for gtkd. Tries to find a compiler specific suffix, then falls back to suffix-less
-PKG_CHECK_MODULES([DEPS], [gtkd-3$GTKD_SUFFIX >= 3.3.0 vted-3$GTKD_SUFFIX >= 3.3.0],,
-				  [PKG_CHECK_MODULES([DEPS], [gtkd-3 >= 3.3.0 vted-3 >= 3.3.0])])
+PKG_CHECK_MODULES([GTKD], [gtkd-3$DC_SUFFIX >= 3.3.0 vted-3$DC_SUFFIX >= 3.3.0],,
+				  [PKG_CHECK_MODULES([GTKD], [gtkd-3 >= 3.3.0 vted-3 >= 3.3.0])])
 # TODO: test if library was compiled with @DC@?
+
+# libx11 is a C library, so no need of suffix
+PKG_CHECK_MODULES([X11], [x11])
 
 AM_INIT_AUTOMAKE([1.15 foreign])
 AC_CONFIG_FILES([Makefile data/appdata/Makefile data/icons/Makefile data/pkg/desktop/Makefile data/resources/Makefile po/Makefile.in])


### PR DESCRIPTION
I've used the pkg-config tooling to look for libx11 and added a corresponding linker flag. Works for me. More testing (especially cross-distro) appreciated.