### PR TITLE
trivial: Remove invalid chars from metainfo file

### DIFF
--- a/data/appdata/com.gexperts.Terminix.appdata.xml.in
+++ b/data/appdata/com.gexperts.Terminix.appdata.xml.in
@@ -33,9 +33,9 @@
 
   <screenshots>
 ​    <screenshot type="default">
-​      <image>http://www.gexperts.com/img/terminix/terminix2.png</image>
-​    </screenshot>
-​  </screenshots>
+      <image>http://www.gexperts.com/img/terminix/terminix2.png</image>
+    </screenshot>
+  </screenshots>
 
   <kudos>
     <kudo>AppMenu</kudo>


### PR DESCRIPTION
The file contained some non-visible characters, and some more strict XML parsers choke on that.