### PR TITLE
i18n: Obsolete strings were not automatically removed

### DIFF
--- a/extract-strings.sh
+++ b/extract-strings.sh
@@ -8,7 +8,6 @@ echo "Extracting translatable strings... "
 # Extract the strings from D source code. Since xgettext does not support D
 # as a language we use Vala, which works reasonable well.
 find ${BASEDIR}/source -name '*.d' | xgettext \
-  --join-existing \
   --output $OUTPUT_FILE \
   --files-from=- \
   --directory=$BASEDIR \

--- a/po/bg.po
+++ b/po/bg.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-08-18 21:17+0000\n"
 "Last-Translator: Ivaylo Kuzev <ivkuzev@gmail.com>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/terminix/"
@@ -18,971 +18,1167 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Файла %s не е цветова схема съвместима с JSON файла"
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
+#: source/gx/terminix/preferences.d:202
 #, fuzzy
-msgid "Color scheme palette requires 16 colors"
-msgstr "Цветовата схема палитра изисква 16 цвята"
-
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
-#, c-format
-msgid "Editing Profile: %s"
-msgstr "Редактиране на профила %s"
-
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
-msgid "New Profile"
-msgstr "Нов профил"
-
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
-msgid "General"
-msgstr "Общи"
-
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
+msgid "ExecuteCommand"
 msgstr "Команда"
 
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
-msgid "Color"
-msgstr "Цвят"
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
-msgid "Scrolling"
-msgstr "Придвижване"
-
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
-msgid "Compatibility"
-msgstr "Съвместимост"
-
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
-msgid "Profile name"
-msgstr "Име на профила"
-
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
-msgid "Terminal size"
-msgstr "Начален размер на терминала"
-
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
-msgid "columns"
-msgstr "Колони"
-
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
-msgid "rows"
-msgstr "Реда"
-
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Възстановяване"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
-msgid "Cursor"
-msgstr "Форма на курсора"
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Block"
-msgstr "Правоъгълник"
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "IBeam"
-msgstr "Вертикална черта"
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Underline"
-msgstr "Подчертаване"
-
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
-msgid "Blink mode"
-msgstr "Режим на примигване"
-
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "System"
-msgstr "Система"
-
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/preferences.d:204
 #, fuzzy
-msgid "On"
-msgstr "Вкл"
+msgid "UpdateTitle"
+msgstr "Заглавие"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
 #, fuzzy
-msgid "Off"
-msgstr "Изкл"
+msgid "SendText"
+msgstr "Текст"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+#, fuzzy
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Тази команда изисква права на администратор за компютъра"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+#, fuzzy
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Копиране на команди от интернет може да бъде опасно. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+#, fuzzy
+msgid "Be sure you understand what each part of this command does."
+msgstr "Бъдете сигурни че разбирате всяка част от тази команда какво прави."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Допълнителни"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Поставяне"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Отменете"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Име"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Нов"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Редактиране"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Изтриване"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Търсене на опции"
+
+#: source/gx/terminix/terminal/search.d:134
+#, fuzzy
+msgid "Find next"
+msgstr "Следваща поява"
+
+#: source/gx/terminix/terminal/search.d:140
+#, fuzzy
+msgid "Find previous"
+msgstr "Предишна поява"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Терминал"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Затваряне"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Максимизиране"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Изключване входната синхронизация за този терминал"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr ""
+
 #: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
+#: source/gx/terminix/profilewindow.d:237
 #, fuzzy
 msgid "Terminal bell"
 msgstr "Звук на терминала"
 
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Редактиране на профила"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+#, fuzzy
+msgid "There are processes that are still running, close anyway?"
+msgstr "Има процеси които все още се изпълняват, затворете при всички случай?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+#, fuzzy
+msgid "Enable input synchronization for this terminal"
+msgstr "Разрешаване входната синхронизация за този терминал"
+
+#: source/gx/terminix/terminal/terminal.d:692
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:752
+#, fuzzy
+msgid "Save Output…"
+msgstr "Запазване Като…"
+
+#: source/gx/terminix/terminal/terminal.d:753
 #: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
+msgid "Reset"
+msgstr "Възстановяване"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Възстановяване и изчистване"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Профили"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Кодиране"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Търсене…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+#, fuzzy
+msgid "Layout Options…"
+msgstr "Разпределение Опции…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+#, fuzzy
+msgid "Add Right"
+msgstr "Разделяне Надясно"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Възстановяване"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Копиране"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Избиране на всичко"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+#, fuzzy
+msgid "Clipboard"
+msgstr "Клипборд"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Синхронизация вход"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Запазване"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Всички текстови Файлове"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Всички файлове"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+#, fuzzy
+msgid "Layout Options"
+msgstr "Разпределение Опции"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Заглавие"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Зареждане на сесия"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Команда"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+#, fuzzy
+msgid "View session sidebar"
+msgstr "Покажи сесия в страничната лента"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Създайте нова сесия"
+
+#: source/gx/terminix/appwindow.d:360
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Преминаване в десен терминал"
+
+#: source/gx/terminix/appwindow.d:364
+#, fuzzy
+msgid "Add terminal down"
+msgstr "Задържане на терминала отворен"
+
+#: source/gx/terminix/appwindow.d:369
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Излизане от терминала"
+
+#: source/gx/terminix/appwindow.d:559
+#, fuzzy
+msgid "Change Session Name"
+msgstr "Променяне името на сесията"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Въведете ново има за сесията"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Отваряне…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Запазване Като…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Име…"
+
+#: source/gx/terminix/appwindow.d:622
+#, fuzzy
+msgid "Synchronize Input"
+msgstr "Синхронизация Вход"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Има процеси които все още се изпълняват, затворете при всички случай?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Не показвай отново това съобщение"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Всички JSON файлове"
+
+#: source/gx/terminix/appwindow.d:1079
+#, fuzzy, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Името на файла '%s' не съществува"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1112
+#, fuzzy
+msgid "Open"
+msgstr "Отваряне…"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1143
+#, fuzzy
+msgid "Save Session"
+msgstr "Запазване на Сесия"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Нова сесия"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Нов прозорец"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Настройки"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Клавишни комбинации"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Относно"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Изход"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Задаване на стартов профил"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Отваряне на определена сесия"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Изпращане на действие до текущата инстанция на Terminix"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Максимизирай прозореца на терминала"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Максимизирай прозореца на терминала"
+
+#: source/gx/terminix/application.d:612
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "На цял екран прозореца на терминала"
+
+#: source/gx/terminix/application.d:613
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "Фокусирай съществуващия прозорец"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:785
+#, fuzzy
+msgid "Configuration Issue Detected"
+msgstr "Открита е грешка със конфигурацията"
+
+#: source/gx/terminix/application.d:797
+#, fuzzy
+msgid "Do not show this message again"
+msgstr "Не показвай отново това съобщение"
+
+#: source/gx/terminix/profilewindow.d:93
+#, c-format
+msgid "Editing Profile: %s"
+msgstr "Редактиране на профила %s"
+
+#: source/gx/terminix/profilewindow.d:95
+msgid "New Profile"
+msgstr "Нов профил"
+
+#: source/gx/terminix/profilewindow.d:104
+msgid "General"
+msgstr "Общи"
+
+#: source/gx/terminix/profilewindow.d:106
+msgid "Color"
+msgstr "Цвят"
+
+#: source/gx/terminix/profilewindow.d:107
+msgid "Scrolling"
+msgstr "Придвижване"
+
+#: source/gx/terminix/profilewindow.d:108
+msgid "Compatibility"
+msgstr "Съвместимост"
+
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Допълнителни"
+
+#: source/gx/terminix/profilewindow.d:165
+msgid "Profile name"
+msgstr "Име на профила"
+
+#: source/gx/terminix/profilewindow.d:174
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/profilewindow.d:181
+msgid "Terminal size"
+msgstr "Начален размер на терминала"
+
+#: source/gx/terminix/profilewindow.d:191
+msgid "columns"
+msgstr "Колони"
+
+#: source/gx/terminix/profilewindow.d:197
+msgid "rows"
+msgstr "Реда"
+
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
+msgid "Cursor"
+msgstr "Форма на курсора"
+
 #: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
+msgid "Block"
+msgstr "Правоъгълник"
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "IBeam"
+msgstr "Вертикална черта"
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "Underline"
+msgstr "Подчертаване"
+
+#: source/gx/terminix/profilewindow.d:226
+msgid "Blink mode"
+msgstr "Режим на примигване"
+
 #: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+msgid "System"
+msgstr "Система"
+
+#: source/gx/terminix/profilewindow.d:229
+#, fuzzy
+msgid "On"
+msgstr "Вкл"
+
+#: source/gx/terminix/profilewindow.d:229
+#, fuzzy
+msgid "Off"
+msgstr "Изкл"
+
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Заглавие на терминала"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Външен вид на текста"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Позволяване на получер текст"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Потребителски шрифт"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Избор на шрифт за терминала"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Цветова схема"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Потребителска"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Цветова палитра"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Опции"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 #, fuzzy
 msgid "Use theme colors for foreground/background"
 msgstr "Използване на цветовете от системната тема за текста и фона"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Допълнителни"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Прозрачност"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 #, fuzzy
 msgid "Unfocused dim"
 msgstr "Фокусиране неактивно състояние"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Текст"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Фон"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 #, fuzzy
 msgid "Select Cursor Foreground Color"
 msgstr "Изберете цвят за текста на курсора"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 #, fuzzy
 msgid "Select Cursor Background Color"
 msgstr "Изберете цвят за фона на курсора"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Неактивно състояние"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 #, fuzzy
 msgid "Select Dim Color"
 msgstr "Изберете цвят за неактивно състояние на терминала"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Изберете %s Цвят"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Изберете цвят за фона"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Изберете цвят за текста"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 #, fuzzy
 msgid "Foreground"
 msgstr "Цвят на текста"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Черен"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Червен"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Зелен"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Оранжев"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Син"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Лилав"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Тюркоаз"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Сив"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Изберете %s Цвят"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Изберете %s Светъл Цвят"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Цветова схема"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Лента за придвижване"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Придвижване при изваждане на текст"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Придвижване при натискане на клавиш"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Ограничаване на придвижването назад до:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Клавишът Backspace генерира"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Екранираща последователност"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Връщане на настройките"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Кодиране"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 #, fuzzy
 msgid "Ambiguous-width characters"
 msgstr "Символи със неточна ширина"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Изпълнение на команда като обвивка при влизане"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Изпълняване на команда вместо стандартната обвивка"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Излизане от терминала"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Рестартиране на командата"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Задържане на терминала отворен"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "Потребителски шрифт"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Действие"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Редактиране на профила"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Файла %s не е цветова схема съвместима с JSON файла"
+
+#: source/gx/terminix/colorschemes.d:245
+#, fuzzy
+msgid "Color scheme palette requires 16 colors"
+msgstr "Цветовата схема палитра изисква 16 цвята"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Профил"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "VTE базиран терминала емулатор за Linux"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -990,20 +1186,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1143,291 +1333,42 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Нова сесия"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Нов прозорец"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Настройки"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Клавишни комбинации"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Относно"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Изход"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Задаване на стартов профил"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Отваряне на определена сесия"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Изпращане на действие до текущата инстанция на Terminix"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Максимизирай прозореца на терминала"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "На цял екран прозореца на терминала"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "Фокусирай съществуващия прозорец"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-#, fuzzy
-msgid "Configuration Issue Detected"
-msgstr "Открита е грешка със конфигурацията"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-#, fuzzy
-msgid "Do not show this message again"
-msgstr "Не показвай отново това съобщение"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Име"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Профил"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Основен"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 #, fuzzy
 msgid "Appearance"
 msgstr "Външен вид"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Профили"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 #, fuzzy
 msgid "Enabled"
 msgstr "Разрешено"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Действие"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Клавишни комбинации"
+
 #: source/gx/terminix/prefwindow.d:294
 #, fuzzy
 msgid "Overwrite Existing Shortcut"
 msgstr "Презапиши Съществуващите Комбинации"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1435,1183 +1376,268 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Нов"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Редактиране"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Изтриване"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Разрешаване на прозрачност, нужен е рестарт"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 #, fuzzy
 msgid "Theme variant"
 msgstr "Вариант на темата"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 #, fuzzy
 msgid "Light"
 msgstr "Светъл"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 #, fuzzy
 msgid "Dark"
 msgstr "Тъмен"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+#, fuzzy
+msgid "Background image"
+msgstr "Фон"
+
+#: source/gx/terminix/prefwindow.d:620
+#, fuzzy
+msgid "Select Image"
+msgstr "Избиране на всичко"
+
+#: source/gx/terminix/prefwindow.d:623
+#, fuzzy
+msgid "All Image Files"
+msgstr "Всички текстови Файлове"
+
+#: source/gx/terminix/prefwindow.d:644
+#, fuzzy
+msgid "Reset background image"
+msgstr "Прозрачен фон"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Преминаване в сесия 1"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-#, fuzzy
-msgid "Dim unfocused terminals"
-msgstr "Фокусиране неактивно състояние"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Запазете съдържанието на терминала"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Поведение"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Фокус на терминал когато мишката е над него"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Автоматично скриване на показалеца на мишката когато пишете"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Изпратете уведомяване на десктопа когато процеса завърши"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "На нова инстанция"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 #, fuzzy
 msgid "Split Right"
 msgstr "Разделяне Надясно"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 #, fuzzy
 msgid "Split Down"
 msgstr "Разделяне Надолу"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Фокусирай Прозорец"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Поставяне"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#, fuzzy
-msgid "Layout Options"
-msgstr "Разпределение Опции"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Отменете"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Заглавие"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Зареждане на сесия"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Търсене на опции"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Терминал"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Затваряне"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Максимизиране"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Изключване входната синхронизация за този терминал"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Редактиране на профила"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-#, fuzzy
-msgid "There are processes that are still running, close anyway?"
-msgstr "Има процеси които все още се изпълняват, затворете при всички случай?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-#, fuzzy
-msgid "Enable input synchronization for this terminal"
-msgstr "Разрешаване входната синхронизация за този терминал"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Запазване…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Търсене…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-#, fuzzy
-msgid "Layout Options…"
-msgstr "Разпределение Опции…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Възстановяване и изчистване"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Разделяне"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Възстановяване"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Копиране"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Избиране на всичко"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-#, fuzzy
-msgid "Clipboard"
-msgstr "Клипборд"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Синхронизация вход"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Всички текстови Файлове"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Всички файлове"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-#, fuzzy
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Тази команда изисква права на администратор за компютъра"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-#, fuzzy
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Копиране на команди от интернет може да бъде опасно. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-#, fuzzy
-msgid "Be sure you understand what each part of this command does."
-msgstr "Бъдете сигурни че разбирате всяка част от тази команда какво прави."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-#, fuzzy
-msgid "View session sidebar"
-msgstr "Покажи сесия в страничната лента"
-
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Създайте нова сесия"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-#, fuzzy
-msgid "Change Session Name"
-msgstr "Променяне името на сесията"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Въведете ново има за сесията"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Отваряне…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Запазване"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Запазване Като…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Име…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-#, fuzzy
-msgid "Synchronize Input"
-msgstr "Синхронизация Вход"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Всички JSON файлове"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, fuzzy, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Името на файла '%s' не съществува"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-#, fuzzy
-msgid "Save Session"
-msgstr "Запазване на Сесия"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr ""
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Грешка: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Приложение"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Приложение"
@@ -2655,414 +1681,392 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Покажи сесия в страничната лента"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Покажи сесия в страничната лента"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Преминаване в следваща сесия"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Преминаване в предишна сесия"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Преминаване в сесия 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Преминаване в сесия 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Преминаване в сесия 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Преминаване в сесия 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Преминаване в сесия 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Преминаване в сесия 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Преминаване в сесия 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Преминаване в сесия 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Преминаване в сесия 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Преминаване в сесия 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Сесия"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Файл"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Затваряне на текущата сесия"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Запазване на текущата сесия"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Запазване на текущата сесия на файл под друго име"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Отваряне на запазена сесия"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Преминаване в десен терминал"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Задържане на терминала отворен"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Преминаване"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Преминаване в следващ терминал"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Преминаване в предишен терминал"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Преминаване в горен терминал"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Преминаване в долен терминал"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Преминаване в ляв терминал"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Преминаване в десен терминал"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Преминаване в терминал 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Преминаване в терминал 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Преминаване в терминал 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Преминаване в терминал 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Преминаване в терминал 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Преминаване в терминал 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Преминаване в терминал 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Преминаване в терминал 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Преминаване в терминал 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Преминаване в терминал 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Разделяне"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Разделяне надясно"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Разделяне надолу"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Търсене"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Следваща поява"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Предишна поява"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Клипборд"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Копиране"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Поставяне"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Избиране на всичко"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Мащабиране"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Увеличаване"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Намаляване"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Нормален размер"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Други"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Преминаване в сесия 1"
+
+#: data/resources/ui/shortcuts.ui:237
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Синхронизация вход"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Преминаване"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Преминаване в следващ терминал"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Преминаване в предишен терминал"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Преминаване в горен терминал"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Преминаване в долен терминал"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Преминаване в ляв терминал"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Преминаване в десен терминал"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Преминаване в терминал 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Преминаване в терминал 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Преминаване в терминал 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Преминаване в терминал 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Преминаване в терминал 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Преминаване в терминал 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Преминаване в терминал 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Преминаване в терминал 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Преминаване в терминал 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Преминаване в терминал 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Търсене"
+
+#: data/resources/ui/shortcuts.ui:371
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Следваща поява"
+
+#: data/resources/ui/shortcuts.ui:377
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Предишна поява"
+
+#: data/resources/ui/shortcuts.ui:385
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Клипборд"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Копиране"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Поставяне"
+
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Допълнителни"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Избиране на всичко"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Мащабиране"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Увеличаване"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Намаляване"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Нормален размер"
+
+#: data/resources/ui/shortcuts.ui:443
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Запазете съдържанието на терминала"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Затваряне на терминала"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Максимизиране на терминала"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Текущи настройки на профила"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Възстановяване на терминал"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Възстановяване и изтриване на терминал"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Превключване на само за четене"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Разпределение опции"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Затваряне на терминала"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:503
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr ""
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "Терминал"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #, fuzzy
 msgid ""
@@ -3071,19 +2075,16 @@ msgstr ""
 "Разпределение на терминалите по всякакъв начин като ги разделяте "
 "хоризонтално или вертикално"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
 "windows"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #, fuzzy
 msgid ""
@@ -3093,34 +2094,28 @@ msgstr ""
 "Входа може да се синхронизира между терминалите като командите въвеждани в "
 "един терминал се повтарят в останалите"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
 "simply creating a new file"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Прозрачен фон"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3128,794 +2123,6 @@ msgid ""
 "decorations, though it can be disabled if necessary."
 msgstr ""
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-#, fuzzy
-msgid "Window"
-msgstr "Прозорец"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Преминаване в сесия 1"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Синхронизация вход"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Сесия"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-#, fuzzy
-msgid "Save Output…"
-msgstr "Запазване Като…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-#, fuzzy
-msgid "Open"
-msgstr "Отваряне…"
-
-#: source/gx/terminix/terminal/search.d:134
-#, fuzzy
-msgid "Find next"
-msgstr "Следваща поява"
-
-#: source/gx/terminix/terminal/search.d:140
-#, fuzzy
-msgid "Find previous"
-msgstr "Предишна поява"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Преминаване в десен терминал"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-#, fuzzy
-msgid "Add terminal down"
-msgstr "Задържане на терминала отворен"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Излизане от терминала"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-#, fuzzy
-msgid "Background image"
-msgstr "Фон"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-#, fuzzy
-msgid "Select Image"
-msgstr "Избиране на всичко"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-#, fuzzy
-msgid "All Image Files"
-msgstr "Всички текстови Файлове"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-#, fuzzy
-msgid "Reset background image"
-msgstr "Прозрачен фон"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Преминаване в десен терминал"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Задържане на терминала отворен"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-#, fuzzy
-msgid "Add Right"
-msgstr "Разделяне Надясно"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Клавишни комбинации"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "Потребителски шрифт"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Затваряне на терминала"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Редактиране на профила"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Команда"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Заглавие"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Текст"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Заглавие на терминала"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Допълнителни"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Максимизирай прозореца на терминала"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Преминаване в сесия 1"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Покажи сесия в страничната лента"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Допълнителни"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Има процеси които все още се изпълняват, затворете при всички случай?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Не показвай отново това съобщение"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Изберете %s Цвят"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:503
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Цветова схема"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Запазете съдържанието на терминала"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-11-05 14:13+0000\n"
 "Last-Translator: Marek Suchánek <marek.suchanek@protonmail.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/terminix/"
@@ -18,964 +18,1155 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Tento příkaz vás žádá o administrátorský přístup k počítači"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Kopírování příkazu z internetu může být nebezpečné. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Ujistěte se, že rozumíte, co která část příkazu znamená."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Pokročilé vkládání"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Vložit"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Název"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Nový"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Upravit"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Smazat"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "S heslem zadejte i znak nového řádku"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Vložit heslo"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Použít"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Heslo"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Potvrdit heslo"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Budiž"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Přidat heslo"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Upravit heslo"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Možnosti hledání"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Hledat další"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Hledat předchozí"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Rozlišovat velikost"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Hledat jen celá slova"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Hledat jako regulérní výraz"
+
+#: source/gx/terminix/terminal/search.d:190
+#, fuzzy
+msgid "Wrap around"
+msgstr "Pokračovat při dosažení konce"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminál"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Zavřít"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximalizovat"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Pro tento terminál vypnout synchronizaci vstupu"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Jen pro čtení"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Zvonek terminálu"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Upravit profil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Terminál obsahuje běžící procesy; přesto zavřít?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Pro tento terminál zapnout synchronizaci vstupu"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Soubor %s není JSON obsahující platné barevné schéma"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Knihovnu %s se nepodařilo načíst; funkcionalita související s hesly není "
+"dostupná."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Paleta barevného schématu vyžaduje 16 barev"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Knihovna nenačtena"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Uložit výstup…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Obnovit"
+
+#: source/gx/terminix/terminal/terminal.d:754
+#, fuzzy
+msgid "Reset and Clear"
+msgstr "Obnovit a vyčistit"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profily"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Kódování"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Najít…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Možnosti rozložení…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Přidat vpravo"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Přidat dolů"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Obnovit"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Otevřít odkaz"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Zkopírovat adresu odkazu"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Kopírovat"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Vybrat vše"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+#, fuzzy
+msgid "Clipboard"
+msgstr "Schránka"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Synchronizovat vstup"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Nastala neočekávaná chyba, bližší informace nejsou dostupné"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Nastala neočekávaná chyba: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Uložit výstup terminálu"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Uložit"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Všechny textové soubory"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Všechny soubory"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Proces potomka skončil normálně se statusem %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Proces potomka byl ukončen signálem %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Proces potomka byl ukončen."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Znovu spustit"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Nevkládat"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Přesto vložit"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Možnosti rozložení"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Aktivní"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titulek"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Načíst sezení"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Příkaz"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktivní předvolby vždy platí a zapínají se okamžitě.\n"
+"Možnosti „Načítání sezení“ se uplatňují, jen když se načítá sezení."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Ukázat boční panel sezení"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Vytvořit nové sezení"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Přidat terminál vpravo"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Přidat terminál dolů"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Hledat v terminálu text"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Změnit název sezení"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Napište nový název sezení"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Otevřít…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Uložit jako…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Název…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Synchronizovat vstup"
+
+#: source/gx/terminix/appwindow.d:627
+#, fuzzy
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Terminál obsahuje běžící procesy; přesto zavřít?"
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr "Příště už neukazovat"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Všechny soubory JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Soubor „%s“ neexistuje"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Načíst sezení"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Otevřít"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Načítání sezení selhalo kvůli neočekávané chybě."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Chyba při načítání sezení"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Uložit sezení"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nové sezení"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nové okno"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Předvolby"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Zkratky"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "O aplikaci"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Ukončit"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Zásluhy"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Nastavit pracovní adresář terminálu"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "ADRESÁŘ"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Nastavit výchozí profil"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "NÁZEV_PROFILU"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Nastavit titulek nového terminálu"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TITULEK"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Otevřít zvolené sezení"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "NÁZEV_SEZENÍ"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Poslat akci běžící instanci Terminixu"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "NÁZEV_AKCE"
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr "Provést předaný parametr jako příkaz"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "PŘÍKAZ"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maximalizovat okno terminálu"
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr "Minimalizovat okno terminálu"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Roztáhnout okno na celou obrazovku"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Zaměřit stávající okno"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Spouštět další instanci jako nový proces (Nedoporučováno)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Nastavit velikost okna; například 80x24 nebo 80x24+200+200 (SLOUPCExŘÁDKY+X"
+"+Y)"
+
+#: source/gx/terminix/application.d:615
+#, fuzzy
+msgid "GEOMETRY"
+msgstr "GEOMETRIE"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Otevře okno v módu „quake“ nebo přepne viditelnost stávajícího okna „quake“"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+#, fuzzy
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Skrytý argument k předání UUID terminálu"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINÁLU"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Byl zřejmě nalezen problém s konfigurací terminálu. Není vážný,\n"
+"ale jeho náprava zpříjemní používání aplikace.\n"
+"Pro další informace klikněte na odkaz níže:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Detekován problém v konfiguraci"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Tuto zprávu již neukazovat"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Úprava profilu: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Nový profil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Obecné"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Příkaz"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Barva"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Posouvání"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Název profilu"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, fuzzy, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Velikost terminálu"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "sloupce"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "řádky"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Obnovit"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Kurzor"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Blokový"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Svislá čára"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Podtrhávací čára"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 #, fuzzy
 msgid "Blink mode"
 msgstr "Blikání"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Podle systému"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Zapnuto"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Vypnuto"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Zvonek terminálu"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+#, fuzzy
+msgid "None"
+msgstr "Žádný"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Zvuk"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Ikona"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Ikona a zvuk"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Titulek terminálu"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr "Severozápad"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr "Severovýchod"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr "Jihozápad"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr "Jihovýchod"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Vzhled textu"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Povolit tučný text"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Při změně velikosti znovu zalomit"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Vlastní písmo"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Vyberte písmo terminálu"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Barevné schéma"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Vlastní"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Barevná paleta"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Možnosti"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Použít barvy z motivu i pro popředí/pozadí"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Pokročilé"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Průhlednost"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Ztlumení nezaměřeného okna"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Text"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Pozadí"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Vyberte barvu popředí kurzoru"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Vyberte barvu pozadí kurzoru"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Zvýraznění"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Vyberte barvu zvýraznění popředí"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Vyberte barvu zvýraznění pozadí"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Ztlumení"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Vyberte barvu ztlumení"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Vyberte barvu nálepky"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Vyberte barvu pozadí"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Vyberte barvu popředí"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Popředí"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "černá"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "červená"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "zelená"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "oranžová"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "modrá"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "fialová"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "tyrkysová"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "šedá"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Vyberte barvu „%s“"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Vyberte barvu „světlá %s“"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Barevné schéma"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Ukazovat posuvník"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Posouvat při výstupu"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Posouvat při stisku klávesy"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Omezit historii posouvání na:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Klávesa Backspace posílá"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automaticky"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 #, fuzzy
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 #, fuzzy
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Únikovou sekvenci"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 #, fuzzy
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Klávesa Delete posílá"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Kódování"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Znaky nejednoznačné šířky"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Úzké"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Široké"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Spustit příkaz jako přihlašovací shell"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Místo mého shellu spustit vlastní příkaz"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Až příkaz skončí"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Zavřít terminál"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Znovu spustit příkaz"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Podržet terminál otevřený"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Vlastní odkazy"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Seznam uživatelem definovaných odkazů, na něž je možné v terminálu kliknout, "
+"zakládající se na regulérních výrazech."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Automatické přepínání profilu"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
+"Hodnoty se zapisují ve formátu <i>uživatelské_jméno@hostitel:adresář</i>. "
+"Buď hostitele nebo adresář je možné vynechat, ale je nutné zachovat "
+"dvojtečku. Položky postrádající hostitele i adresář nejsou povoleny."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
+"Hodnoty se zapisují ve formátu <i>hostitel:adresář</i>. Buď hostitele nebo "
+"adresář je možné vynechat, ale je nutné zachovat dvojtečku. Položky "
+"postrádající hostitele i adresář nejsou povoleny."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Přidat"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "Výraz %s není platný regulérní výraz"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Regulérní výraz"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Nerozlišovat velikost"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Upravit vlastní odkazy"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Činnost"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parametr"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Soubor %s není JSON obsahující platné barevné schéma"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Paleta barevného schématu vyžaduje 16 barev"
+
+#: source/gx/terminix/session.d:548
+#, fuzzy
+msgid "Could not locate dropped terminal"
+msgstr "Nebylo možno nalézt přetažený terminál"
+
+#: source/gx/terminix/session.d:553
+#, fuzzy
+msgid "Could not locate session for dropped terminal"
+msgstr "Nebylo možno nalézt sezení pro přetažený terminál"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Výchozí"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Linuxový terminál založený na VTE"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -986,20 +1177,14 @@ msgstr ""
 "License verze 2.0. Pokud nebyla s tímto souborem dodána i kopie MPL, můžete "
 "ji získat na http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "Tým GTK VTE widgetu. Terminix by bez jejich práce nebyl možný"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD za to, že vytvořili tak skvělý obal okolo GTK"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org za vynikající jazyk D"
@@ -1141,292 +1326,40 @@ msgstr "vietnamské"
 msgid "Thai"
 msgstr "thajské"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nové sezení"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nové okno"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Předvolby"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Zkratky"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "O aplikaci"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Ukončit"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Zásluhy"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Nastavit pracovní adresář terminálu"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "ADRESÁŘ"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Nastavit výchozí profil"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "NÁZEV_PROFILU"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Otevřít zvolené sezení"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "NÁZEV_SEZENÍ"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Poslat akci běžící instanci Terminixu"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "NÁZEV_AKCE"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Provést předaný příkaz"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "PROVÉST"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maximalizovat okno terminálu"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Roztáhnout okno na celou obrazovku"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Zaměřit stávající okno"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-#, fuzzy
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Skrytý argument k předání UUID terminálu"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINÁLU"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Byl zřejmě nalezen problém s konfigurací terminálu. Není vážný,\n"
-"ale jeho náprava zpříjemní používání aplikace.\n"
-"Pro další informace klikněte na odkaz níže:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Detekován problém v konfiguraci"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Tuto zprávu již neukazovat"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-#, fuzzy
-msgid "Could not locate dropped terminal"
-msgstr "Nebylo možno nalézt přetažený terminál"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-#, fuzzy
-msgid "Could not locate session for dropped terminal"
-msgstr "Nebylo možno nalézt sezení pro přetažený terminál"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Název"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 #, fuzzy
 msgid "Global"
 msgstr "Globální"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Vzhled"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profily"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Kódování zobrazená v nabídce:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 #, fuzzy
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Činnost"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Klávesová zkratka"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Povolit zkratky"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Přepsat stávající zkratku"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1436,989 +1369,200 @@ msgstr ""
 "Zkratka %s je už přiřazena k %s.\n"
 "Odejmout zkratku od stávající akce a přiřadit ji místo toho sem?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Výchozí"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nový"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Upravit"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Smazat"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Povolit průhlednost; vyžaduje restart"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Styl titulku terminálu"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 #, fuzzy
 msgid "Normal"
 msgstr "Normální"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 #, fuzzy
 msgid "Small"
 msgstr "Malý"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-#, fuzzy
-msgid "None"
-msgstr "Žádný"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Varianta motivu"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Světlý"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Tmavý"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Obrázek na pozadí"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Vybrat obrázek"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Všechny obrázky"
+
+#: source/gx/terminix/prefwindow.d:644
+#, fuzzy
+msgid "Reset background image"
+msgstr "Odstranit obrázek na pozadí"
+
+#: source/gx/terminix/prefwindow.d:650
+#, fuzzy
+msgid "Scale"
+msgstr "Škálovat"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Dlaždice"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Vystředit"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Roztáhnout"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Výchozí název sezení"
+
+#: source/gx/terminix/prefwindow.d:682
 #, fuzzy
 msgid "Use a wide handle for splitters"
 msgstr "Použít široký oddělovač terminálů"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Ztlumit nezaměřené terminály"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Umístit boční panel doprava"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Ukazovat titulek terminálu, i když je to jediný terminál"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "Velikost"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Ukazovat terminál na všech plochách"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr "Při ztrátě zaměření skrýt okno"
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Zobrazit terminál na primárním monitoru"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Zobrazit na zvoleném monitoru"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Chování"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 #, fuzzy
 msgid "Prompt when creating a new session"
 msgstr "Upozornit při vytváření nového sezení"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Zaměřit terminál, když na něj ukáže myš"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Při psaní automaticky skrývat kurzor myši"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Zavřít terminál kliknutím prostředním tlačítkem na titulek"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Zavřít okno, když se zavře poslední sezení"
+
+#: source/gx/terminix/prefwindow.d:852
 #, fuzzy
 msgid "Send desktop notification on process complete"
 msgstr "Po skončení procesu zasílat upozornění"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 #, fuzzy
 msgid "On new instance"
 msgstr "Při nové instanci"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Rozdělit doprava"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Rozdělit dolů"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Zaměřit okno"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Vložit"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr "Vždy použít dialog pokročilého vkládání"
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Varovat při pokusu o nebezpečné vkládání"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 #, fuzzy
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Odstranit první znak vkládaného textu, pokud jde o komentář nebo deklaraci "
 "proměnné"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Možnosti rozložení"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Při označení automaticky zkopírovat text do schránky"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Budiž"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Aktivní"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titulek"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Načíst sezení"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktivní předvolby vždy platí a zapínají se okamžitě.\n"
-"Možnosti „Načítání sezení“ se uplatňují, jen když se načítá sezení."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Možnosti hledání"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Rozlišovat velikost"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Hledat jen celá slova"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Hledat jako regulérní výraz"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-#, fuzzy
-msgid "Wrap around"
-msgstr "Pokračovat při dosažení konce"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminál"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Zavřít"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximalizovat"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Pro tento terminál vypnout synchronizaci vstupu"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Upravit profil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Terminál obsahuje běžící procesy; přesto zavřít?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Pro tento terminál zapnout synchronizaci vstupu"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Uložit…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Najít…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Možnosti rozložení…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Jen pro čtení"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-#, fuzzy
-msgid "Reset and Clear"
-msgstr "Obnovit a vyčistit"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Rozdělit"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Obnovit"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Otevřít odkaz"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Zkopírovat adresu odkazu"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Kopírovat"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Vybrat vše"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-#, fuzzy
-msgid "Clipboard"
-msgstr "Schránka"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Synchronizovat vstup"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Nastala neočekávaná chyba, bližší informace nejsou dostupné"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Nastala neočekávaná chyba: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Uložit výstup terminálu"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Všechny textové soubory"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Všechny soubory"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Proces potomka skončil normálně se statusem %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Proces potomka byl ukončen signálem %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Proces potomka byl ukončen."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Znovu spustit"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Tento příkaz vás žádá o administrátorský přístup k počítači"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Kopírování příkazu z internetu může být nebezpečné. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Ujistěte se, že rozumíte, co která část příkazu znamená."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Nevkládat"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Přesto vložit"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Přeskočeno, jelikož „%s“ není adresář"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Přeskočen parametr sezení, jelikož „%s“ neexistuje"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2427,191 +1571,70 @@ msgstr ""
 "Nemůžete zároveň načíst sezení a nastavit profil / pracovní adresář / "
 "prováděný příkaz. Vyberte prosím první či druhé"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Ukázat boční panel sezení"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Vytvořit nové sezení"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
+"Mód „quake“ nemůžete použít současně s parametry maximalizace, minimalizace, "
+"celé obrazovky či geometrie"
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Změnit název sezení"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Napište nový název sezení"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Otevřít…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Uložit"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Uložit jako…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Název…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Synchronizovat vstup"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-#, fuzzy
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Všechny soubory JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Soubor „%s“ neexistuje"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Načíst sezení"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Načítání sezení selhalo kvůli neočekávané chybě."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Chyba při načítání sezení"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Uložit sezení"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "zakázáno"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "Máte příliš starou verzi GTK, potřebujete nejméně GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Nastala neočekávaná výjimka"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Chyba: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
+msgstr "Otevřít vzdálený Terminix…"
+
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Otevřít vzdálený Terminix v %s"
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
 msgstr "Otevřít v Terminixu…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Otevřít Terminix v %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr "Otevřít zde vzdálený Terminix…"
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr "Otevřít v tomto adresáři vzdálený Terminix"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Otevřít zde Terminix…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Otevřít v tomto adresáři Terminix"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Aplikace"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Aplikace"
@@ -2651,426 +1674,396 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Zobrazit boční panel sezení"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Přepnout do dalšího sezení"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Přepnout do předchozího sezení"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Přepnout do sezení 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Přepnout do sezení 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Přepnout do sezení 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Přepnout do sezení 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Přepnout do sezení 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Přepnout do sezení 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Přepnout do sezení 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Přepnout do sezení 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Přepnout do sezení 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Přepnout do sezení 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sezení"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Soubor"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Zavřít toto sezení"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Uložit toto sezení"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Uložit toto sezení do nového souboru"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Otevřít uložené sezení"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Přidat"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Přidat terminál vpravo"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Přidat terminál dolů"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Změnit velikost"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Změnit velikost nahoru"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Změnit velikost dolů"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Změnit velikost doleva"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Změnit velikost doprava"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Přepnout"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Přepnout do dalšího terminálu"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Přepnout do předchozího terminálu"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Přepnout do terminálu nahoře"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Přepnout do terminálu dole"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Přepnout do terminálu vlevo"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Přepnout do terminálu vpravo"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Přepnout do terminálu 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Přepnout do terminálu 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Přepnout do terminálu 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Přepnout do terminálu 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Přepnout do terminálu 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Přepnout do terminálu 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Přepnout do terminálu 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Přepnout do terminálu 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Přepnout do terminálu 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Přepnout do terminálu 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Rozdělit"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Rozdělit doprava"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Rozdělit dolů"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Hledat"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Hledat další"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Hledat předchozí"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Schránka"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Kopírovat"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Vložit"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Vybrat vše"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Přibližování"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Přiblížit"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Oddálit"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Obnovit běžnou velikost"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Další"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Upravit název sezení"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Synchronizovat vstup"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Přepnout"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Přepnout do dalšího terminálu"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Přepnout do předchozího terminálu"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Přepnout do terminálu nahoře"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Přepnout do terminálu dole"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Přepnout do terminálu vlevo"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Přepnout do terminálu vpravo"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Přepnout do terminálu 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Přepnout do terminálu 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Přepnout do terminálu 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Přepnout do terminálu 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Přepnout do terminálu 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Přepnout do terminálu 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Přepnout do terminálu 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Přepnout do terminálu 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Přepnout do terminálu 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Přepnout do terminálu 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Hledat"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Hledat další"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Hledat předchozí"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Schránka"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Kopírovat"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Vložit"
+
+#: data/resources/ui/shortcuts.ui:401
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Pokročilé vkládání"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Vybrat vše"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Přibližování"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Přiblížit"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Oddálit"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Obnovit běžnou velikost"
+
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Uložit obsah terminálu"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Zavřít terminál"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Maximalizovat terminál"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Předvolby aktuálního profilu"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Obnovit terminál"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Obnovit a vyčistit terminál"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Přepnout jen pro čtení"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Možnosti rozložení"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Vložte číslo terminálu"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Vložit heslo"
+
+#: data/resources/ui/shortcuts.ui:503
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Přepínat styl titulku"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 #, fuzzy
 msgid "A tiling terminal for Gnome"
 msgstr "Dlaždicový terminál pro Gnome"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 #, fuzzy
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Nový terminál"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 #, fuzzy
 msgid "A tiling terminal for GNOME"
 msgstr "Dlaždicový terminál pro GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 #, fuzzy
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix je dlaždicový emulátor terminálu."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Můžete v něm:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
 msgstr "Rozložit terminály libovolným rozdělením vodorovně či svisle"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
 "windows"
 msgstr "Přesouvat terminály přetáhnutím uvnitř oken i mezi okny"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "Přetažením odpojit terminály do nového okna"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3079,17 +2072,14 @@ msgstr ""
 "Synchronizovat vstup mezi terminály, aby se příkazy zadávané v jednom "
 "replikovaly v dalších"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "Ukládat seskupení terminálů a zpětně načítat z disku"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Nastavit terminálům vlastní titulky"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3098,17 +2088,14 @@ msgstr ""
 "Barevná schémeta jsou uložena v souborech a vlastní můžete vytvořit prostě "
 "vytvořením nového souboru"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Průhledné pozadí"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "Podporuje upozornění, když skončí procesy v nezaměřeném okně"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3119,787 +2106,6 @@ msgstr ""
 "Zásadami lidského rozhraní (HIG) GNOME. Ve výsledku tedy Terminix využívá "
 "dekorace na straně klienta, umí je však v případě nutnosti i vypnout."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix je testován v GNOME a Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Nastavit velikost okna; například 80x24 nebo 80x24+200+200 (SLOUPCExŘÁDKY+X"
-"+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-#, fuzzy
-msgid "GEOMETRY"
-msgstr "GEOMETRIE"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Okno"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Upravit název sezení"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Synchronizovat vstup"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sezení"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Uložit výstup…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Otevřít"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Hledat další"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Hledat předchozí"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Spouštět další instanci jako nový proces (Nedoporučováno)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Přidat terminál vpravo"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Přidat terminál dolů"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Hledat v terminálu text"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Zvuk"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Ikona"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Ikona a zvuk"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Automatické přepínání profilu"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Přidat"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Obrázek na pozadí"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Vybrat obrázek"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Všechny obrázky"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-#, fuzzy
-msgid "Reset background image"
-msgstr "Odstranit obrázek na pozadí"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-#, fuzzy
-msgid "Scale"
-msgstr "Škálovat"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Dlaždice"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Vystředit"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Roztáhnout"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Přidat"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Přidat terminál vpravo"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Přidat terminál dolů"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Při označení automaticky zkopírovat text do schránky"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Přidat vpravo"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Přidat dolů"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Nastavit titulek nového terminálu"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TITULEK"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
-"Hodnoty se zapisují ve formátu <i>hostitel:adresář</i>. Buď hostitele nebo "
-"adresář je možné vynechat, ale je nutné zachovat dvojtečku. Položky "
-"postrádající hostitele i adresář nejsou povoleny"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Povolit zkratky"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Vlastní odkazy"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Seznam uživatelem definovaných odkazů, na něž je možné v terminálu kliknout, "
-"zakládající se na regulérních výrazech."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
-"Hodnoty se zapisují ve formátu <i>hostitel:adresář</i>. Buď hostitele nebo "
-"adresář je možné vynechat, ale je nutné zachovat dvojtečku. Položky "
-"postrádající hostitele i adresář nejsou povoleny."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "Výraz %s není platný regulérní výraz"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Regulérní výraz"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Nerozlišovat velikost"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Upravit vlastní odkazy"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Použít"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Vložte číslo terminálu"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Knihovnu %s se nepodařilo načíst; funkcionalita související s hesly není "
-"dostupná."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Knihovna nenačtena"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "S heslem zadejte i znak nového řádku"
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Vložit heslo"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Heslo"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Potvrdit heslo"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Přidat heslo"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Upravit heslo"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr "Provést předaný parametr jako příkaz"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "PŘÍKAZ"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Otevře okno v módu „quake“ nebo přepne viditelnost stávajícího okna „quake“"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "QUAKE"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-"Mód „quake“ nemůžete použít současně s parametry maximalizace, celé "
-"obrazovky či geometrie"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
-"Hodnoty se zapisují ve formátu <i>uživatelské_jméno@hostitel:adresář</i>. "
-"Buď hostitele nebo adresář je možné vynechat, ale je nutné zachovat "
-"dvojtečku. Položky postrádající hostitele i adresář nejsou povoleny."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parametr"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Umístit boční panel doprava"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Ukazovat terminál na všech plochách"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Zobrazit terminál na primárním monitoru"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Zobrazit na zvoleném monitoru"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Výška terminálu"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Zavřít terminál kliknutím prostředním tlačítkem na titulek"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Zavřít okno, když se zavře poslední sezení"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Vložit heslo"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Pokročilé vkládání"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr "Minimalizovat okno terminálu"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-"Mód „quake“ nemůžete použít současně s parametry maximalizace, minimalizace, "
-"celé obrazovky či geometrie"
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Výchozí název sezení"
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Ukazovat titulek terminálu, i když je to jediný terminál"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "Velikost"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr "Vždy použít dialog pokročilého vkládání"
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:401
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Pokročilé vkládání"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Terminál obsahuje běžící procesy; přesto zavřít?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
-msgstr "Příště už neukazovat"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr "Severozápad"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr "Severovýchod"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr "Jihozápad"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr "Jihovýchod"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Vyberte barvu nálepky"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr "Při ztrátě zaměření skrýt okno"
-
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr "Otevřít vzdálený Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Otevřít vzdálený Terminix v %s"
-
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr "Otevřít v Terminixu…"
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr "Otevřít zde vzdálený Terminix…"
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
-msgstr "Otevřít v tomto adresáři vzdálený Terminix"
-
-#: data/resources/ui/shortcuts.ui:503
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Přepínat styl titulku"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Barevné schéma"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Zobrazit terminál na primárním monitoru"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -2,973 +2,1166 @@ msgid ""
 msgstr ""
 "Project-Id-Version: German (Terminix)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
-"PO-Revision-Date: 2016-11-08 15:26+0000\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
+"PO-Revision-Date: 2016-11-09 08:19+0100\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German "
-"<https://hosted.weblate.org/projects/terminix/translations/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/terminix/"
+"translations/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2.9\n"
+"X-Generator: Poedit 1.8.11\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr "Status aktualisieren"
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr "Befehl ausführen"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr "Benachrichtigung senden"
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr "Titel aktualisieren"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr "Terminal-Glocke läuten"
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr "Text senden"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr "Passwort einfügen"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+"Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
+"macht."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Umwandeln"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Leerzeichen in Tabstopps umwandeln"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "CRLF und CR in LF umwandeln"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Erweitertes Einfügen"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Einfügen"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Name"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Neu"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Löschen"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Passwort mit Zeilenumbruch abschließen"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Passwort eingeben"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Anwenden"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Passwort"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Passwort bestätigen"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Passwort hinzufügen"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Passwort bearbeiten"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Suchoptionen"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Nächster Treffer"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Vorheriger Treffer"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Groß-/Kleinschreibung beachten"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Nur vollständige Wörter berücksichtigen"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Als regulären Ausdruck verarbeiten"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Schließen"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximieren"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Eingabesynchronisierung für dieses Terminal deaktivieren"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Nur lesen"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Terminal-Glocke"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Profil bearbeiten"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Es gibt noch laufende Prozesse, trotzdem beenden?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Eingabesynchronisierung für dieses Terminal aktivieren"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Die Datei %s ist keine konforme Farbschema-Datei"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Die Bibliothek %s konnte nicht geladen werden, Passwort-Funktionalität ist "
+"nicht verfügbar."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Die Palette des Farbschemas erfordert 16 Farben"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Bibliothek nicht geladen"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Ausgabe speichern …"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Zurücksetzen und leeren"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profile"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Zeichenkodierung"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Suchen …"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Layout-Optionen …"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Rechts hinzufügen"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Unten hinzufügen"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Wiederherstellen"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Verweis öffnen"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Verweisadresse kopieren"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Kopieren"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Alles auswählen"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Zwischenablage"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Eingabe synchronisieren"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Unerwarteter Fehler aufgetreten: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Terminalausgabe speichern"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Speichern"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Alle Textdateien"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Alle Dateien"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Der Kindprozess wurde normal mit Status %d beendet."
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Der Kindprozess wurde mit Signal %d beendet."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Der Kindprozess wurde beendet."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Neustart"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Nicht einfügen"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Trotzdem einfügen"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Layout-Optionen"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Aktiv"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Sitzung"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Befehl"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktive Optionen sind immer aktiv und werden sofort angewendet. Sitzungs-"
+"Optionen werden nur beim Laden der Sitzung angewendet."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Sitzungs-Seitenleiste anzeigen"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Neue Sitzung erstellen"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Terminal rechts hinzufügen"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Terminal unten hinzufügen"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Text in Terminal suchen"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Sitzungsnamen ändern"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Öffnen …"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Speichern unter …"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Name …"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Eingabe synchronisieren"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Es sind mehrere Sitzungen geöffnet, trotzdem beenden?"
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr "Nicht wieder anzeigen"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Alle JSON-Dateien"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Dateiname »%s« existiert nicht"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Sitzung laden"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Öffnen"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Fehler beim Laden der Sitzung"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Sitzung speichern"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Neue Sitzung"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Neues Fenster"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Tastenkombinationen"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Info"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Beenden"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Mitwirkende"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Arbeitsordner des Terminals wählen"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "ORDNER"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Als Startprofil festlegen"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "PROFIL_NAME"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Titel des neuen Terminals setzen"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TITEL"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Die angegebene Sitzung öffnen"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "SITZUNGS_NAME"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "AKTIONS_NAME"
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr "Parameter als Befehl ausführen"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "BEFEHL"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Terminalfenster maximieren"
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr "Terminalfenster minimieren"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Terminalfenster im Vollbildmodus anzeigen"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Vorhandenes Fenster fokussieren"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Neue Instanzen in separaten Prozessen starten (nicht empfohlen)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Fenstergröße setzen, z.B. 80x24 oder 80x24+200+200 (SPALTENxZEILEN+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "GEOMETRIE"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Öffnet ein Fenster im Quake-Modus oder schaltet die Sichtbarkeit eines "
+"vorhandenen Fensters im Quake-Modus um"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr "Versionsnummern von Terminix und abhängigen Komponenten anzeigen"
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
+"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
+"Klicken Sie auf den unten stehenden Verweis für weitere Informationen:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Probleme mit der Konfiguration entdeckt"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Diese Meldung nicht mehr anzeigen"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Editiere Profil: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Neues Profil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Allgemein"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Befehl"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Farbe"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Bildlauf"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Kompatibilität"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Profilname"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Terminal-Größe"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "Spalten"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "Zeilen"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Zurücksetzen"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Eingabemarke"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Block"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Senkrechter Strich"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Unterstrich"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Eingabemarke blinkt"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "System"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "An"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Aus"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Terminal-Glocke"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Keine"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Ton"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Symbol"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Symbol und Ton"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Terminal-Titel"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr "Badge"
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr "Badge-Position"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr "Oben links"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr "Oben rechts"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr "Unten links"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr "Unten rechts"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Text-Erscheinungsbild"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Fettformatierten Text zulassen"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Bei Größenänderung neu umbrechen"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Benutzerdefinierte Schriftart"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Wähle eine Terminal-Schriftart"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Farbschema"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr "Exportieren"
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Farbpalette"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Optionen"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Farbe des Themas für Vorder-/Hintergrund verwenden"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Erweitert"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Transparenz"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Inaktive Abdunklung"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Text"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Hintergrund"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Vordergrundfarbe für Eingabemarke wählen"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Hintergrundfarbe für Eingabemarke wählen"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Hervorhebung"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Vordergrundfarbe für Hervorhebung wählen"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Hintergrundfarbe für Hervorhebung wählen"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Abdunklung"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Farbe für Abdunklung wählen"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr "Badge-Farbe wählen"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Hintergrundfarbe wählen"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Vordergrundfarbe wählen"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Vordergrund"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Schwarz"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Rot"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Grün"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Orange"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Blau"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Lila"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Türkis"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Grau"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Farbe für »%s« wählen"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Helle Farbe für »%s« wählen"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+msgid "Export Color Scheme"
+msgstr "Farbschema exportieren"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Bildlaufleiste anzeigen"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Bildlauf bei Ausgabe"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Bildlauf bei Tastendruck"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Zeilenpuffer beschränken auf:"
 
 # Terminix gettext pot file
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Rücktaste erzeugt"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Strg-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Escape-Sequenz"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Entfernen-Taste erzeugt"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Zeichenkodierung"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Zeichen mit unbekannter Breite"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Schmal"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Breit"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Befehl als Login-Shell ausführen"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Einen benutzerdefinierten Befehl statt meiner Shell ausführen"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Wenn Befehl beendet:"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Terminal verlassen"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Befehl neu starten"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Terminal geöffnet lassen"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Benutzerdefinierte Verweise"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Eine Liste benutzerdefinierter Verweise basierend auf regulären Ausdrücken, "
+"die im Terminal angeklickt werden können."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr "Auslöser"
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Auslöser sind reguläre Ausdrücke, die auf den Ausgabetext des Terminals "
+"angewendet werden. Bei einem Treffer wird die konfigurierte Aktion "
+"ausgeführt."
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Automatischer Profilwechsel"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
+"Die Werte werden im Format <i>Benutzername@Rechnername:Ordner</i> "
+"eingegeben. Sowohl der Rechnername als auch der Ordner können weggelassen "
+"werden, aber der Doppelpunkt muss vorhanden sein. Einträge, die weder "
+"Rechnername noch Ordner enthalten, sind nicht zulässig."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
+"Die Werte werden im Format <i>Rechnername:Ordner</i> eingegeben. Sowohl der "
+"Rechnername als auch der Ordner können weggelassen werden, aber der "
+"Doppelpunkt muss vorhanden sein. Einträge, die weder Rechnername noch Ordner "
+"enthalten, sind nicht zulässig."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Übereinstimmung"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr "Benutzername@Rechnername:Ordner eingeben"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Rechnername:Ordner eingeben"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Neue Übereinstimmung hinzufügen"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr "Benutzername@Rechnername:Ordner bearbeiten"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Rechnername:Ordner bearbeiten"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Übereinstimmung bearbeiten"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "%s ist kein gültiger regulärer Ausdruck"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Regulärer Ausdruck"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Groß-/Kleinschreibung nicht beachten"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Benutzerdefinierte Verweise bearbeiten"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Aktion"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parameter"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Anzahl der Zeilen für Auslöser-Bearbeitung beschränken:"
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr "Auslöser bearbeiten"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Die Datei %s ist keine konforme Farbschema-Datei"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Die Palette des Farbschemas erfordert 16 Farben"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Das abgelegte Terminal konnte nicht gefunden werden"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Die Sitzung für das abgelegte Terminal konnte nicht gefunden werden"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Standard"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Ein auf VTE basierender Terminalemulator für Linux"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -979,20 +1172,14 @@ msgstr ""
 "2.0. Falls mit diesem Programm keine Kopie der MPL verteilt wurde, können "
 "Sie die MPL unter http://mozilla.org/MPL/2.0/ einsehen."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "GTK VTE Widget Team, Terminix wäre ohne deren Arbeit nicht möglich"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD für die Bereitstellung eines hervorragenden GTK-Wrappers"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org für eine hervorragende Sprache, D"
@@ -1135,287 +1322,38 @@ msgstr "Vietnamesisch"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Neue Sitzung"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Neues Fenster"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Tastenkombinationen"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Info"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Beenden"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Mitwirkende"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Arbeitsordner des Terminals wählen"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "ORDNER"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Als Startprofil festlegen"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "PROFIL_NAME"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Die angegebene Sitzung öffnen"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "SITZUNGS_NAME"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "AKTIONS_NAME"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Übergebenen Befehl ausführen"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "BEFEHL"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Terminalfenster maximieren"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Terminalfenster im Vollbildmodus anzeigen"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Vorhandenes Fenster fokussieren"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
-"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
-"Klicken Sie auf den unten stehenden Verweis für weitere Informationen:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Probleme mit der Konfiguration entdeckt"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Diese Meldung nicht mehr anzeigen"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Das abgelegte Terminal konnte nicht gefunden werden"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Die Sitzung für das abgelegte Terminal konnte nicht gefunden werden"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Name"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Global"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Erscheinungsbild"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profile"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr "Quake"
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Im Menü angezeigte Zeichenkodierungen:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Aktion"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Tastenkombination"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Tastenkombinationen aktivieren"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Bestehende Tastenkombination überschreiben"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1425,981 +1363,190 @@ msgstr ""
 "Die Tastenkombination %s ist bereits %s zugewiesen. Die Tastenkombination "
 "für die andere Aktion deaktivieren und hier zuweisen?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Standard"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr "Klonen"
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Neu"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Löschen"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Aktiviere Transparenz, erforder Neustart"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Stil der Terminal-Titelzeile:"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Klein"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Keine"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Themen-Variante:"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Hell"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Dunkel"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Hintergrundbild:"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Bild wählen"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Alle Bilddateien"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Hintergrundbild zurücksetzen"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Skalieren"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Kachel"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Zentrieren"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Strecken"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Standard-Sitzungsname"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Breiten Griff für Fenstertrenner verwenden"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Nicht fokussiertes Terminal abdunkeln"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Seitenleiste rechts anzeigen"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Terminal-Titel auch anzeigen, auch wenn es das einzige Terminal ist"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "Größe"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr "Höhe in Prozent"
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr "Breite in Prozent"
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Terminal auf allen Arbeitsflächen anzeigen"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr "Hinweis für Fenstermanager setzen, um Animationen zu deaktivieren"
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr "Fenster verbergen sobald es den Fokus verliert"
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr "Terminal auf dem aktiven Monitor anzeigen"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Auf spezifischem Monitor anzeigen"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Beim Erstellen einer neuen Sitzung nachfragen"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Terminal beim Überfahren mit der Maus fokusieren"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Mauszeiger beim Tippen ausblenden"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Terminal mit Klick der mittleren Maustaste auf den Titel schließen"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Fenster schließen, wenn die letzte Sitzung geschlossen wird"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Desktop-Benachrichtigung bei Beendigung des Prozesses senden"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Beim Öffnen einer neuen Instanz:"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Nach rechts teilen"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Nach unten teilen"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Fenster fokussieren"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Einfügen"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr "Immer erweiterten Einfügedialog verwenden"
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Vor unsicherem Einfügen warnen"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Das erste Zeichen beim Einfügen von Kommentaren oder Variablendeklarationen "
 "entfernen"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Layout-Optionen"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Text beim Auswählen automatisch in Zwischenablage kopieren"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Aktiv"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Sitzung"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktive Optionen sind immer aktiv und werden sofort angewendet. Sitzungs-"
-"Optionen werden nur beim Laden der Sitzung angewendet."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Suchoptionen"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Groß-/Kleinschreibung beachten"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Nur vollständige Wörter berücksichtigen"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Als regulären Ausdruck verarbeiten"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Schließen"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximieren"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Eingabesynchronisierung für dieses Terminal deaktivieren"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Profil bearbeiten"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Es gibt noch laufende Prozesse, trotzdem beenden?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Eingabesynchronisierung für dieses Terminal aktivieren"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Speichern …"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Suchen …"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Layout-Optionen …"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Nur lesen"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Zurücksetzen und leeren"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Teilen"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Wiederherstellen"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Verweis öffnen"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Verweisadresse kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Alles auswählen"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Zwischenablage"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Eingabe synchronisieren"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Unerwarteter Fehler aufgetreten: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Terminalausgabe speichern"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Alle Textdateien"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Alle Dateien"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Der Kindprozess wurde normal mit Status %d beendet."
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Der Kindprozess wurde mit Signal %d beendet."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Der Kindprozess wurde beendet."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Neustart"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-"Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
-"macht."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Nicht einfügen"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Trotzdem einfügen"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Ignoriere da »%s« kein Ordner ist"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignoriere Parameter session da »%s« nicht existiert"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2409,196 +1556,78 @@ msgstr ""
 "Arbeitsordner setzen oder eine Befehlsoption ausführen. Bitte wählen Sie das "
 "eine oder das andere."
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Sitzungs-Seitenleiste anzeigen"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr "Der Parameter action kann nur innerhalb von Terminix verwendet werden"
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Neue Sitzung erstellen"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Sitzungsnamen ändern"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Öffnen …"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Speichern"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Speichern unter …"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Name …"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Eingabe synchronisieren"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Alle JSON-Dateien"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Dateiname »%s« existiert nicht"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Sitzung laden"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
-"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
+"Der Quake-Modus kann nicht mit den Parametern maximize, minimize, fullscreen "
+"oder geometry zusammen verwendet werden"
 
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Fehler beim Laden der Sitzung"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Sitzung speichern"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "Die installierte GTK-Version ist zu alt, es ist mindestens GTK %d.%d.%d "
 "erforderlich!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Unerwartete Ausnahme aufgetreten"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Fehler:"
 
 # ******************
 # Nautilus extension
 # ******************
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
+msgstr "In entferntem Terminix öffnen …"
+
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Entferntes Terminix in %s öffnen"
+
+# ******************
+# Nautilus extension
+# ******************
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
 msgstr "In Terminix öffnen …"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Terminix in %s öffnen"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr "Entferntes Terminix hier öffnen …"
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr "Entferntes Terminix in diesem Ordner öffnen"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Terminix hier öffnen …"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Terminix in diesem Ordner öffnen"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Anwendung"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Anwendung"
@@ -2638,257 +1667,247 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Sitzungs-Seitenleiste anzeigen"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Sitzungs-Wechsler anzeigen"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Zur nächsten Sitzung wechseln"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Zur vorherigen Sitzung wechseln"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Zu Sitzung 1 wechseln"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Zu Sitzung 2 wechseln"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Zu Sitzung 3 wechseln"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Zu Sitzung 4 wechseln"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Zu Sitzung 5 wechseln"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Zu Sitzung 6 wechseln"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Zu Sitzung 7 wechseln"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Zu Sitzung 8 wechseln"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Zu Sitzung 9 wechseln"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Zu Sitzung 10 wechseln"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sitzung"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Datei"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Aktuelle Sitzung schließen"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Aktuelle Sitzung speichern"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Aktuelle Sitzung unter neuem Dateinamen speichern"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Gespeicherte Sitzung öffnen"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Terminal rechts hinzufügen"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Terminal unten hinzufügen"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Größe ändern"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Terminalgröße aufwärts verändern"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Terminalgröße abwärts verändern"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Terminalgröße nach links verändern"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Terminalgröße nach rechts verändern"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "Sonstige"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Sitzungsnamen bearbeiten"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Eingabe synchronisieren"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
 msgid "Switch"
 msgstr "Wechseln"
 
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
+#: data/resources/ui/shortcuts.ui:249
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "Zum nächsten Terminal wechseln"
 
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
+#: data/resources/ui/shortcuts.ui:255
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "Zum vorherigen Terminal wechseln"
 
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
+#: data/resources/ui/shortcuts.ui:261
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "Zum oberen Terminal wechseln"
 
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
+#: data/resources/ui/shortcuts.ui:267
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "Zum unteren Terminal wechseln"
 
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
+#: data/resources/ui/shortcuts.ui:273
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "Zum linken Terminal wechseln"
 
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
+#: data/resources/ui/shortcuts.ui:279
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "Zum rechten Terminal wechseln"
 
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
+#: data/resources/ui/shortcuts.ui:291
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "Zu Terminal 1 wechseln"
 
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
+#: data/resources/ui/shortcuts.ui:297
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "Zu Terminal 2 wechseln"
 
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
+#: data/resources/ui/shortcuts.ui:303
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "Zu Terminal 3 wechseln"
 
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
+#: data/resources/ui/shortcuts.ui:309
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "Zu Terminal 4 wechseln"
 
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
+#: data/resources/ui/shortcuts.ui:315
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "Zu Terminal 5 wechseln"
 
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
+#: data/resources/ui/shortcuts.ui:321
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "Zu Terminal 6 wechseln"
 
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
+#: data/resources/ui/shortcuts.ui:327
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "Zu Terminal 7 wechseln"
 
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
+#: data/resources/ui/shortcuts.ui:333
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "Zu Terminal 8 wechseln"
 
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
+#: data/resources/ui/shortcuts.ui:339
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "Zu Terminal 9 wechseln"
 
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
+#: data/resources/ui/shortcuts.ui:345
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "Zu Terminal 10 wechseln"
 
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Teilen"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Nach rechts teilen"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Nach unten teilen"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
 #: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
 msgctxt "shortcut window"
 msgid "Find"
 msgstr "Suchen"
 
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
+#: data/resources/ui/shortcuts.ui:371
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "Nächster Treffer"
@@ -2898,153 +1917,136 @@ msgstr "Nächster Treffer"
 # in the Shortcut preferences and in the future
 # the shortcut overview if available in Gnome 3.20
 # ***********************************************
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
+#: data/resources/ui/shortcuts.ui:377
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "Vorheriger Treffer"
 
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
 msgid "Clipboard"
 msgstr "Zwischenablage"
 
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "Einfügen"
 
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
+#: data/resources/ui/shortcuts.ui:401
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Erweitertes Einfügen"
+
+#: data/resources/ui/shortcuts.ui:407
 msgctxt "shortcut window"
 msgid "Select all"
 msgstr "Alles auswählen"
 
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
+#: data/resources/ui/shortcuts.ui:415
 msgctxt "shortcut window"
 msgid "Zoom"
 msgstr "Vergrößerung"
 
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
+#: data/resources/ui/shortcuts.ui:419
 msgctxt "shortcut window"
 msgid "Zoom in"
 msgstr "Ansicht vergrößern"
 
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
+#: data/resources/ui/shortcuts.ui:425
 msgctxt "shortcut window"
 msgid "Zoom out"
 msgstr "Ansicht verkleinern"
 
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
+#: data/resources/ui/shortcuts.ui:431
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "Ansicht Standardvergrößerung"
 
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "Sonstige"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Terminalausgabe speichern"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Terminal schließen"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Terminal maximieren"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Aktuelle Profil-Einstellungen"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Terminal zurücksetzen"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Terminal zurücksetzen und leeren"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Nur lesend umschalten"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Layout-Optionen"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Terminalnummer einfügen"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Passwort eingeben"
+
+#: data/resources/ui/shortcuts.ui:503
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Stil der Terminal-Titelzeile durchwechseln"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Ein Terminal für Gnome mit Kacheldarstellung"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Neues Terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Ein Terminal für GNOME mit Kacheldarstellung"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix ist ein Terminal-Emulator mit Kacheldarstellung."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Damit können Sie:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
 msgstr "Terminals durch horizontales oder vertikales Teilen beliebig anordnen"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3053,12 +2055,10 @@ msgstr ""
 "Terminals durch ziehen und ablegen sowohl innerhalb eines Fensters als auch "
 "zwischen Fenstern neu anordnen"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "Terminals per ziehen und ablegen als neues Fenster loslösen"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3067,17 +2067,14 @@ msgstr ""
 "Die Eingabe zwischen Terminals synchronisieren, um Befehle in einem Terminal "
 "auf ein anderes zu replizieren"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "Die Gruppierung der Terminals speichern und vom Datenträger laden"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Terminals unterstützen benutzerdefinierte Titel"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3086,18 +2083,15 @@ msgstr ""
 "Farbschemata werden in Dateien gespeichert und benutzerdefinierte "
 "Farbschemata können durch Anlegen einer Datei erstellt werden"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Transparenter Hintergrund"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr ""
 "Unterstützt Benachrichtigungen, wenn nicht sichtbare Prozesse beendet werden"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3109,797 +2103,6 @@ msgstr ""
 "werden Client Side Decorations verwendet, die aber bei Bedarf deaktiviert "
 "werden können."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix wurde mit GNOME und Unity getestet."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Fenstergröße setzen, z.B. 80x24 oder 80x24+200+200 (SPALTENxZEILEN+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "GEOMETRIE"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Fenster"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Sitzungsnamen bearbeiten"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Eingabe synchronisieren"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sitzung"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Ausgabe speichern …"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Öffnen"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Nächster Treffer"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Vorheriger Treffer"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Neue Instanzen in separaten Prozessen starten (nicht empfohlen)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Terminal rechts hinzufügen"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Terminal unten hinzufügen"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Text in Terminal suchen"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Ton"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Symbol"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Symbol und Ton"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Automatischer Profilwechsel"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Übereinstimmung"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Neue Übereinstimmung hinzufügen"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Rechnername:Ordner eingeben"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Übereinstimmung bearbeiten"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Rechnername:Ordner bearbeiten"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Hintergrundbild:"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Bild wählen"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Alle Bilddateien"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Hintergrundbild zurücksetzen"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Skalieren"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Kachel"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Zentrieren"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Strecken"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Terminal rechts hinzufügen"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Terminal unten hinzufügen"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Text beim Auswählen automatisch in Zwischenablage kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Rechts hinzufügen"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Unten hinzufügen"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Titel des neuen Terminals setzen"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TITEL"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
-"Die Werte werden im Format <i>Rechnername:Ordner</i> eingegeben. Sowohl der "
-"Rechnername als auch der Ordner können weggelassen werden, aber der "
-"Doppelpunkt muss vorhanden sein. Einträge, die weder Rechnername noch Ordner "
-"enthalten, sind nicht zulässig."
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Tastenkombinationen aktivieren"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Benutzerdefinierte Verweise"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Eine Liste benutzerdefinierter Verweise basierend auf regulären Ausdrücken, "
-"die im Terminal angeklickt werden können."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
-"Die Werte werden im Format <i>Rechnername:Ordner</i> eingegeben. Sowohl der "
-"Rechnername als auch der Ordner können weggelassen werden, aber der "
-"Doppelpunkt muss vorhanden sein. Einträge, die weder Rechnername noch Ordner "
-"enthalten, sind nicht zulässig."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "%s ist kein gültiger regulärer Ausdruck"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Regulärer Ausdruck"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Groß-/Kleinschreibung nicht beachten"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Benutzerdefinierte Verweise bearbeiten"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Anwenden"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Terminalnummer einfügen"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Die Bibliothek %s konnte nicht geladen werden, Passwort-Funktionalität ist "
-"nicht verfügbar."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Bibliothek nicht geladen"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Passwort mit Zeilenumbruch abschließen"
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Passwort eingeben"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Passwort"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Passwort bestätigen"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Passwort hinzufügen"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Passwort bearbeiten"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr "Parameter als Befehl ausführen"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "BEFEHL"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Öffnet ein Fenster im Quake-Modus oder schaltet die Sichtbarkeit eines "
-"vorhandenen Fensters im Quake-Modus um"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "QUAKE"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-"Der Quake-Modus kann nicht mit den Parametern maximize, fullscreen oder "
-"geometry zusammen verwendet werden"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr "Auslöser"
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Auslöser sind reguläre Ausdrücke, die auf den Ausgabetext des Terminals "
-"angewendet werden. Bei einem Treffer wird die konfigurierte Aktion "
-"ausgeführt."
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
-"Die Werte werden im Format <i>Benutzername@Rechnername:Ordner</i> "
-"eingegeben. Sowohl der Rechnername als auch der Ordner können weggelassen "
-"werden, aber der Doppelpunkt muss vorhanden sein. Einträge, die weder "
-"Rechnername noch Ordner enthalten, sind nicht zulässig."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr "Benutzername@Rechnername:Ordner eingeben"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr "Benutzername@Rechnername:Ordner bearbeiten"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parameter"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr "Auslöser bearbeiten"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr "Status aktualisieren"
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr "Befehl ausführen"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr "Benachrichtigung senden"
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr "Titel aktualisieren"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr "Terminal-Glocke läuten"
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr "Text senden"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr "Passwort einfügen"
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Seitenleiste rechts anzeigen"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Terminal auf allen Arbeitsflächen anzeigen"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Terminal auf dem primären Monitor anzeigen"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Auf spezifischem Monitor anzeigen"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Terminal-Höhe"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Terminal mit Klick der mittleren Maustaste auf den Titel schließen"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Fenster schließen, wenn die letzte Sitzung geschlossen wird"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Passwort eingeben"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Umwandeln"
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Erweitertes Einfügen"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr "Terminalfenster minimieren"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr "Der Parameter action kann nur innerhalb von Terminix verwendet werden"
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-"Der Quake-Modus kann nicht mit den Parametern maximize, minimize, fullscreen "
-"oder geometry zusammen verwendet werden"
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Standard-Sitzungsname"
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Terminal-Titel auch anzeigen, auch wenn es das einzige Terminal ist"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "Größe"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr "Höhe in Prozent"
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr "Breite in Prozent"
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr "Hinweis für Fenstermanager setzen, um Animationen zu deaktivieren"
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr "Immer erweiterten Einfügedialog verwenden"
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Sitzungs-Wechsler anzeigen"
-
-#: data/resources/ui/shortcuts.ui:401
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Erweitertes Einfügen"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr "Versionsnummern von Terminix und abhängigen Komponenten anzeigen"
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Es sind mehrere Sitzungen geöffnet, trotzdem beenden?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
-msgstr "Nicht wieder anzeigen"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr "Badge"
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr "Badge-Position"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr "Oben links"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr "Oben rechts"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr "Unten links"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr "Unten rechts"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
-msgstr "Badge-Farbe wählen"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr "Fenster verbergen sobald es den Fokus verliert"
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr "In entferntem Terminix öffnen …"
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Entferntes Terminix in %s öffnen"
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr "In Terminix öffnen …"
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr "Entferntes Terminix hier öffnen …"
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
-msgstr "Entferntes Terminix in diesem Ordner öffnen"
-
-#: data/resources/ui/shortcuts.ui:503
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Stil der Terminal-Titelzeile durchwechseln"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr "Exportieren"
-
-#: source/gx/terminix/profilewindow.d:728
-msgid "Export Color Scheme"
-msgstr "Farbschema exportieren"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
-msgstr "Terminal auf dem aktiven Monitor anzeigen"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Anzahl der Zeilen für Auslöser-Bearbeitung beschränken:"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Leerzeichen in Tabstopps umwandeln"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "CRLF und CR in LF umwandeln"

--- a/po/el.po
+++ b/po/el.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-05-16 13:46+0000\n"
 "Last-Translator: alex285 <alexis.diavatis@hotmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/terminix/"
@@ -18,960 +18,1123 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Εντολή"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Κείμενο"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Κουδούνι  τερματικού"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Το αρχείο %s δεν είναι συμβατό θέμα χρωμάτων με JSON"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Η χρωματική παλέτα απαιτεί 16 χρώματα"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Επαναφορά"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Εντολή"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:360
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Τίτλος τερματικού"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr ""
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr ""
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr ""
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr ""
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr ""
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr ""
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Επεξεργασία προφίλ: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Νέο προφίλ"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Γενικά"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Εντολή"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Χρώμα"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Κύλιση"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Συμβατότητα"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "'Ονομα προφίλ"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Μέγεθος Τερματικού"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "στήλες"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "σειρές"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Επαναφορά"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Κέρσορας"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Τούβλο"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Δέσμη"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Υπογραμμίση"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Αναβόσβημα"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Σύστημα"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "On"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Off"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Κουδούνι  τερματικού"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Τίτλος τερματικού"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Εμφάνιση κειμένου"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Να επιτραπεί έντονο κέιμενο"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Θέμα χρώματος"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Διαφάνεια"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Κείμενο"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Φόντο"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Θέμα χρώματος"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr ""
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Το αρχείο %s δεν είναι συμβατό θέμα χρωμάτων με JSON"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Η χρωματική παλέτα απαιτεί 16 χρώματα"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr ""
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -979,20 +1142,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1132,284 +1289,38 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr ""
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr ""
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr ""
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr ""
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr ""
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr ""
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr ""
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1417,1164 +1328,257 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+#, fuzzy
+msgid "Background image"
+msgstr "Φόντο"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr ""
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr ""
@@ -2614,1114 +1618,271 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Τίτλος τερματικού"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Τίτλος τερματικού"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "Μέγεθος Τερματικού"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-msgid "Supports notifications when processes are completed out of view"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
+#: data/resources/ui/shortcuts.ui:231
 msgctxt "shortcut window"
 msgid "Edit the session name"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
+#: data/resources/ui/shortcuts.ui:237
 msgctxt "shortcut window"
 msgid "Synchronize the input"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
-msgid "Session"
+msgid "Switch"
 msgstr ""
 
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:134
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
 msgid "Find next"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:140
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
 msgid "Find previous"
 msgstr ""
 
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Τίτλος τερματικού"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-#, fuzzy
-msgid "Background image"
-msgstr "Φόντο"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
-msgid "Add"
+msgid "Clipboard"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Τίτλος τερματικού"
+msgid "Copy"
+msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Τίτλος τερματικού"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Εντολή"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Κείμενο"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Τίτλος τερματικού"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
+msgid "Paste"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:401
@@ -3729,78 +1890,79 @@ msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr ""
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
+#: data/resources/ui/shortcuts.ui:467
+msgctxt "shortcut window"
+msgid "Reset the terminal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
@@ -3808,27 +1970,76 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Θέμα χρώματος"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
+msgid "Supports notifications when processes are completed out of view"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-05-07 02:09+0000\n"
 "Last-Translator: Gerald Nunn <gerald.b.nunn@gmail.com>\n"
 "Language-Team: English <https://hosted.weblate.org/projects/terminix/"
@@ -14,971 +14,1154 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
-#, c-format
-msgid "Editing Profile: %s"
-msgstr "Editing Profile: %s"
-
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
-msgid "New Profile"
-msgstr "New Profile"
-
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
-msgid "General"
-msgstr "General"
-
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
 msgstr "Command"
 
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
-msgid "Color"
-msgstr "Color"
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
-msgid "Scrolling"
-msgstr "Scrolling"
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
-msgid "Compatibility"
-msgstr "Compatibility"
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Paste"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Name"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "New"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Edit"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Delete"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Search Options"
+
+#: source/gx/terminix/terminal/search.d:134
 #, fuzzy
-msgid "Profile name"
-msgstr "Profile Name"
+msgid "Find next"
+msgstr "Find Next"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/terminal/search.d:140
 #, fuzzy
-msgid "Terminal size"
-msgstr "Terminal Size"
+msgid "Find previous"
+msgstr "Find Previous"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
-msgid "columns"
-msgstr "columns"
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Match case"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
-msgid "rows"
-msgstr "rows"
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Match entire word only"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Reset"
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Match as regular expression"
 
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
-msgid "Cursor"
-msgstr "Cursor"
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Wrap around"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Block"
-msgstr "Block"
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "IBeam"
-msgstr "IBeam"
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Close"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Underline"
-msgstr "Underline"
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+#, fuzzy
+msgid "Maximize"
+msgstr "Maximize"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
-msgid "Blink mode"
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "System"
-msgstr ""
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Read-Only"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "On"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "Off"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
 #: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
+#: source/gx/terminix/profilewindow.d:237
 #, fuzzy
 msgid "Terminal bell"
 msgstr "Terminal Bell"
 
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Edit Profile"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:752
+#, fuzzy
+msgid "Save Output…"
+msgstr "Save As…"
+
+#: source/gx/terminix/terminal/terminal.d:753
 #: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
+msgid "Reset"
+msgstr "Reset"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profiles"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Encoding"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Find…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:775
+#, fuzzy
+msgid "Add Right"
+msgstr "Split Right"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Copy"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Select All"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1402
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Synchronize Input"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Save"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Don't Paste"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Layout Options"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Command"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "View session sidebar"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Create a new session"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Add terminal right"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Add terminal down"
+
+#: source/gx/terminix/appwindow.d:369
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Exit the terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Change Session Name"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Enter a new name for the session"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Save As…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Name…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Synchronize Input"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Do not show this message again"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Filename '%s' does not exist"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Load Session"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Could not load session due to unexpected error."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Error Loading Session"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Save Session"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "New Session"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "New Window"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Preferences"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "About"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Quit"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Set the starting profile"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Open the specified session"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Send an action to current Terminix instance"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Execute the passed command"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:612
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:613
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"There appears to be an issue with the configuration of the terminal. This\n"
+"issue is not serious, but correcting it will improve your experience. Click\n"
+"the link below for more information:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Configuration Issue Detected"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Do not show this message again"
+
+#: source/gx/terminix/profilewindow.d:93
+#, c-format
+msgid "Editing Profile: %s"
+msgstr "Editing Profile: %s"
+
+#: source/gx/terminix/profilewindow.d:95
+msgid "New Profile"
+msgstr "New Profile"
+
+#: source/gx/terminix/profilewindow.d:104
+msgid "General"
+msgstr "General"
+
+#: source/gx/terminix/profilewindow.d:106
+msgid "Color"
+msgstr "Color"
+
+#: source/gx/terminix/profilewindow.d:107
+msgid "Scrolling"
+msgstr "Scrolling"
+
+#: source/gx/terminix/profilewindow.d:108
+msgid "Compatibility"
+msgstr "Compatibility"
+
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:165
+#, fuzzy
+msgid "Profile name"
+msgstr "Profile Name"
+
+#: source/gx/terminix/profilewindow.d:174
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/profilewindow.d:181
+#, fuzzy
+msgid "Terminal size"
+msgstr "Terminal Size"
+
+#: source/gx/terminix/profilewindow.d:191
+msgid "columns"
+msgstr "columns"
+
+#: source/gx/terminix/profilewindow.d:197
+msgid "rows"
+msgstr "rows"
+
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
+msgid "Cursor"
+msgstr "Cursor"
+
 #: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
+msgid "Block"
+msgstr "Block"
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "Underline"
+msgstr "Underline"
+
+#: source/gx/terminix/profilewindow.d:226
+msgid "Blink mode"
+msgstr ""
+
 #: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+msgid "System"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:229
+msgid "On"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:229
+msgid "Off"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 #, fuzzy
 msgid "Terminal title"
 msgstr "Terminal Title"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "South European"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Text Appearance"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Allow bold text"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Rewrap on resize"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 #, fuzzy
 msgid "Custom font"
 msgstr "Custom Font"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Choose A Terminal Font"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Color scheme"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Custom"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Color palette"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Options"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Use theme colors for foreground/background"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Transparency"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Background"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 #, fuzzy
 msgid "Select Cursor Foreground Color"
 msgstr "Select Foreground Color"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 #, fuzzy
 msgid "Select Cursor Background Color"
 msgstr "Select Background Color"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 #, fuzzy
 msgid "Select Highlight Foreground Color"
 msgstr "Select Foreground Color"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 #, fuzzy
 msgid "Select Highlight Background Color"
 msgstr "Select Background Color"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 #, fuzzy
 msgid "Select Dim Color"
 msgstr "Select %s Color"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Select %s Color"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Select Background Color"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Select Foreground Color"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Foreground"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Black"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Red"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Green"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Orange"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Blue"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Purple"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turquoise"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Grey"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Select %s Color"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Select %s Light Color"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Color scheme"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Show scrollbar"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Scroll on output"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Scroll on keystroke"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Limit scrollback to:"
 
 # Terminix gettext pot file
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Backspace key generates"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatic"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Escape sequence"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Delete key generates"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Encoding"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Ambiguous-width characters"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Narrow"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Wide"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Run command as a login shell"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Run a custom command instead of my shell"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "When command exits"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Exit the terminal"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Restart the command"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Hold the terminal open"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "Custom Font"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+#, fuzzy
+msgid "Match"
+msgstr "Match case"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Action"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Edit Profile"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Could not locate dropped terminal"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Could not locate session for dropped terminal"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Default"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profile"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -986,20 +1169,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1142,291 +1319,40 @@ msgstr "Vietnamese"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "New Session"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "New Window"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Preferences"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Shortcuts"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "About"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Quit"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Set the starting profile"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Open the specified session"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Send an action to current Terminix instance"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Execute the passed command"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"There appears to be an issue with the configuration of the terminal. This\n"
-"issue is not serious, but correcting it will improve your experience. Click\n"
-"the link below for more information:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Configuration Issue Detected"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Do not show this message again"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Could not locate dropped terminal"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Could not locate session for dropped terminal"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Name"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profile"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Global"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 #, fuzzy
 msgid "Appearance"
 msgstr "Appearance"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profiles"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Encodings showing in menu:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Enabled"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Action"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Shortcut Key"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Shortcuts"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1434,1172 +1360,265 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Default"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "New"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Edit"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Delete"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 #, fuzzy
 msgid "Terminal title style"
 msgstr "Terminal Title"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 #, fuzzy
 msgid "Theme variant"
 msgstr "Theme Variant"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Light"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Dark"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+#, fuzzy
+msgid "Background image"
+msgstr "Background"
+
+#: source/gx/terminix/prefwindow.d:620
+#, fuzzy
+msgid "Select Image"
+msgstr "Select All"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:644
+#, fuzzy
+msgid "Reset background image"
+msgstr "Transparency"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Switch To Session 1"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-#, fuzzy
-msgid "Dim unfocused terminals"
-msgstr "Terminal"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Behavior"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Prompt when creating a new session"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Focus a terminal when the mouse moves over it"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Send desktop notification on process complete"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Split Right"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Split Down"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 #, fuzzy
 msgid "Focus Window"
 msgstr "New Window"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Paste"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Warn when attempting unsafe paste"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "Strip first character of paste if comment or variable declaration"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Layout Options"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Search Options"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Match case"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Match entire word only"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Match as regular expression"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Wrap around"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Close"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-#, fuzzy
-msgid "Maximize"
-msgstr "Maximize"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Edit Profile"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Save…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Find…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Read-Only"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-#, fuzzy
-msgid "Split"
-msgstr "Split Down"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Copy"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Select All"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Synchronize Input"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Don't Paste"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignoring parameter session as '%s' does not exist"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "View session sidebar"
-
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Create a new session"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Change Session Name"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Enter a new name for the session"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Save"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Save As…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Name…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Synchronize Input"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Filename '%s' does not exist"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Load Session"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Could not load session due to unexpected error."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Error Loading Session"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Save Session"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "disabled"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-#, fuzzy
-msgid "Application"
-msgstr "Action"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Application"
@@ -2646,1271 +1665,405 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "View session sidebar"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to next session"
-msgstr "Switch To Next Session"
-
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to previous session"
-msgstr "Switch To Previous Session"
-
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 1"
-msgstr "Switch To Session 1"
-
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 2"
-msgstr "Switch To Session 2"
-
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 3"
-msgstr "Switch To Session 3"
-
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 4"
-msgstr "Switch To Session 4"
-
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 5"
-msgstr "Switch To Session 5"
-
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 6"
-msgstr "Switch To Session 6"
-
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 7"
-msgstr "Switch To Session 7"
-
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 8"
-msgstr "Switch To Session 8"
-
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 9"
-msgstr "Switch To Session 9"
-
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 10"
-msgstr "Switch To Session 10"
-
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
-#, fuzzy
-msgid "Session"
-msgstr "Session"
-
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
-msgctxt "shortcut window"
-msgid "File"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Close the current session"
-msgstr "Open the specified session"
-
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Save the current session"
-msgstr "Open the specified session"
-
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
-msgctxt "shortcut window"
-msgid "Save the current session with new filename"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Open a saved session"
-msgstr "Create a new session"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
-#: data/resources/ui/shortcuts.ui:197
-msgctxt "shortcut window"
-msgid "Resize"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
-#: data/resources/ui/shortcuts.ui:201
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal up"
-msgstr "Exit the terminal"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
-#: data/resources/ui/shortcuts.ui:207
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal down"
-msgstr "Hold the terminal open"
-
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:213
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal left"
-msgstr "Exit the terminal"
-
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:219
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal right"
-msgstr "Switch To Terminal 10"
-
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Switch To Next Terminal"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Switch To Previous Terminal"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Switch To Terminal 10"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Switch To Terminal 10"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Switch To Terminal 10"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Switch To Terminal 10"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Switch To Terminal 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Switch To Terminal 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Switch To Terminal 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Switch To Terminal 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Switch To Terminal 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Switch To Terminal 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Switch To Terminal 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Switch To Terminal 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Switch To Terminal 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Switch To Terminal 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Split Down"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Split Right"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Split Down"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Find…"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Find Next"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Find Previous"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Copy"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Paste"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Select All"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Zoom Normal"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr "Hold the terminal open"
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr "Terminal"
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr "Exit the terminal"
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr "Profile Preference"
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr "Exit the terminal"
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr "Exit the terminal"
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr "Read-only"
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr "Options"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "Terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-#, fuzzy
-msgid "Transparent background"
-msgstr "Transparency"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#, fuzzy
-msgid "Supports notifications when processes are completed out of view"
-msgstr "Send desktop notification on process complete"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-#, fuzzy
-msgid "Window"
-msgstr "New Window"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Switch To Session 1"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Synchronize Input"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Session"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-#, fuzzy
-msgid "Save Output…"
-msgstr "Save As…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:134
-#, fuzzy
-msgid "Find next"
-msgstr "Find Next"
-
-#: source/gx/terminix/terminal/search.d:140
-#, fuzzy
-msgid "Find previous"
-msgstr "Find Previous"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Add terminal right"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Add terminal down"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Exit the terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-#, fuzzy
-msgid "Match"
-msgstr "Match case"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-#, fuzzy
-msgid "Background image"
-msgstr "Background"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-#, fuzzy
-msgid "Select Image"
-msgstr "Select All"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-#, fuzzy
-msgid "Reset background image"
-msgstr "Transparency"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Add terminal right"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Add terminal down"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-#, fuzzy
-msgid "Add Right"
-msgstr "Split Right"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Shortcuts"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "Custom Font"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Exit the terminal"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Execute the passed command"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Edit Profile"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Command"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Terminal Title"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Switch To Session 1"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
 #: data/resources/ui/shortcuts.ui:61
 #, fuzzy
 msgctxt "shortcut window"
 msgid "View session switcher"
 msgstr "View session sidebar"
 
+#: data/resources/ui/shortcuts.ui:67
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to next session"
+msgstr "Switch To Next Session"
+
+#: data/resources/ui/shortcuts.ui:73
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to previous session"
+msgstr "Switch To Previous Session"
+
+#: data/resources/ui/shortcuts.ui:79
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 1"
+msgstr "Switch To Session 1"
+
+#: data/resources/ui/shortcuts.ui:85
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 2"
+msgstr "Switch To Session 2"
+
+#: data/resources/ui/shortcuts.ui:91
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 3"
+msgstr "Switch To Session 3"
+
+#: data/resources/ui/shortcuts.ui:97
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 4"
+msgstr "Switch To Session 4"
+
+#: data/resources/ui/shortcuts.ui:103
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 5"
+msgstr "Switch To Session 5"
+
+#: data/resources/ui/shortcuts.ui:109
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 6"
+msgstr "Switch To Session 6"
+
+#: data/resources/ui/shortcuts.ui:115
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 7"
+msgstr "Switch To Session 7"
+
+#: data/resources/ui/shortcuts.ui:121
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 8"
+msgstr "Switch To Session 8"
+
+#: data/resources/ui/shortcuts.ui:127
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 9"
+msgstr "Switch To Session 9"
+
+#: data/resources/ui/shortcuts.ui:133
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 10"
+msgstr "Switch To Session 10"
+
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
+msgid "Session"
+msgstr "Session"
+
+#: data/resources/ui/shortcuts.ui:149
+msgctxt "shortcut window"
+msgid "File"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:153
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Close the current session"
+msgstr "Open the specified session"
+
+#: data/resources/ui/shortcuts.ui:159
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Save the current session"
+msgstr "Open the specified session"
+
+#: data/resources/ui/shortcuts.ui:165
+msgctxt "shortcut window"
+msgid "Save the current session with new filename"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:171
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Open a saved session"
+msgstr "Create a new session"
+
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Add terminal right"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Add terminal down"
+
+#: data/resources/ui/shortcuts.ui:197
+msgctxt "shortcut window"
+msgid "Resize"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:201
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal up"
+msgstr "Exit the terminal"
+
+#: data/resources/ui/shortcuts.ui:207
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal down"
+msgstr "Hold the terminal open"
+
+#: data/resources/ui/shortcuts.ui:213
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal left"
+msgstr "Exit the terminal"
+
+#: data/resources/ui/shortcuts.ui:219
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal right"
+msgstr "Switch To Terminal 10"
+
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:231
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Switch To Session 1"
+
+#: data/resources/ui/shortcuts.ui:237
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Synchronize Input"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:249
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Switch To Next Terminal"
+
+#: data/resources/ui/shortcuts.ui:255
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Switch To Previous Terminal"
+
+#: data/resources/ui/shortcuts.ui:261
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Switch To Terminal 10"
+
+#: data/resources/ui/shortcuts.ui:267
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Switch To Terminal 10"
+
+#: data/resources/ui/shortcuts.ui:273
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Switch To Terminal 10"
+
+#: data/resources/ui/shortcuts.ui:279
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Switch To Terminal 10"
+
+#: data/resources/ui/shortcuts.ui:291
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Switch To Terminal 1"
+
+#: data/resources/ui/shortcuts.ui:297
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Switch To Terminal 2"
+
+#: data/resources/ui/shortcuts.ui:303
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Switch To Terminal 3"
+
+#: data/resources/ui/shortcuts.ui:309
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Switch To Terminal 4"
+
+#: data/resources/ui/shortcuts.ui:315
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Switch To Terminal 5"
+
+#: data/resources/ui/shortcuts.ui:321
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Switch To Terminal 6"
+
+#: data/resources/ui/shortcuts.ui:327
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Switch To Terminal 7"
+
+#: data/resources/ui/shortcuts.ui:333
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Switch To Terminal 8"
+
+#: data/resources/ui/shortcuts.ui:339
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Switch To Terminal 9"
+
+#: data/resources/ui/shortcuts.ui:345
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Switch To Terminal 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Find…"
+
+#: data/resources/ui/shortcuts.ui:371
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Find Next"
+
+#: data/resources/ui/shortcuts.ui:377
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Find Previous"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:389
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Copy"
+
+#: data/resources/ui/shortcuts.ui:395
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Paste"
+
 #: data/resources/ui/shortcuts.ui:401
 msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr ""
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
+#: data/resources/ui/shortcuts.ui:407
 #, fuzzy
-msgid "Do not show this again"
-msgstr "Do not show this message again"
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Select All"
 
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
+#: data/resources/ui/shortcuts.ui:431
 #, fuzzy
-msgid "Southeast"
-msgstr "South European"
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Zoom Normal"
 
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
+#: data/resources/ui/shortcuts.ui:443
 #, fuzzy
-msgid "Select Badge Color"
-msgstr "Select %s Color"
+msgctxt "shortcut window"
+msgid "Save terminal contents"
+msgstr "Hold the terminal open"
 
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:449
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Close terminal"
+msgstr "Terminal"
 
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:455
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Maximize terminal"
+msgstr "Exit the terminal"
 
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:461
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Current profile preferences"
+msgstr "Profile Preference"
 
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:467
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Reset the terminal"
+msgstr "Exit the terminal"
 
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:473
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
+msgstr "Exit the terminal"
 
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
+#: data/resources/ui/shortcuts.ui:479
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Toggle read only"
+msgstr "Read-only"
+
+#: data/resources/ui/shortcuts.ui:485
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Layout options"
+msgstr "Options"
+
+#: data/resources/ui/shortcuts.ui:491
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Exit the terminal"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
@@ -3919,28 +2072,78 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr "Terminal Title"
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 #, fuzzy
-msgid "Export Color Scheme"
-msgstr "Color scheme"
+msgid "Transparent background"
+msgstr "Transparency"
 
-#: source/gx/terminix/prefwindow.d:767
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Hold the terminal open"
+msgid "Supports notifications when processes are completed out of view"
+msgstr "Send desktop notification on process complete"
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-11-06 08:04+0000\n"
 "Last-Translator: Adolfo Jayme-Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/terminix/"
@@ -18,960 +18,1155 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Comando"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Título"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Texto"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Este comando está solicitando acceso administrativo en su ordenador"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiar comandos de Internet puede ser peligroso. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Asegúrese de entender qué hace cada parte de este comando."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformar"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Pegado avanzado"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Pegar"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Nombre"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "Id."
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Nuevo"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Editar"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Eliminar"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Incluir carácter de retorno en la contraseña"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Insertar contraseña"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Aplicar"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Contraseña"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Confirmar contraseña"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Aceptar"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Añadir contraseña"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Editar contraseña"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Opciones de búsqueda"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Buscar siguiente"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Buscar anterior"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Coincidir con capitalización"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Coincidir sólo con la palabra entera"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Coincidir con expresión regular"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Volver al principio"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Cerrar"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximinar"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Desactivar sincronización en esta terminal"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Sólo lectura"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Campana de la terminal"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Todavía quedan procesos en ejecución, ¿cerrar igualmente?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Activar sincronización de entrada para esta terminal"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "«%s» no es un archivo JSON de combinación de colores válido"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"No se pudo cargar la biblioteca %s. La funcionalidad de contraseñas no está "
+"disponible."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "La paleta de la combinación de colores requiere 16 colores"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Biblioteca no cargada"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Guardar salida…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Reiniciar"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Reiniciar y limpiar"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Perfiles"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Codificación"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Buscar…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Opciones de diseño…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Añadir a la derecha"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Añadir abajo"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Restaurar"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Abrir enlace"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Copiar dirección del enlace"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Copiar"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Seleccionar todo"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Portapapeles"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Se produjo un error inesperado, no hay información adicional disponible"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Se produjo un error inesperado: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Guardar salida de la terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Guardar"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Todos los ficheros de texto"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Todos los ficheros"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "El proceso hijo finalizó correctamente con el estado %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Se interrumpió el proceso hijo con la señal %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Se interrumpió el proceso hijo."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Relanzar"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "No pegar"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Pegar igualmente"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opciones de diseño"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Activar"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Título"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Cargar sesión"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Comando"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Las opciones activas siempre son efectivas y se aplican inmediatamente.\n"
+"Las opciones de carga de sesión se aplican únicamente al cargar un fichero "
+"de sesión."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Mostrar la barra lateral de sesiones"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Crear nueva sesión"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Añadir terminal a la derecha"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Añadir terminal abajo"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Buscar texto en la terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Cambiar el nombre de la sesión"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Introduzca un nuevo nombre para la sesión"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Abrir…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Guardar como…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Nombre…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Hay varias sesiones abiertas. ¿Quiere cerrar de todos modos?"
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr "No mostrar de nuevo"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Todos los ficheros JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "El fichero '%s' no existe"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Cargar sesión"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Abrir"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "No se pudo cargar la sesión debido a un error inesperado."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Error cargando la sesión"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Guardar sesión"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nueva sesión"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nueva ventana"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Atajos del teclado"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Acerca de"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Salir"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Créditos"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Establecer directorio de trabajo de la terminal"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DIRECTORIO"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Establecer perfil de inicio"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "NOMBRE-DEL-PERFIL"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Establecer título de la nueva terminal"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TÍTULO"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Abrir la sesión especificada"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "NOMBRE-DE-SESIÓN"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Enviar una acción a la instancia de Terminix actual"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "NOMRE-DE-LA-ACCIÓN"
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr "Ejecutar el parámetro como una orden"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "ORDEN"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maximizar la ventana de la terminal"
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr "Minimizar la ventana de la terminal"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Poner a pantalla completa la ventana de la terminal"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Dar el foco a la ventana existente"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Iniciar instancia adicional como un nuevo proceso (no recomendado)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Establecer el tamaño de la ventana; por ejemplo: 80x24, o 80x24+200+200 "
+"(COLUMNASxFILAS+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "GEOMETRÍA"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Abre una ventana en modo Quake o cambia la visibilidad de una ventana en "
+"modo Quake existente"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr "Mostrar las versiones de Terminix y de sus componentes dependientes"
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argumento oculto para pasar el UUID de la terminal"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID-DE-LA-TERMINAL"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Parece que hay un problema con la configuración de la terminal. Este\n"
+"problema no es grave, pero corregirlo puede mejorar tu experiencia. Abre\n"
+"el siguiente enlace para más información:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Detectado un problema de configuración"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "No volver a mostrar este mensaje"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Editando el perfil: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Nuevo perfil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "General"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Comando"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Color"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Desplazamiento"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Compatibilidad"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Nombre del perfil"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Tamaño del terminal"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "columnas"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "filas"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Reiniciar"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Cursor"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Bloque"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Doble T"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Subrayado"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Modo de parpadeo"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Sistema"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Activado"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Desactivado"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Campana de la terminal"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Ninguno"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Sonido"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Icono"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Icono y sonido"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Título de la terminal"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr "Tarjeta"
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr "Posición de la tarjeta"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr "Superior izquierda"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr "Superior derecha"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr "Inferior izquierda"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr "Inferior derecha"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Apariencia del texto"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Permitir texto en negrita"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Reajustar al redimensionar"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Fuente personalizada"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Elija una tipografía para la terminal"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Combinación de colores"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Personalizado"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr "Exportar"
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Paleta de color"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Opciones"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Usar los colores del tema para el primer plano/fondo"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Transparencia"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Difuminado sin el foco"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Texto"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Fondo"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Seleccionar el color de primer plano del cursor"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Seleccionar el color de fondo del cursor"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Resaltar"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Seleccionar el color de resaltado para el primer plano"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Seleccionar el color de resaltado para el fondo"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Difuminar"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Seleccionar el color de difuminado"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr "Seleccionar color de la tarjeta"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Seleccionar el color de fondo"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Seleccionar el color del primer plano"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Primer plano"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Negro"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Rojo"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Verde"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Naranja"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Azul"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Púrpura"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turquesa"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Gris"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Seleccionar color %s"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Seleccionar el color claro %s"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+msgid "Export Color Scheme"
+msgstr "Exportar combinación de colores"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Mostrar la barra de desplazamiento"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Desplazar en la salida"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Desplazar al pulsar letras"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Limitar el desplazamiento hacía atrás a:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "La tecla Retroceso genera"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automático"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII para Supr."
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Secuencia de escape"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "La tecla Suprimir genera"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Codificación"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Caracteres de anchura ambigua"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Estrechos"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Anchos"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Ejecutar el comando como intérprete de conexión"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Ejecutar un comando personalizado en vez de mi intérprete"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Cuando el comando termina"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Salir de la terminal"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Reiniciar el comando"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Mantener la terminal abierta"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Enlaces personalizados"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Una lista de enlaces cliqueables en la terminal definidos por el usuario. "
+"Basados en las definiciones de expresiones regulares."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr "Desencadenadores"
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Los desencadenadores son expresiones regulares para comprobar texto de "
+"salida en la terminal. Cuando se detecte una coincidencia, se ejecutará una "
+"acción configurada."
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Cambio de perfil automático"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Los perfiles se seleccionan automáticamente según los valores que se "
+"introduzcan aquí.\n"
+"Los valores se proporcionan en el formato <i>nombredeusuario@nombredeequipo:"
+"directorio</i>. Pueden omitirse tanto el nombre de equipo como el "
+"directorio, pero los dos puntos deben estar presentes. No se permiten "
+"entradas sin nombre de equipo y sin directorio."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Los perfiles se seleccionan de manera automática basados en los valores "
+"introducidos aquí.\n"
+"Los valores tienen que tener el siguiente formato: <i>nombre de host:"
+"directorio</i>. Tanto el nombre de host o el directorio pueden ser omitidos, "
+"pero los dos puntos tienen que estar presentes. No se permiten entradas sin "
+"el nombre de host o directorio."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Coincidir"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Añadir"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+"Escriba un nombredeusuario@nombredeequipo:directorio para buscar "
+"coincidencias"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Introduce el nombre de host:directorio para coincidir"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Añadir nueva coincidencia"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+"Edite un nombredeusuario@nombredeequipo:directorio para buscar coincidencias"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Editar nombre de host:directorio para coincidir"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Editar coincidencia"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "%s no es una expresión regular válida"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Expresión regular"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Ignora mayús./minús."
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Editar links personalizados"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Acción"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parámetro"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr "Editar desencadenadores"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "«%s» no es un archivo JSON de combinación de colores válido"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "La paleta de la combinación de colores requiere 16 colores"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "No se pudo localizar la terminal que ha sido soltada"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "No se pudo localizar la sesión para la terminal que ha sido soltada"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Por defecto"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Perfil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Un emulador de terminal basado en VTE para Linux"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -982,21 +1177,15 @@ msgstr ""
 "License, v.2.0. Si una copia de la MPL no es distribuida con este fichero, "
 "usted puede obtener una en http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "Equipo del componente GTK VTE, Terminix no habría sido posible sin su trabajo"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD por proporcionar un excelente envoltorio para GTK"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org por tan execelente lenguaje, D"
@@ -1136,287 +1325,38 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandés"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nueva sesión"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nueva ventana"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Atajos del teclado"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Acerca de"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Salir"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Créditos"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Establecer directorio de trabajo de la terminal"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DIRECTORIO"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Establecer perfil de inicio"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "NOMBRE-DEL-PERFIL"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Abrir la sesión especificada"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "NOMBRE-DE-SESIÓN"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Enviar una acción a la instancia de Terminix actual"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "NOMRE-DE-LA-ACCIÓN"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Ejecutar el comando pasado como argumento"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "EJECUTAR"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maximizar la ventana de la terminal"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Poner a pantalla completa la ventana de la terminal"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Dar el foco a la ventana existente"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argumento oculto para pasar el UUID de la terminal"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID-DE-LA-TERMINAL"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Parece que hay un problema con la configuración de la terminal. Este\n"
-"problema no es grave, pero corregirlo puede mejorar tu experiencia. Abre\n"
-"el siguiente enlace para más información:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Detectado un problema de configuración"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "No volver a mostrar este mensaje"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "No se pudo localizar la terminal que ha sido soltada"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "No se pudo localizar la sesión para la terminal que ha sido soltada"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Nombre"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Perfil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Global"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Perfiles"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr "Quake"
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Codificaciones mostradas en el menú:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Activado"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Acción"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Tecla de atajo del teclado"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Activar atajos de teclado"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Sobrescribir atajo del teclado existente"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1427,980 +1367,191 @@ msgstr ""
 "¿Quieres desactivar el atajo del teclado para la otra acción y asignarla a "
 "esta?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Por defecto"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nuevo"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Editar"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Eliminar"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Activar transparencia, requiere reiniciar"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Estilo del título de la terminal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Pequeño"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Ninguno"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Variante del tema"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Claro"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Oscuro"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Imagen de fondo"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Seleccionar imagen"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Todas las imagenes"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Restablecer imagen de fondo"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Ampliar"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Repetir"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Centrar"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Estirar"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Nombre de sesión predeterminado"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Utilizar un separador ancho para los divisores"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Difuminar las terminales que no tienen el foco"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Situar la barra lateral en la derecha"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Mostrar el título de la terminal incluso si es la única"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "Tamaño"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr "Porcentaje de altura"
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr "Porcentaje de anchura"
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Mostrar la terminal en todas las áreas de trabajo"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr "Indicar al gestor de ventanas que desactive las animaciones"
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr "Ocultar la ventana cuando se pierde el foco"
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr "Mostrar la terminal en el monitor activo"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Mostrar en un monitor específico"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Preguntar al crear una sesión nueva"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Dar el foco a la terminal al situar el ratón sobre ella"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Ocultar automáticamente el puntero del ratón mientras se escribe"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+"Cerrar terminales al pulsar con el botón central del ratón sobre el título"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Cerrar la ventana cuando se cierre la última sesión"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Enviar una notificación de escritorio cuando un proceso termine"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "En una instancia nueva"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Dar el foco a la ventana"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Pegar"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr "Usar siempre el cuadro de diálogo de pegado avanzado"
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Advertir al hacer un pegado inseguro"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Quitar el primer carácter del texto pegado si es un comentario o una "
 "declaración de variable"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opciones de diseño"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Copiar texto automáticamente al portapapeles al seleccionar"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Aceptar"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Activar"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Título"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Cargar sesión"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Las opciones activas siempre son efectivas y se aplican inmediatamente.\n"
-"Las opciones de carga de sesión se aplican únicamente al cargar un fichero "
-"de sesión."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Opciones de búsqueda"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Coincidir con capitalización"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Coincidir sólo con la palabra entera"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Coincidir con expresión regular"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Volver al principio"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Cerrar"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximinar"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Desactivar sincronización en esta terminal"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Todavía quedan procesos en ejecución, ¿cerrar igualmente?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Activar sincronización de entrada para esta terminal"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Guardar…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Buscar…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Opciones de diseño…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Sólo lectura"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Reiniciar y limpiar"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Dividir"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Restaurar"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Abrir enlace"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Copiar dirección del enlace"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Copiar"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Seleccionar todo"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Portapapeles"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Se produjo un error inesperado, no hay información adicional disponible"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Se produjo un error inesperado: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Guardar salida de la terminal"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Todos los ficheros de texto"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Todos los ficheros"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "El proceso hijo finalizó correctamente con el estado %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Se interrumpió el proceso hijo con la señal %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Se interrumpió el proceso hijo."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Relanzar"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Este comando está solicitando acceso administrativo en su ordenador"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiar comandos de Internet puede ser peligroso. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Asegúrese de entender qué hace cada parte de este comando."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "No pegar"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Pegar igualmente"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Ignorando '%s' ya que no es un directorio"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignorando el parámetro de sesión '%s' ya que no existe"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2409,191 +1560,71 @@ msgstr ""
 "No puede cargar una sesión y establecer la opción perfil/directorio de "
 "trabajo/ejecutar un comando, por favor, seleccione uno u otro"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Mostrar la barra lateral de sesiones"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr "Puede utilizar el parámetro «action» solo dentro de Terminix"
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Crear nueva sesión"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
+"No se puede utilizar el modo Quake con los parámetros «maximize», «minimize» "
+"o «geometry»"
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Cambiar el nombre de la sesión"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Introduzca un nuevo nombre para la sesión"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Abrir…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Guardar"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Guardar como…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Nombre…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Todos los ficheros JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "El fichero '%s' no existe"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Cargar sesión"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "No se pudo cargar la sesión debido a un error inesperado."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Error cargando la sesión"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Guardar sesión"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "desactivado"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "¡Su versión de GTK es demasiado antigua, necesita por lo menos GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Se produjo una excepción inesperada"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Error: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
+msgstr "Abrir Terminix remoto…"
+
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Abrir Terminix remoto en %s"
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
 msgstr "Abrir en Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Abrir Terminix en %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr "Abrir Terminix remoto aquí…"
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr "Abrir Terminix remoto en este directorio"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Abrir Terminix aquí…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Abrir Terminix en este directorio"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Aplicación"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Aplicación"
@@ -2633,409 +1664,382 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Mostrar barra lateral de sesiones"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Mostrar el selector de sesiones"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Cambiar a la sesión siguiente"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Cambiar a la sesión anterior"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Cambiar a la sesión 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Cambiar a la sesión 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Cambiar a la sesión 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Cambiar a la sesión 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Cambiar a la sesión 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Cambiar a la sesión 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Cambiar a la sesión 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Cambiar a la sesión 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Cambiar a la sesión 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Cambiar a la sesión 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sesión"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Archivo"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Cerrar la sesión actual"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Guardar la sesión actual"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Guardar la sesión actual en un archivo nuevo"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Abrir una sesión guardada"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Añadir"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Añadir terminal a la derecha"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Añadir terminal abajo"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Redimensionar"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Redimensionar la terminal hacia arriba"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Redimensionar la terminal hacia abajo"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Redimensionar la terminal hacia la izquierda"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Redimensionar la terminal hacia la derecha"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Cambiar"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Cambiar a la terminal siguiente"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Cambiar a la terminal anterior"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Cambiar a la terminal de arriba"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Cambiar a la terminal de abajo"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Cambiar a la terminal de la izquierda"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Cambiar a la terminal de la derecha"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Cambiar a la terminal 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Cambiar a la terminal 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Cambiar a la terminal 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Cambiar a la terminal 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Cambiar a la terminal 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Cambiar a la terminal 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Cambiar a la terminal 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Cambiar a la terminal 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Cambiar a la terminal 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Cambiar a la terminal 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Dividir"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Dividir por la derecha"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Dividir por abajo"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Buscar"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Buscar siguiente"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Buscar anterior"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Portapapeles"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Copiar"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Pegar"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Seleccionar todo"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Ampliación"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Ampliar"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Reducir"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Restaurar tamaño normal"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Otro"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Editar el nombre de la sesión"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Sincronizar la entrada"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Cambiar"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Cambiar a la terminal siguiente"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Cambiar a la terminal anterior"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Cambiar a la terminal de arriba"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Cambiar a la terminal de abajo"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Cambiar a la terminal de la izquierda"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Cambiar a la terminal de la derecha"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Cambiar a la terminal 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Cambiar a la terminal 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Cambiar a la terminal 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Cambiar a la terminal 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Cambiar a la terminal 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Cambiar a la terminal 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Cambiar a la terminal 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Cambiar a la terminal 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Cambiar a la terminal 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Cambiar a la terminal 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Buscar"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Buscar siguiente"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Buscar anterior"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Portapapeles"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Copiar"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Pegar"
+
+#: data/resources/ui/shortcuts.ui:401
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Pegado avanzado"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Seleccionar todo"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Ampliación"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Ampliar"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Reducir"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Restaurar tamaño normal"
+
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Guardar el contenido de la terminal"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Cerrar la terminal"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Maximizar la terminal"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Preferencias del perfil actual"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Reiniciar la terminal"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Reiniciar y limpiar la terminal"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Cambiar a sólo lectura"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Opciones de diseño"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Introduce el número de terminal"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Insertar contraseña"
+
+#: data/resources/ui/shortcuts.ui:503
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Cambiar entre estilos de título"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Una terminal divisible para Gnome"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Nueva terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Una terminal divisible para GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix es un emulador de terminal divisible."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Le permite:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
 msgstr ""
 "Distribuir las terminales dividiéndolas horizontalmente o verticalmente"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3043,13 +2047,11 @@ msgid ""
 msgstr ""
 "Las terminales pueden ser reordenadas arrastrando y soltando entre ventanas"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr ""
 "Las terminales se pueden mover a una ventana nueva vía arrastrar y soltar"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3058,17 +2060,14 @@ msgstr ""
 "La entrada puede ser sincronizada entre terminales haciendo que los comandos "
 "introducidos en una se repliquen en las otras"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "La agrupación de terminales se puede guardar y cargar desde el disco"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Las terminales soportan títulos personalizados"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3077,17 +2076,14 @@ msgstr ""
 "las combinaciones de colores se guardan en archivos y es posible crear "
 "combinaciones personalizadas tan solo con un archivo nuevo"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Fondo transparente"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "Soporte de notificaciones para procesos finalizados fuera de la vista"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3099,800 +2095,6 @@ msgstr ""
 "decoraciones en el lado del cliente, aunque se pueden desactivar si fuera "
 "necesario."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix fue probado en GNOME y en Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Establecer el tamaño de la ventana; por ejemplo: 80x24, o 80x24+200+200 "
-"(COLUMNASxFILAS+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "GEOMETRÍA"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Ventana"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Editar el nombre de la sesión"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Sincronizar la entrada"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sesión"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Guardar salida…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Abrir"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Buscar siguiente"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Buscar anterior"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Iniciar instancia adicional como un nuevo proceso (no recomendado)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Añadir terminal a la derecha"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Añadir terminal abajo"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Buscar texto en la terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Sonido"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Icono"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Icono y sonido"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Cambio de perfil automático"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Coincidir"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Añadir"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Añadir nueva coincidencia"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Introduce el nombre de host:directorio para coincidir"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Editar coincidencia"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Editar nombre de host:directorio para coincidir"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Imagen de fondo"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Seleccionar imagen"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Todas las imagenes"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Restablecer imagen de fondo"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Ampliar"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Repetir"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Centrar"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Estirar"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Añadir"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Añadir terminal a la derecha"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Añadir terminal abajo"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Copiar texto automáticamente al portapapeles al seleccionar"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Añadir a la derecha"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Añadir abajo"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Establecer título de la nueva terminal"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TÍTULO"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Los perfiles se seleccionan de manera automática basados en los valores "
-"introducidos aquí.\n"
-"Los valores tienen que tener el siguiente formato: <i>nombre de host:"
-"directorio</i>. Tanto el nombre de host o el directorio pueden ser omitidos, "
-"pero los dos puntos tienen que estar presentes. No se permiten entradas sin "
-"el nombre de host o directorio"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Activar atajos de teclado"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Enlaces personalizados"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Una lista de enlaces cliqueables en la terminal definidos por el usuario. "
-"Basados en las definiciones de expresiones regulares."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Los perfiles se seleccionan de manera automática basados en los valores "
-"introducidos aquí.\n"
-"Los valores tienen que tener el siguiente formato: <i>nombre de host:"
-"directorio</i>. Tanto el nombre de host o el directorio pueden ser omitidos, "
-"pero los dos puntos tienen que estar presentes. No se permiten entradas sin "
-"el nombre de host o directorio."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "%s no es una expresión regular válida"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Expresión regular"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Ignora mayús./minús."
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Editar links personalizados"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Aplicar"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Introduce el número de terminal"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"No se pudo cargar la biblioteca %s. La funcionalidad de contraseñas no está "
-"disponible."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Biblioteca no cargada"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Id."
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Incluir carácter de retorno en la contraseña"
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Insertar contraseña"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Contraseña"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Confirmar contraseña"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Añadir contraseña"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Editar contraseña"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr "Ejecutar el parámetro como una orden"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "ORDEN"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Abre una ventana en modo Quake o cambia la visibilidad de una ventana en "
-"modo Quake existente"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "QUAKE"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-"No se puede utilizar el modo Quake con los parámetros «maximize», "
-"«fullscreen» o «geometry»"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr "Desencadenadores"
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Los desencadenadores son expresiones regulares para comprobar texto de "
-"salida en la terminal. Cuando se detecte una coincidencia, se ejecutará una "
-"acción configurada."
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Los perfiles se seleccionan automáticamente según los valores que se "
-"introduzcan aquí.\n"
-"Los valores se proporcionan en el formato <i>nombredeusuario@nombredeequipo:"
-"directorio</i>. Pueden omitirse tanto el nombre de equipo como el "
-"directorio, pero los dos puntos deben estar presentes. No se permiten "
-"entradas sin nombre de equipo y sin directorio."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-"Escriba un nombredeusuario@nombredeequipo:directorio para buscar "
-"coincidencias"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-"Edite un nombredeusuario@nombredeequipo:directorio para buscar coincidencias"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parámetro"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr "Editar desencadenadores"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Comando"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Título"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Texto"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Situar la barra lateral en la derecha"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Mostrar la terminal en todas las áreas de trabajo"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Mostrar la terminal en el monitor primario"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Mostrar en un monitor específico"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Altura de la terminal"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-"Cerrar terminales al pulsar con el botón central del ratón sobre el título"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Cerrar la ventana cuando se cierre la última sesión"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Insertar contraseña"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformar"
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Pegado avanzado"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr "Minimizar la ventana de la terminal"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr "Puede utilizar el parámetro «action» solo dentro de Terminix"
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-"No se puede utilizar el modo Quake con los parámetros «maximize», «minimize» "
-"o «geometry»"
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Nombre de sesión predeterminado"
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Mostrar el título de la terminal incluso si es la única"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "Tamaño"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr "Porcentaje de altura"
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr "Porcentaje de anchura"
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr "Indicar al gestor de ventanas que desactive las animaciones"
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr "Usar siempre el cuadro de diálogo de pegado avanzado"
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Mostrar el selector de sesiones"
-
-#: data/resources/ui/shortcuts.ui:401
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Pegado avanzado"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr "Mostrar las versiones de Terminix y de sus componentes dependientes"
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Hay varias sesiones abiertas. ¿Quiere cerrar de todos modos?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
-msgstr "No mostrar de nuevo"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr "Tarjeta"
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr "Posición de la tarjeta"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr "Superior izquierda"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr "Superior derecha"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr "Inferior izquierda"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr "Inferior derecha"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
-msgstr "Seleccionar color de la tarjeta"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr "Ocultar la ventana cuando se pierde el foco"
-
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr "Abrir Terminix remoto…"
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Abrir Terminix remoto en %s"
-
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr "Abrir en Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr "Abrir Terminix remoto aquí…"
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
-msgstr "Abrir Terminix remoto en este directorio"
-
-#: data/resources/ui/shortcuts.ui:503
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Cambiar entre estilos de título"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr "Exportar"
-
-#: source/gx/terminix/profilewindow.d:728
-msgid "Export Color Scheme"
-msgstr "Exportar combinación de colores"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
-msgstr "Mostrar la terminal en el monitor activo"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#~ msgid "You can only use the the action parameter within Terminix"
-#~ msgstr "Puede utilizar el parámetro de acción solo dentro de Terminix"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-08-01 07:29+0000\n"
 "Last-Translator: Boiethios <fdaudre-@student.42.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/terminix/"
@@ -14,961 +14,1167 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Commande"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Titre"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Texte"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+"Cette commande demande les droits d'administrateur sur votre ordinateur"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copier des commandes depuis l'internet peut être dangereux. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Soyez sûr de comprendre ce que fait chaque partie de la commande."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Avancé"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Coller"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Annuler"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Nom"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Nouveau"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Modifier"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Supprimer"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Appliquer"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Ok"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Options de recherche"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Rechercher le suivant"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Rechercher le précédent"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Respecter la case"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Mots entiers seulement"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Utiliser comme expression régulière"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Recherche circulaire"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Fermer"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximiser"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Désactiver la synchronisation d'entrée pour ce terminal"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Lecture seule"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "« Bip » du terminal"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Modifier le profil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Des processus continuent de s'exécuter, fermer quand-même ?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Activer la synchronisation d'entrée pour ce terminal"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Le fichier %s n'est pas un fichier JSON de palette de couleurs"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Une palette de couleurs requiert 16 couleurs"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Enregistrer la sortie sous…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Réinitialiser et effacer"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profils"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Codage"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Rechercher…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Options de disposition…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Division à droite"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Division en bas"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Restaurer"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Ouvrir le lien"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Copier l'adresse du lien"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Copier"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Tout sélectionner"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Presse-papier"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Synchroniser l'entrée"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Une erreur inattendue est survenue, aucune information supplémentaire n'est "
+"disponible"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Une erreur inattendue est survenue : %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Sauvegarder la sortie du terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Enregistrer"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Tous les fichiers texte"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Tous les fichiers"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Les processus fils a quitté normalement avec le status %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Le processus fils a été interrompu par le signal %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Le processus fils a été interrompu."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Relancer"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Ne pas coller"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Coller quand même"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Options de disposition"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Actif"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titre"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Chargement de session"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Commande"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Les options « Actif » sont toujours actives et prennent effet "
+"immédiatement.\n"
+"Les options « Chargement de session » s'appliquent seulement quand une "
+"session est chargée."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Voir la barre latérale de session"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Créer une nouvelle session"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Ajouter un terminal à droite"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Ajouter un terminal en bas"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Chercher le texte dans le terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Changer le nom de la sesssion"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Entrer un nouveau nom pour la session"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Ouvrir…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Enregistrer sous…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Nom…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Synchroniser l'entrée"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Des processus continuent de s'exécuter, fermer quand-même ?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Ne pas réafficher ce message"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Tous les fichiers JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Le nom de fichier « %s » n'existe pas"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Charger la session"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Ouvrir"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Impossible de charger la session en raison d'une erreur inattendue."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Erreur lors du chargement de la session"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Sauvegarder la session"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nouvelle Session"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nouvelle fenêtre"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Préférences"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "À propos"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Quitter"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Crédits"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Définir le répertoire de travail pour le terminal"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DOSSIER"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Définir le profil de démarrage"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "NOM_PROFIL"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Définir le titre du nouveau terminal"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TITRE"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Ouvrir la session specifiée"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "NOM_SESSION"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Envoyer une action à l'instance actuelle Terminix"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "NOM_ACTION"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Exécuter la commande passée"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maximiser la fenêtre du terminal"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Maximiser la fenêtre du terminal"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Mettre la fenêtre du terminal en plein écran"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Donner le focus à la fenêtre existante"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+"Démarrer une instance supplémentaire en tant que nouveau processus (non "
+"recommandé)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Définir la taille de la fenêtre ; par exemple : 80x24, ou 80x24+200+200 "
+"(COLSxLIGNES+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "GEOMETRIE"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argument caché passant l'UUID du terminal"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINAL"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Il semble y avoir un problème avec la configuration du terminal.\n"
+"Ce problème n'est pas grave, mais le corriger permettra d'améliorer votre "
+"expérience.\n"
+"Cliquez sur le lien ci-dessous pour plus d'informations :"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Problème de configuration détecté"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Ne pas réafficher ce message"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Édition du profil : %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Nouveau profil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Général"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Commande"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Couleur"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Défilement"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Compatibilité"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Avancé"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Nom du profil"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID : %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Taille du terminal"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "colonnes"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "lignes"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Réinitialiser"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Forme du curseur"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Bloc"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Barre verticale"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Souligner"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Mode clignotement"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Système"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Activer"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Désactiver"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "« Bip » du terminal"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Aucun"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Son"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Icône"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Icône et son"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Titre du terminal"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Europe du sud"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Apparence du texte"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Activer le texte en gras"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Réaligner après redimensionnement"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Police personnalisée"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Choisissez la police du terminal"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Palettes prédéfinies"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Personnalisée"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Palette de couleur"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Options"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Utiliser les couleurs du thème système"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Avancé"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Transparence"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Éclaircissement des terminaux sans le focus"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Texte"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Arrière-plan"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Sélectionner la couleur de premier plan du curseur"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Sélectionner la couleur de l'arrière-plan du curseur"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Surligner"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Sélectionner la couleur de premier plan du surlignage"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Sélectionner la couleur de l'arrière-plan du surlignage"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Éclaircissement"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Sélectionner la couleur d'éclaircissement"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Sélectionner la couleur : %s"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Sélectionner la couleur de l'arrière-plan"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Sélectionner couleur de premier plan"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Premier plan"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Noir"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Rouge"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Vert"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Orange"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Bleu"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Violet"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turquoise"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Gris"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Sélectionner la couleur : %s"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Sélectionner la couleur : %s clair"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Palettes prédéfinies"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Afficher la barre de défilement"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Défilement sur la sortie"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Défilement sur pression d'une touche"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Limiter les lignes d'historique à :"
 
 # Terminix gettext pot file
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "La touche « Retour arrière » émet"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatique"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Contrôle-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Séquence d'échappement"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "La touche « Suppr » émet"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Codage"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Caractères de largeur ambiguë"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Fins"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Larges"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Lancer la commande en tant que shell de connexion"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Exécuter une commande personnalisée au lieu du shell"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Lorsqu'une commande se termine"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Quitter le terminal"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Relancer la commande"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Conserver le terminal ouvert"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Liens personnalisés"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Une liste des liens cliquables dans le terminal personnalisés par "
+"l'utilisateur basés sur des définitions d'expressions régulières."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Changement de profil automatique"
+
+#: source/gx/terminix/profilewindow.d:1075
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
+"saisies ici.\n"
+"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
+"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
+"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
+"saisies ici.\n"
+"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
+"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
+"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Correspond à"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Ajouter"
+
+#: source/gx/terminix/profilewindow.d:1108
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "Entrez un nom_d'hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Entrez un nom_d'hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Ajouter une nouvelle correspondance"
+
+#: source/gx/terminix/profilewindow.d:1129
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "Éditer un nom_d'hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Éditer un nom_d'hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Éditer la correspondance"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "L'expression %s n'est pas une expression régulière valide"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Expression régulière"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Insensible à la casse"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Éditer les liens personnalisés"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Action"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Modifier le profil"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Le fichier %s n'est pas un fichier JSON de palette de couleurs"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Une palette de couleurs requiert 16 couleurs"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Impossible de localiser le terminal lâché"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Impossible de localiser une session pour le terminal lâché"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Par défaut"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Un émulateur de terminal pour Linux basé sur VTE"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -979,22 +1185,16 @@ msgstr ""
 "aucune copie de la MPL n'a été distribuée avec ce fichier, vous pouvez en "
 "obtenir une à http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "L'équipe du widget GTK VTE, Terminix n'aurait pas été possible sans leur "
 "travail"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD pour avoir fourni un wrapper GTK si excellent"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org pour le D, un langage si excellent"
@@ -1137,288 +1337,38 @@ msgstr "Vietnamien"
 msgid "Thai"
 msgstr "Thaï"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nouvelle Session"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nouvelle fenêtre"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Préférences"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Raccourcis"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "À propos"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Quitter"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Crédits"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Définir le répertoire de travail pour le terminal"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DOSSIER"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Définir le profil de démarrage"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "NOM_PROFIL"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Ouvrir la session specifiée"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "NOM_SESSION"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Envoyer une action à l'instance actuelle Terminix"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "NOM_ACTION"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Exécuter la commande passée"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "EXECUTER"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maximiser la fenêtre du terminal"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Mettre la fenêtre du terminal en plein écran"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Donner le focus à la fenêtre existante"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argument caché passant l'UUID du terminal"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINAL"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Il semble y avoir un problème avec la configuration du terminal.\n"
-"Ce problème n'est pas grave, mais le corriger permettra d'améliorer votre "
-"expérience.\n"
-"Cliquez sur le lien ci-dessous pour plus d'informations :"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Problème de configuration détecté"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Ne pas réafficher ce message"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Impossible de localiser le terminal lâché"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Impossible de localiser une session pour le terminal lâché"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Nom"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Général"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Apparence"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profils"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Codages affichés dans le menu :"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Activé"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Action"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Touche de raccourci"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Activer les raccourcis"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Écraser le raccourcis actuel"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1429,983 +1379,194 @@ msgstr ""
 "Désactiver le raccourcis pour l'autre option et l'assigner à celle-ci à la "
 "place ?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Par défaut"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nouveau"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Modifier"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Supprimer"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Activer la transparence, requiert un redémarrage"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Style du titre du terminal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Petit"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Aucun"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Variante de thème"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Clair"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Sombre"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Image d'arrière-plan"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Sélectionner l'image"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Tous les fichiers image"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Réinitialiser l'image de fond d'écran"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Mettre à l'échelle"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Paver"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Centrer"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Étirer"
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Éditer le nom de la session"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Utiliser une poignée large pour les séparateurs"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Éclaircir des terminaux sans le focus"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Définir le titre du nouveau terminal"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Sauvegarder le contenu du terminal"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Comportement"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Invite de commande lors de la création d'une nouvelle session"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Faire le point sur le terminal lors du survolement de la souris"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Cacher automatiquement le pointeur de la souris pendant la frappe"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Envoyer une notification bureau une fois le processus accompli"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Lors d'une nouvelle instance"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Division droite"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Division basse"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Donner le focus à la fenêtre"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Coller"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Alerter lors d'un collage dangeureux"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Supprimer le premier caractère si c'est un commentaire ou une déclaration de "
 "variable"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Options de disposition"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Ok"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Annuler"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Actif"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titre"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Chargement de session"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
-"Les options « Actif » sont toujours actives et prennent effet "
-"immédiatement.\n"
-"Les options « Chargement de session » s'appliquent seulement quand une "
-"session est chargée."
+"Copier automatiquement le texte dans le presse-papier quand sélectionné"
 
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Options de recherche"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Respecter la case"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Mots entiers seulement"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Utiliser comme expression régulière"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Recherche circulaire"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Fermer"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximiser"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Désactiver la synchronisation d'entrée pour ce terminal"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Modifier le profil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Des processus continuent de s'exécuter, fermer quand-même ?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Activer la synchronisation d'entrée pour ce terminal"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Enregistrer…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Rechercher…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Options de disposition…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Lecture seule"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Réinitialiser et effacer"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Diviser"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Restaurer"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Ouvrir le lien"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Copier l'adresse du lien"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Copier"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Tout sélectionner"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Presse-papier"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Synchroniser l'entrée"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Une erreur inattendue est survenue, aucune information supplémentaire n'est "
-"disponible"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Une erreur inattendue est survenue : %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Sauvegarder la sortie du terminal"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Tous les fichiers texte"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Tous les fichiers"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Les processus fils a quitté normalement avec le status %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Le processus fils a été interrompu par le signal %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Le processus fils a été interrompu."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Relancer"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-"Cette commande demande les droits d'administrateur sur votre ordinateur"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copier des commandes depuis l'internet peut être dangereux. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Soyez sûr de comprendre ce que fait chaque partie de la commande."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Ne pas coller"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Coller quand même"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Ignorer que « %s » n'est pas un dossier"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignorer le paramètre de session car « %s » n'existe pas"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2415,192 +1576,74 @@ msgstr ""
 "dossier de travail / exécuter une commande : choisissez l'un ou l'autre s'il "
 "vous plaît"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Voir la barre latérale de session"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Créer une nouvelle session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Changer le nom de la sesssion"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Entrer un nouveau nom pour la session"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Ouvrir…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Enregistrer"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Enregistrer sous…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Nom…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Synchroniser l'entrée"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Tous les fichiers JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Le nom de fichier « %s » n'existe pas"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Charger la session"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Impossible de charger la session en raison d'une erreur inattendue."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Erreur lors du chargement de la session"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Sauvegarder la session"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "désactivé"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "Votre version de GTK est trop vieille, vous avez besoin au moins de GTK %d."
 "%d.%d !"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Une exception inattendue est survenue"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Erreur : "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Ouvrir dans Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Ouvrir Terminix dans %s"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Ouvrir dans Terminix…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Ouvrir Terminix dans %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "Ouvrir Terminix ici…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "Ouvrir Terminix dans ce dossier"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Ouvrir Terminix ici…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Ouvrir Terminix dans ce dossier"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Application"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Application"
@@ -2640,257 +1683,248 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Voir la barre latérale de session"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Voir la barre latérale de session"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Basculer vers la session suivante"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Basculer vers la session précédente"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Basculer vers la session 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Basculer vers la session 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Basculer vers la session 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Basculer vers la session 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Basculer vers la session 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Basculer vers la session 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Basculer vers la session 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Basculer vers la session 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Basculer vers la session 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Basculer vers la session 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Session"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Fichier"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Fermer la session en cours"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Sauvegarder la session en cours"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Sauvegarder la session courante avec un nouveau nom de fichier"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Ouvrir une session sauvegardée"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Ajouter"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Ajouter un terminal à droite"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Ajouter un terminal en bas"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Redimensionner"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Redimensionner le terminal vers le haut"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Redimensionner le terminal vers le bas"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Redimensionner le terminal vers la gauche"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Redimensionner le terminal vers la droite"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "Autre"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Éditer le nom de la session"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Synchroniser l'entrée"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
 msgid "Switch"
 msgstr "Basculement vers"
 
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
+#: data/resources/ui/shortcuts.ui:249
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "Terminal suivant"
 
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
+#: data/resources/ui/shortcuts.ui:255
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "Terminal précédent"
 
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
+#: data/resources/ui/shortcuts.ui:261
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "Basculer vers le terminal du haut"
 
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
+#: data/resources/ui/shortcuts.ui:267
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "Basculer vers le terminal du bas"
 
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
+#: data/resources/ui/shortcuts.ui:273
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "Basculer vers le terminal de gauche"
 
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
+#: data/resources/ui/shortcuts.ui:279
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "Basculer vers le terminal de droite"
 
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
+#: data/resources/ui/shortcuts.ui:291
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "Basculer vers le terminal 1"
 
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
+#: data/resources/ui/shortcuts.ui:297
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "Basculer vers le terminal 2"
 
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
+#: data/resources/ui/shortcuts.ui:303
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "Basculer vers le terminal 3"
 
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
+#: data/resources/ui/shortcuts.ui:309
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "Basculer vers le terminal 4"
 
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
+#: data/resources/ui/shortcuts.ui:315
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "Basculer vers le terminal 5"
 
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
+#: data/resources/ui/shortcuts.ui:321
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "Basculer vers le terminal 6"
 
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
+#: data/resources/ui/shortcuts.ui:327
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "Basculer vers le terminal 7"
 
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
+#: data/resources/ui/shortcuts.ui:333
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "Basculer vers le terminal 8"
 
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
+#: data/resources/ui/shortcuts.ui:339
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "Basculer vers le terminal 9"
 
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
+#: data/resources/ui/shortcuts.ui:345
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "Basculer vers le terminal 10"
 
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Diviser"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Diviser à droite"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Diviser en bas"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
 #: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
 msgctxt "shortcut window"
 msgid "Find"
 msgstr "Rechercher"
 
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
+#: data/resources/ui/shortcuts.ui:371
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "Rechercher le suivant"
@@ -2900,147 +1934,133 @@ msgstr "Rechercher le suivant"
 # in the Shortcut preferences and in the future
 # the shortcut overview if available in Gnome 3.20
 # ***********************************************
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
+#: data/resources/ui/shortcuts.ui:377
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "Rechercher le précédent"
 
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
 msgid "Clipboard"
 msgstr "Presse-papier"
 
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "Copier"
 
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "Coller"
 
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Avancé"
+
+#: data/resources/ui/shortcuts.ui:407
 msgctxt "shortcut window"
 msgid "Select all"
 msgstr "Tout sélectionner"
 
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
+#: data/resources/ui/shortcuts.ui:415
 msgctxt "shortcut window"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
+#: data/resources/ui/shortcuts.ui:419
 msgctxt "shortcut window"
 msgid "Zoom in"
 msgstr "Zoom avant"
 
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
+#: data/resources/ui/shortcuts.ui:425
 msgctxt "shortcut window"
 msgid "Zoom out"
 msgstr "Zoom arrière"
 
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
+#: data/resources/ui/shortcuts.ui:431
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "Réinitialiser le niveau de zoom"
 
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "Autre"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Sauvegarder le contenu du terminal"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Fermer le terminal"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Maximiser le terminal"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Préférences du profil en cours"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Réinitialiser le terminal"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Réinitialiser et effacer le terminal"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Lecture seule"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Options de disposition"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Insérer le numéro du terminal"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Style du titre du terminal"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Un terminal scindable pour Gnome"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Nouveau terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Un terminal scindable pour GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix est un émulateur de terminal scindable."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Il vous permet :"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
@@ -3048,7 +2068,6 @@ msgstr ""
 "D'organiser les terminaux de toutes les façons en les divisant "
 "horizontalement et verticalement"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3057,14 +2076,12 @@ msgstr ""
 "Les terminaux peuvent être réorganisés en utilisant le glisser-déposer dans "
 "une même fenêtre ou entre les fenêtres"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr ""
 "Les terminaux peuvent être détachés en une nouvelle fenêtre via un glisser-"
 "déposer"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3073,18 +2090,15 @@ msgstr ""
 "L'entrée peut être synchronisée entre les terminaux de façon à ce que les "
 "commandes tapées dans un terminal soient répliquées dans les autres"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr ""
 "Les groupes de terminaux peuvent être enregistrés et chargés depuis le disque"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Les terminaux acceptent les titres personnalisés"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3094,19 +2108,16 @@ msgstr ""
 "combinaisons de couleur personnalisées peuvent être créées simplement en "
 "créant un nouveau fichier"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Transparence du fond"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr ""
 "Supporte les notifications bureau quand les processus s'achèvent sans avoir "
 "le focus"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3118,810 +2129,6 @@ msgstr ""
 "utilise des décorations côté client, quoiqu'elles puissent être désactivées "
 "si nécessaire."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix a été testé sous GNOME et sous Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Définir la taille de la fenêtre ; par exemple : 80x24, ou 80x24+200+200 "
-"(COLSxLIGNES+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "GEOMETRIE"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Fenêtre"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Éditer le nom de la session"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Synchroniser l'entrée"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Session"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Enregistrer la sortie sous…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Ouvrir"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Rechercher le suivant"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Rechercher le précédent"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-"Démarrer une instance supplémentaire en tant que nouveau processus (non "
-"recommandé)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Ajouter un terminal à droite"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Ajouter un terminal en bas"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Chercher le texte dans le terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Son"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Icône"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Icône et son"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Changement de profil automatique"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Correspond à"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Ajouter"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Ajouter une nouvelle correspondance"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Entrez un nom_d'hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Éditer la correspondance"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Éditer un nom_d'hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Image d'arrière-plan"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Sélectionner l'image"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Tous les fichiers image"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Réinitialiser l'image de fond d'écran"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Mettre à l'échelle"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Paver"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Centrer"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Étirer"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Ajouter"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Ajouter un terminal à droite"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Ajouter un terminal en bas"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-"Copier automatiquement le texte dans le presse-papier quand sélectionné"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Division à droite"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Division en bas"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Définir le titre du nouveau terminal"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TITRE"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
-"saisies ici.\n"
-"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
-"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
-"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Activer les raccourcis"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Liens personnalisés"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Une liste des liens cliquables dans le terminal personnalisés par "
-"l'utilisateur basés sur des définitions d'expressions régulières."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
-"saisies ici.\n"
-"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
-"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
-"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "L'expression %s n'est pas une expression régulière valide"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Expression régulière"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Insensible à la casse"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Éditer les liens personnalisés"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Appliquer"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Insérer le numéro du terminal"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Exécuter la commande passée"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
-"saisies ici.\n"
-"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
-"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
-"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "Entrez un nom_d'hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "Éditer un nom_d'hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Modifier le profil"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Commande"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Titre"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Texte"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Titre du terminal"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Avancé"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Maximiser la fenêtre du terminal"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Éditer le nom de la session"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Définir le titre du nouveau terminal"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Voir la barre latérale de session"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Avancé"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Des processus continuent de s'exécuter, fermer quand-même ?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Ne pas réafficher ce message"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Europe du sud"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Sélectionner la couleur : %s"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Ouvrir dans Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Ouvrir Terminix dans %s"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Ouvrir dans Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "Ouvrir Terminix ici…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "Ouvrir Terminix dans ce dossier"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Style du titre du terminal"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Palettes prédéfinies"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Sauvegarder le contenu du terminal"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-10-21 14:33+0000\n"
 "Last-Translator: Niv Baehr <bloop93@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/terminix/"
@@ -18,966 +18,1157 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.9-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "פקודה"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "כותרת"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "טקסט"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "פקודה זו מבקשת גישה ניהולית למחשב"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "העתקת פקודות מהאינטרנט עלולה להיות מסוכנת. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "נא לוודא הבנה של כל חלק בפקודה זו."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "הדבקה מתקדמת"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "הדבקה"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "ביטול"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "שם"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "חדש"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "עריכה"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "מחיקה"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "החלה"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "אישור"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "אפשרויות חיפוש"
+
+#: source/gx/terminix/terminal/search.d:134
+#, fuzzy
+msgid "Find next"
+msgstr "חיפוש הבא"
+
+#: source/gx/terminix/terminal/search.d:140
+#, fuzzy
+msgid "Find previous"
+msgstr "חיפוש הקודם"
+
+#: source/gx/terminix/terminal/search.d:187
+#, fuzzy
+msgid "Match case"
+msgstr "התאמת רישיות"
+
+#: source/gx/terminix/terminal/search.d:188
+#, fuzzy
+msgid "Match entire word only"
+msgstr "התאמה למילה שלמה בלבד"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "התאמה כביטוי רגולרי"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "גלישת שורות"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "מסוף"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "סגירה"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+#, fuzzy
+msgid "Maximize"
+msgstr "הגדלה"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "השבתת סנכרון קלט עבור מסוף זה"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "קריאה בלבד"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "פעמון מסוף"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "עריכת פרופיל"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "ישנם תהליכים שעדיין רצים, האם לסגור בכל זאת?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "הפעלת סנכרון קלט עבור מסוף זה"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "הקובץ %s אינו קובץ JSON תואם תכנית צבעים"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "תכנית לוח הצבעים דורשת 16 צבעים"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "שמירת הפלט…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "איפוס"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "איפוס וניקוי"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "פרופילים"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "קידוד"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "חיפוש…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "אפשרויות פריסה…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "הוספה ימינה"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "הוספה למטה"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "שחזור"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+#, fuzzy
+msgid "Open Link"
+msgstr "פתיחת קישור"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+#, fuzzy
+msgid "Copy Link Address"
+msgstr "העתקת כתובת קישור"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "העתקה"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "בחירת הכל"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "לוח גזירים"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "סנכרון הקלט"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "התרחשה שגיאה בלתי צפויה, אין מידע נוסף זמין"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, fuzzy, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "התרחשה שגיאה בלתי צפויה: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "שמירת פלט מסוף"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "שמירה"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "כל קובצי הטקסט"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "כל הקבצים"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "תהליך הבן יצא כרגיל במצב %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "תהליך הבן נפל עם האות %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "תהליך הבן נפל."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "הפעלה מחדש"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+#, fuzzy
+msgid "Don't Paste"
+msgstr "לא להדביק"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+#, fuzzy
+msgid "Paste Anyway"
+msgstr "להדביק בכל זאת"
+
+#: source/gx/terminix/terminal/layout.d:28
+#, fuzzy
+msgid "Layout Options"
+msgstr "אפשרויות פריסה"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "פעיל"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "כותרת"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "טעינת הפעלה"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "פקודה"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"אפשרויות פעילות תמיד פעילות ומיושמות מיד.\n"
+"אפשרויות טעינת הפעלה מיושמות רק בעת טעינת קובץ הפעלה."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "הצגת חלונית הצד להפעלה"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "יצירת הפעלה חדשה"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "הוספת מסוף מימין"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "הוספת מסוף למטה"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "מציאת טקסט במסוף"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "שינוי שם ההפעלה"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "הזנת שם עבור ההפעלה"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "פתיחה…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "שמירה בשם…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "שם…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "סנכרון קלט"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "ישנם תהליכים שעדיין רצים, האם לסגור בכל זאת?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "לא להציג הודעה זו שוב"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "כל קובצי ה־JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "הקובץ „%s” אינו קיים"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "טעינת הפעלה"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "פתיחה"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "לא ניתן לטעון הפעלה עקב שגיאה בלתי צפויה."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "שגיאה בטעינת הפעלה"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "שמירת הפעלה"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "הפעלה חדשה"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "חלון חדש"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "העדפות"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "קיצורים"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "אודות"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "יציאה"
+
+#: source/gx/terminix/application.d:291
+#, fuzzy
+msgid "Credits"
+msgstr "תודות"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "הגדרת תיקיית העבודה של המסוף"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+#, fuzzy
+msgid "Set the starting profile"
+msgstr "הגדרת הפרופיל הפותח"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "קביעת כותרת המסוף החדש"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "פתיחת ההפעלה שצוינה"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+#, fuzzy
+msgid "Send an action to current Terminix instance"
+msgstr "שליחת פעולה למופע Terminix הנוכחי"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "ביצוע הפקודה שהועברה"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "הגדלת חלון המסוף"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "הגדלת חלון המסוף"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "העברת חלון המסוף למסך מלא"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "מיקוד בחלון הקיים"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "התחלת מופע נוסף כתהליך חדש (לא מומלץ)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "קביעת גודל החלון; למשל: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+#, fuzzy
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"נראה שיש בעיה בהגדרות המסוף.\n"
+"זו אינה בעיה רצינית, אך תיקונה יכול לשפר את חווית השימוש.\n"
+"יש ללחוץ על הקישור למטה למידע נוסף:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "זוהתה בעיית תצורה"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "לא להציג הודעה זו שוב"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "עריכת פרופיל: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "פרופיל חדש"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "כללי"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "פקודה"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "צבע"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "גלילה"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "תאימות"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "מתקדם"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "שם פרופיל"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "מזהה: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "גודל מסוף"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "עמודות"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "שורות"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "איפוס"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "סמן"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "בלוק"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "IBeam"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "קו תחתון"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "מצב הבהוב"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "מערכת"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "גע"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "תוק"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "פעמון מסוף"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "ללא"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "צליל"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "סמל"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "סמל וצליל"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "כותרת מסוף"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "דרום אירופאי"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "מראה טקסט"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "אפשור טקסט מודגש"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "גלישה בעת שינוי הגודל"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "גופן מותאם אישית"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "בחירת גופן מסוף"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "תכנית צבעים"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "מותאם אישית"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "לוח צבעים"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "אפשרויות"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "שימוש בצבעי ערכת הנושא עבור חזית/רקע"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "מתקדם"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "שקיפות"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "עמעום לא ממוקד"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "טקסט"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "רקע"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "בחירת צבע סמן חזית"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "בחירת צבע סמן רקע"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "הדגשה"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "בחירת צבע הדגשת חזית"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "בחירת צבע הדגשת רקע"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "עמעום"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "בחירת צבע עמעום"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "בחירת צבע %s"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "בחירת צבע רקע"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "בחירת צבע חזית"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "חזית"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "שחור"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "אדום"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "ירוק"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "כתום"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "כחול"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "סגול"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "טורקיז"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "אפור"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "בחירת צבע %s"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, fuzzy, c-format
 msgid "Select %s Light Color"
 msgstr "בחירת צבע %s בהיר"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "תכנית צבעים"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "הצגת פס הגלילה"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 #, fuzzy
 msgid "Scroll on output"
 msgstr "גלילה בעת פלט"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 #, fuzzy
 msgid "Scroll on keystroke"
 msgstr "גלילה בעת לחיצה על מקש"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "הגבלת הגלילה ל:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "מקש Backspace מחולל"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 #, fuzzy
 msgid "Automatic"
 msgstr "אוטומטי"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "רצף מילוט"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "מקש Delete מחולל"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "קידוד"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 #, fuzzy
 msgid "Ambiguous-width characters"
 msgstr "תוים ברוחב משתנה"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "צר"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "רחב"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "הרצת פקודה כמעטפת כניסה"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "הרצת פקודה מותאמת אישית במקום המעטפת"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 #, fuzzy
 msgid "When command exits"
 msgstr "בעת יציאת פקודה"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "יציאה מהמסוף"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "הפעלת הפקודה מחדש"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "השארת המסוף פתוח"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "גופן מותאם אישית"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "מעבר פרופיל אוטומטי"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "התאמה"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+#, fuzzy
+msgid "Add"
+msgstr "הוספה"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "הוספת התאמה חדשה"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "עריכת התאמה"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "לא תלוי רישיות"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "פעולה"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "עריכת פרופיל"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "הקובץ %s אינו קובץ JSON תואם תכנית צבעים"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "תכנית לוח הצבעים דורשת 16 צבעים"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "לא ניתן לאתר את המסוף שנשמט"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "לא ניתן לאתר הפעלה עבור המסוף שנשמט"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "ברירת מחדל"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "פרופיל"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "אמולטור מסוף מבוסס VTE עבור לינוקס"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -988,20 +1179,14 @@ msgstr ""
 "הופץ עותק של MPL יחד עם קובץ זה, ניתן להשיג כזה בכתובת http://mozilla.org/"
 "MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "צוות היישומון GTK VTE, שלולא עבודתם Terminix לא היה מתאפשר"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD שסיפק עוטף Gtk נהדר"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org עבור השפה הנהדרת D"
@@ -1141,291 +1326,39 @@ msgstr "וויאטנמית"
 msgid "Thai"
 msgstr "תאי"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "הפעלה חדשה"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "חלון חדש"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "העדפות"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "קיצורים"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "אודות"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "יציאה"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-#, fuzzy
-msgid "Credits"
-msgstr "תודות"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "הגדרת תיקיית העבודה של המסוף"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-#, fuzzy
-msgid "Set the starting profile"
-msgstr "הגדרת הפרופיל הפותח"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "פתיחת ההפעלה שצוינה"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-#, fuzzy
-msgid "Send an action to current Terminix instance"
-msgstr "שליחת פעולה למופע Terminix הנוכחי"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "ביצוע הפקודה שהועברה"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "הגדלת חלון המסוף"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "העברת חלון המסוף למסך מלא"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "מיקוד בחלון הקיים"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-#, fuzzy
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"נראה שיש בעיה בהגדרות המסוף.\n"
-"זו אינה בעיה רצינית, אך תיקונה יכול לשפר את חווית השימוש.\n"
-"יש ללחוץ על הקישור למטה למידע נוסף:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "זוהתה בעיית תצורה"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "לא להציג הודעה זו שוב"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "לא ניתן לאתר את המסוף שנשמט"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "לא ניתן לאתר הפעלה עבור המסוף שנשמט"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "שם"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "פרופיל"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "כללי"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "מראה"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "פרופילים"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "קידודים המוצגים בתפריט:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "מופעל"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "פעולה"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "מקש קיצור"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "קיצורים"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "דרוס קיצור קיים"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, fuzzy, c-format
 msgid ""
@@ -1435,986 +1368,192 @@ msgstr ""
 "קיצור הדרך %s כבר מוגדר עבור %s\n"
 "האם לבטל את קיצור הדרך עבור הפעולה האחרת ולהגדיר אותו כאן במקומה?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "ברירת מחדל"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "חדש"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "עריכה"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "מחיקה"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "אפשור שקיפות, נדרשת הפעלה מחדש"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "סגנון כותרת מסוף"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "רגיל"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "קטן"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "ללא"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 #, fuzzy
 msgid "Theme variant"
 msgstr "גוון ערכת נושא"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "בהיר"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "כהה"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "תמונת רקע"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "בחירת תמונה"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "כל קובצי התמונה"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "איפוס תמונת רקע"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "אריח"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "מרכז"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "מתיחה"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "שם הפעלה ברירת מחדל"
+
+#: source/gx/terminix/prefwindow.d:682
 #, fuzzy
 msgid "Use a wide handle for splitters"
 msgstr "שימוש בידית רחבה עבור המפרידים"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "עמעום מסופים בלתי ממוקדים"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "הגדרת תיקיית העבודה של המסוף"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "גודל"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr "אחוז גובה"
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr "אחוז רוחב"
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "שמירת תכני מסוף"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "התנהגות"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "בקשה בעת יצירת הפעלה חדשה"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "מיקוד מסוף בעת מעבר העכבר מעליו"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "הסתרה אוטומטית של מצביע העכבר בעת הקלדה"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "שליחת התראה לשולחן העבודה בסיום תהליך"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "במופע חדש"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "פיצול ימינה"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "פיצול למטה"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "מיקוד חלון"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "הדבקה"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr "תמיד להשתמש בתיבת דו־השיח של הדבקה מתקדמת"
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "אזהרה בעת ניסיון להדבקה לא בטוחה"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "הסרת התו הראשון בהדבקה במקרה של הערה או הצהרת משתנים"
 
-#: source/gx/terminix/terminal/layout.d:28
-#, fuzzy
-msgid "Layout Options"
-msgstr "אפשרויות פריסה"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "אישור"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "ביטול"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "פעיל"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "כותרת"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "טעינת הפעלה"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
-"אפשרויות פעילות תמיד פעילות ומיושמות מיד.\n"
-"אפשרויות טעינת הפעלה מיושמות רק בעת טעינת קובץ הפעלה."
 
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "אפשרויות חיפוש"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-#, fuzzy
-msgid "Match case"
-msgstr "התאמת רישיות"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-#, fuzzy
-msgid "Match entire word only"
-msgstr "התאמה למילה שלמה בלבד"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "התאמה כביטוי רגולרי"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "גלישת שורות"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "מסוף"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "סגירה"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-#, fuzzy
-msgid "Maximize"
-msgstr "הגדלה"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "השבתת סנכרון קלט עבור מסוף זה"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "עריכת פרופיל"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "ישנם תהליכים שעדיין רצים, האם לסגור בכל זאת?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "הפעלת סנכרון קלט עבור מסוף זה"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "שמירה…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "חיפוש…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "אפשרויות פריסה…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "קריאה בלבד"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "איפוס וניקוי"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "פיצול"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "שחזור"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-#, fuzzy
-msgid "Open Link"
-msgstr "פתיחת קישור"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-#, fuzzy
-msgid "Copy Link Address"
-msgstr "העתקת כתובת קישור"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "העתקה"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "בחירת הכל"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "לוח גזירים"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "סנכרון הקלט"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "התרחשה שגיאה בלתי צפויה, אין מידע נוסף זמין"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, fuzzy, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "התרחשה שגיאה בלתי צפויה: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "שמירת פלט מסוף"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "כל קובצי הטקסט"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "כל הקבצים"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "תהליך הבן יצא כרגיל במצב %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "תהליך הבן נפל עם האות %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "תהליך הבן נפל."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "הפעלה מחדש"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "פקודה זו מבקשת גישה ניהולית למחשב"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "העתקת פקודות מהאינטרנט עלולה להיות מסוכנת. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "נא לוודא הבנה של כל חלק בפקודה זו."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-#, fuzzy
-msgid "Don't Paste"
-msgstr "לא להדביק"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-#, fuzzy
-msgid "Paste Anyway"
-msgstr "להדביק בכל זאת"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "מתעלם כי „%s” אינה תיקייה"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "מתעלם מפרמטר הפעלה כי „%s” אינו קיים"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2423,193 +1562,75 @@ msgstr ""
 "לא ניתן לטעון הפעלה וגם לקבוע אפשרות עבור פרופיל/תיקיית עבודה/פקודה לביצוע, "
 "נא לבחור האחד או האחר"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "הצגת חלונית הצד להפעלה"
-
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "יצירת הפעלה חדשה"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "שינוי שם ההפעלה"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "הזנת שם עבור ההפעלה"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "פתיחה…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "שמירה"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "שמירה בשם…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "שם…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "סנכרון קלט"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "כל קובצי ה־JSON"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "הקובץ „%s” אינו קיים"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "טעינת הפעלה"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "לא ניתן לטעון הפעלה עקב שגיאה בלתי צפויה."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "שגיאה בטעינת הפעלה"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "שמירת הפעלה"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "מושבת"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "גרסת GTK ישנה מדי, נדרש GTK  %d.%d.%d לפחות!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 #, fuzzy
 msgid "Unexpected exception occurred"
 msgstr "אירעה חריגה לא צפויה"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "שגיאה: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "פתיחה ב־Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "פתיחת Terminix ב־%s"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "פתיחה ב־Terminix…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "פתיחת Terminix ב־%s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "פתיחת Terminix כאן…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "פתיחת Terminix בתיקייה זו"
+
 #: data/nautilus/open-terminix.py:93
 #, fuzzy
 msgid "Open Terminix Here…"
 msgstr "פתיחת Terminix כאן…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 #, fuzzy
 msgid "Open Terminix In This Directory"
 msgstr "פתיחת Terminix בתיקייה זו"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "יישום"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "יישום"
@@ -2652,439 +1673,409 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "הצגת חלונית הצד להפעלה"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "הצגת מחליף ההפעלות"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "מעבר להפעלה הבאה"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "מעבר להפעלה הקודמת"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "מעבר להפעלה 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "מעבר להפעלה 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "מעבר להפעלה 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "מעבר להפעלה 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "מעבר להפעלה 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "מעבר להפעלה 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "מעבר להפעלה 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "מעבר להפעלה 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "מעבר להפעלה 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "מעבר להפעלה 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "הפעלה"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "קובץ"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "סגירת ההפעלה הנוכחית"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "שמירת ההפעלה הנוכחית"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "שמירת ההפעלה הנוכחית בקובץ חדש"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "פתיחת הפעלה שנשמרה"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "הוספה"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "הוספת מסוף מימין"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "הוספת מסוף למטה"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "שינוי גודל"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "שינוי גודל המסוף כלפי מעלה"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "שינוי גודל המסוף כלפי מטה"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "שינוי גודל המסוף לשמאל"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "שינוי גודל המסוף לימין"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "אחר"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "עריכת שם ההפעלה"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "סנכרון הקלט"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
 msgid "Switch"
 msgstr "מעבר"
 
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
+#: data/resources/ui/shortcuts.ui:249
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "מעבר למסוף הבא"
 
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
+#: data/resources/ui/shortcuts.ui:255
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "מעבר למסוף הקודם"
 
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
+#: data/resources/ui/shortcuts.ui:261
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "מעבר למסוף למעלה"
 
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
+#: data/resources/ui/shortcuts.ui:267
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "מעבר למסוף למטה"
 
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
+#: data/resources/ui/shortcuts.ui:273
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "מעבר למסוף משמאל"
 
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
+#: data/resources/ui/shortcuts.ui:279
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "מעבר למסוף מימין"
 
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
+#: data/resources/ui/shortcuts.ui:291
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "מעבר למסוף 1"
 
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
+#: data/resources/ui/shortcuts.ui:297
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "מעבר למסוף 2"
 
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
+#: data/resources/ui/shortcuts.ui:303
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "מעבר למסוף 3"
 
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
+#: data/resources/ui/shortcuts.ui:309
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "מעבר למסוף 4"
 
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
+#: data/resources/ui/shortcuts.ui:315
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "מעבר למסוף 5"
 
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
+#: data/resources/ui/shortcuts.ui:321
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "מעבר למסוף 6"
 
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
+#: data/resources/ui/shortcuts.ui:327
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "מעבר למסוף 7"
 
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
+#: data/resources/ui/shortcuts.ui:333
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "מעבר למסוף 8"
 
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
+#: data/resources/ui/shortcuts.ui:339
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "מעבר למסוף 9"
 
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
+#: data/resources/ui/shortcuts.ui:345
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "מעבר למסוף 10"
 
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "פיצול"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "פיצול ימינה"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "פיצול למטה"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
 #: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Find"
 msgstr "חיפוש"
 
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
+#: data/resources/ui/shortcuts.ui:371
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "חיפוש הבא"
 
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
+#: data/resources/ui/shortcuts.ui:377
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "חיפוש הקודם"
 
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
 msgid "Clipboard"
 msgstr "לוח גזירים"
 
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "העתקה"
 
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "הדבקה"
 
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
+#: data/resources/ui/shortcuts.ui:401
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "הדבקה מתקדמת"
+
+#: data/resources/ui/shortcuts.ui:407
 msgctxt "shortcut window"
 msgid "Select all"
 msgstr "בחירת הכל"
 
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
+#: data/resources/ui/shortcuts.ui:415
 msgctxt "shortcut window"
 msgid "Zoom"
 msgstr "תקריב"
 
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
+#: data/resources/ui/shortcuts.ui:419
 msgctxt "shortcut window"
 msgid "Zoom in"
 msgstr "התקרבות"
 
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
+#: data/resources/ui/shortcuts.ui:425
 msgctxt "shortcut window"
 msgid "Zoom out"
 msgstr "התרחקות"
 
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
+#: data/resources/ui/shortcuts.ui:431
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "גודל רגיל"
 
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "אחר"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "שמירת תכני מסוף"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "סגירת מסוף"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "הגדלת המסוף"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "העדפות פרופיל נוכחיות"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "איפוס המסוף"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "איפוס וניקוי המסוף"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "מיתוג קריאה בלבד"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "אפשרויות פריסה"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "סגירת מסוף"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "סגנון כותרת מסוף"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "מסוף בריצוף עבור GNOME"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "מסוף חדש"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "מסוף בריצוף עבור GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix הוא מדמה מסוף בריצוף."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "ביכולתו:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
 msgstr "פריסת מסופים בכל דרך באמצעות פיצולם, אופקית או אנכית"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
 "windows"
 msgstr "ארגון מחדש של מסופים באמצעות גרירה ושחרור מחוץ לחלונות ובתוכם"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "ניתוק מסופים לחלון חדש באמצעות גרירה ושחרור"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
 "terminal are replicated to the others"
 msgstr "סנכרון קלט בין מסופים כך שפקודה המוזנת לאחד מועתקת לאחרים"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "שמירה וטעינה של קיבוץ המסופים"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "תמיכה בהתאמה אישית של כותרות המסופים"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3092,17 +2083,14 @@ msgid ""
 msgstr ""
 "אחסון תכניות צבעים בקבצים ויצירת תכניות צבעים חדשות באמצעות יצירת קובץ חדש"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "רקע שקוף"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "תמיכה בהתראות בסיום תהליכים מחוץ לתצוגה"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3112,782 +2100,6 @@ msgstr ""
 "היישום נכתב באמצעות GTK 3 ונעשה מאמץ להתאימו להנחיות לממשק אנוש (HIG) של "
 "GNOME. כתוצאה מכך, נעשה שימוש בקישוטי צד־לקוח, אם כי ניתן להשביתם בעת הצורך."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix נבדק עם GNOME ועם Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "קביעת גודל החלון; למשל: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "חלון"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "עריכת שם ההפעלה"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "סנכרון הקלט"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "הפעלה"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "שמירת הפלט…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "פתיחה"
-
-#: source/gx/terminix/terminal/search.d:134
-#, fuzzy
-msgid "Find next"
-msgstr "חיפוש הבא"
-
-#: source/gx/terminix/terminal/search.d:140
-#, fuzzy
-msgid "Find previous"
-msgstr "חיפוש הקודם"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "התחלת מופע נוסף כתהליך חדש (לא מומלץ)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "הוספת מסוף מימין"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "הוספת מסוף למטה"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "מציאת טקסט במסוף"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "צליל"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "סמל"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "סמל וצליל"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "מעבר פרופיל אוטומטי"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "התאמה"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-#, fuzzy
-msgid "Add"
-msgstr "הוספה"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "הוספת התאמה חדשה"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "עריכת התאמה"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "תמונת רקע"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "בחירת תמונה"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "כל קובצי התמונה"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "איפוס תמונת רקע"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "אריח"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "מרכז"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "מתיחה"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "הוספה"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "הוספת מסוף מימין"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "הוספת מסוף למטה"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "הוספה ימינה"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "הוספה למטה"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "קביעת כותרת המסוף החדש"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "קיצורים"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "גופן מותאם אישית"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "לא תלוי רישיות"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "החלה"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "סגירת מסוף"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "ביצוע הפקודה שהועברה"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "עריכת פרופיל"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "פקודה"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "כותרת"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "טקסט"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "כותרת מסוף"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "הדבקה מתקדמת"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "הגדלת חלון המסוף"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "שם הפעלה ברירת מחדל"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "הגדרת תיקיית העבודה של המסוף"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "גודל"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr "אחוז גובה"
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr "אחוז רוחב"
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr "תמיד להשתמש בתיבת דו־השיח של הדבקה מתקדמת"
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "הצגת מחליף ההפעלות"
-
-#: data/resources/ui/shortcuts.ui:401
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "הדבקה מתקדמת"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "ישנם תהליכים שעדיין רצים, האם לסגור בכל זאת?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "לא להציג הודעה זו שוב"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "דרום אירופאי"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "בחירת צבע %s"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "פתיחה ב־Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "פתיחת Terminix ב־%s"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "פתיחה ב־Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "פתיחת Terminix כאן…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "פתיחת Terminix בתיקייה זו"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "סגנון כותרת מסוף"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "תכנית צבעים"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "שמירת תכני מסוף"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-10-30 04:29+0000\n"
 "Last-Translator: Arrizal Amin <arrizalamin@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/terminix/"
@@ -18,964 +18,1140 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.9-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
-#, c-format
-msgid "Editing Profile: %s"
-msgstr "Menyunting Profil: %s"
-
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
-msgid "New Profile"
-msgstr "Profil Baru"
-
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
-msgid "General"
-msgstr "Umum"
-
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
 msgstr "Perintah"
 
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
-msgid "Color"
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
-msgid "Scrolling"
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr "PerbaruiJudul"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
-msgid "Compatibility"
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
-msgid "Profile name"
-msgstr "Nama profil"
-
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
-#, c-format
-msgid "ID: %s"
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
-#, fuzzy
-msgid "Terminal size"
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Perintah ini meminta akses Administrasi ke komputer kamu"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Menyalin perintah dari internet bisa jadi berbahaya. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Pastikan anda mengerti apa yang dilakukan setiap bagian perintah ini."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Tempel"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Batal"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Ok"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Opsi Pencarian"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
 msgstr "Terminal"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
-msgid "columns"
-msgstr ""
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Tutup"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
-msgid "rows"
-msgstr ""
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maksimalkan"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr ""
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Nonfungsikan sinkronisasi masukan untuk terminal ini"
 
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
-msgid "Cursor"
-msgstr ""
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Hanya-Baca"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Block"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "IBeam"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Underline"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
-msgid "Blink mode"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "System"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "On"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "Off"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
 #: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
+#: source/gx/terminix/profilewindow.d:237
 #, fuzzy
 msgid "Terminal bell"
 msgstr "Terminal"
 
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Sunting Profil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Terdapat proses yang masih berjalan, tetap tutup?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Fungsikan sinkronisasi masukan untuk terminal ini"
+
+#: source/gx/terminix/terminal/terminal.d:692
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:752
+#, fuzzy
+msgid "Save Output…"
+msgstr "Simpan Sebagai…"
+
+#: source/gx/terminix/terminal/terminal.d:753
 #: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
+msgid "Reset"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profil"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Enkoding"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Cari…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Opsi Tata Letak…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+#, fuzzy
+msgid "Add Right"
+msgstr "Pisah Kanan"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Pulihkan"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Buka Tautan"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Salin Alamat Tautan"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Salin"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Papan Klip"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Sinkronisasi masukan"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Terjadi galat tak terduga, tidak ada informasi tambahan yang tersedia"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Terjadi galat tak terduga: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Simpan Keluaran Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Simpan"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Semua Berkas Teks"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Semua Berkas"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Proses anak keluar secara normal dengan status %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Proses anak dibatalkan dengan sinyal %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Proses anak telah dibatalkan."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Jalankan ulang"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Jangan Tempel"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Tempel Saja"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opsi Tata Letak"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Aktif"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Judul"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Muatan Sesi"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Perintah"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Opsi aktif selalu berefek dan diaktifkan langsung.\n"
+"Opsi Muatan Sesi hanya diaktifkan ketika memuat berkas sesi."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Lihat bilah samping sesi"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Buat sesi baru"
+
+#: source/gx/terminix/appwindow.d:360
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Terminal"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:369
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Ubah Nama Sesi"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Ketik nama baru untuk sesi"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Buka…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Simpan Sebagai…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Nama…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Sinkronisasi Masukan"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Terdapat proses yang masih berjalan, tetap tutup?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Jangan tampilkan pesan ini lagi"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Berkas Semua JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Nama Berkas '%s' tidak ada"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Muat Sesi"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Buka"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Tidak dapat memuat sesi dikarenakan galat tak terduga."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Galat Memuat Sesi"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Simpan Sesi"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Sesi Baru"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Jendela Baru"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Preferensi"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Pintasan"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Tentang"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Keluar"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Kredit"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Atur direktori kerja terminal"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DIREKTORI"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Atur profil awalan"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "NAMA_PROFIL"
+
+#: source/gx/terminix/application.d:606
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Atur direktori kerja terminal"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Buka sesi spesifik"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "NAMA_SESI"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Kirim aksi ke Terminix yang sekarang saat ini"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "NAMA_AKSI"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Eksekusi perintah yang terlewati"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maksimalkan jendela terminal"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Maksimalkan jendela terminal"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Layar-penuh jendela terminal"
+
+#: source/gx/terminix/application.d:613
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "Layar-penuh jendela terminal"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Sembunyikan argumentasi untuk melewati UUID terminal"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINAL"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Sepertinya ada isu dengan konfigurasi terminal.\n"
+"Isu ini tidak serius, tapi memperbaikinya akan memperbagus pengalaman anda.\n"
+"Klik tautan dibawah untuk info selanjutnya:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Isu Konfigurasi Terdeteksi"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Jangan tampilkan pesan ini lagi"
+
+#: source/gx/terminix/profilewindow.d:93
+#, c-format
+msgid "Editing Profile: %s"
+msgstr "Menyunting Profil: %s"
+
+#: source/gx/terminix/profilewindow.d:95
+msgid "New Profile"
+msgstr "Profil Baru"
+
+#: source/gx/terminix/profilewindow.d:104
+msgid "General"
+msgstr "Umum"
+
+#: source/gx/terminix/profilewindow.d:106
+msgid "Color"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:107
+msgid "Scrolling"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:108
+msgid "Compatibility"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:165
+msgid "Profile name"
+msgstr "Nama profil"
+
+#: source/gx/terminix/profilewindow.d:174
+#, c-format
+msgid "ID: %s"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:181
+#, fuzzy
+msgid "Terminal size"
+msgstr "Terminal"
+
+#: source/gx/terminix/profilewindow.d:191
+msgid "columns"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:197
+msgid "rows"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
+msgid "Cursor"
+msgstr ""
+
 #: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
+msgid "Block"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "IBeam"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "Underline"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:226
+msgid "Blink mode"
+msgstr ""
+
 #: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+msgid "System"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:229
+msgid "On"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:229
+msgid "Off"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 #, fuzzy
 msgid "Terminal title"
 msgstr "Terminal"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 #, fuzzy
 msgid "Select Dim Color"
 msgstr "Pilih Semua"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr "Pilih Lencana Warna"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+msgid "Export Color Scheme"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Enkoding"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr ""
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Sunting Profil"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Bawaan"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr ""
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -983,20 +1159,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1136,289 +1306,40 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Sesi Baru"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Jendela Baru"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Preferensi"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Pintasan"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Tentang"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Keluar"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Kredit"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Atur direktori kerja terminal"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DIREKTORI"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Atur profil awalan"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "NAMA_PROFIL"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Buka sesi spesifik"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "NAMA_SESI"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Kirim aksi ke Terminix yang sekarang saat ini"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "NAMA_AKSI"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Eksekusi perintah yang terlewati"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "EKSEKUSI"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maksimalkan jendela terminal"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Layar-penuh jendela terminal"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "Layar-penuh jendela terminal"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Sembunyikan argumentasi untuk melewati UUID terminal"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINAL"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Sepertinya ada isu dengan konfigurasi terminal.\n"
-"Isu ini tidak serius, tapi memperbaikinya akan memperbagus pengalaman anda.\n"
-"Klik tautan dibawah untuk info selanjutnya:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Isu Konfigurasi Terdeteksi"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Jangan tampilkan pesan ini lagi"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 #, fuzzy
 msgid "Appearance"
 msgstr "Preferensi"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profil"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Pintasan"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1426,1167 +1347,259 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Bawaan"
-
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:620
+#, fuzzy
+msgid "Select Image"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/prefwindow.d:623
+#, fuzzy
+msgid "All Image Files"
+msgstr "Semua Berkas Teks"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Nama sesi bawaan"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Tampilkan judul terminal meskipun itu hanya satu-satunya terminal"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Pisah Kanan"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Pisah Bawah"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 #, fuzzy
 msgid "Focus Window"
 msgstr "Jendela Baru"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Tempel"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opsi Tata Letak"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Ok"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Batal"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Aktif"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Judul"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Muatan Sesi"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Opsi aktif selalu berefek dan diaktifkan langsung.\n"
-"Opsi Muatan Sesi hanya diaktifkan ketika memuat berkas sesi."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Opsi Pencarian"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Tutup"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maksimalkan"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Nonfungsikan sinkronisasi masukan untuk terminal ini"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Sunting Profil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Terdapat proses yang masih berjalan, tetap tutup?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Fungsikan sinkronisasi masukan untuk terminal ini"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Simpan…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Cari…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Opsi Tata Letak…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Hanya-Baca"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Pisah"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Pulihkan"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Buka Tautan"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Salin Alamat Tautan"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Salin"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Papan Klip"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Sinkronisasi masukan"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Terjadi galat tak terduga, tidak ada informasi tambahan yang tersedia"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Terjadi galat tak terduga: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Simpan Keluaran Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Semua Berkas Teks"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Semua Berkas"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Proses anak keluar secara normal dengan status %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Proses anak dibatalkan dengan sinyal %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Proses anak telah dibatalkan."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Jalankan ulang"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Perintah ini meminta akses Administrasi ke komputer kamu"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Menyalin perintah dari internet bisa jadi berbahaya. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Pastikan anda mengerti apa yang dilakukan setiap bagian perintah ini."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Jangan Tempel"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Tempel Saja"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Lihat bilah samping sesi"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Buat sesi baru"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Ubah Nama Sesi"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Ketik nama baru untuk sesi"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Buka…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Simpan"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Simpan Sebagai…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Nama…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Sinkronisasi Masukan"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Berkas Semua JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Nama Berkas '%s' tidak ada"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Muat Sesi"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Tidak dapat memuat sesi dikarenakan galat tak terduga."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Galat Memuat Sesi"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Simpan Sesi"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr ""
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr ""
@@ -2626,1208 +1639,356 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
-msgctxt "shortcut window"
-msgid "Switch to next session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
-msgctxt "shortcut window"
-msgid "Switch to previous session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
-msgctxt "shortcut window"
-msgid "Switch to session 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
-msgctxt "shortcut window"
-msgid "Switch to session 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
-msgctxt "shortcut window"
-msgid "Switch to session 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
-msgctxt "shortcut window"
-msgid "Switch to session 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
-msgctxt "shortcut window"
-msgid "Switch to session 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
-msgctxt "shortcut window"
-msgid "Switch to session 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
-msgctxt "shortcut window"
-msgid "Switch to session 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
-msgctxt "shortcut window"
-msgid "Switch to session 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
-msgctxt "shortcut window"
-msgid "Switch to session 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
-msgctxt "shortcut window"
-msgid "Switch to session 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
-msgid "Session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
-msgctxt "shortcut window"
-msgid "File"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
-msgctxt "shortcut window"
-msgid "Close the current session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
-msgctxt "shortcut window"
-msgid "Save the current session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
-msgctxt "shortcut window"
-msgid "Save the current session with new filename"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
-msgctxt "shortcut window"
-msgid "Open a saved session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
-#: data/resources/ui/shortcuts.ui:197
-msgctxt "shortcut window"
-msgid "Resize"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
-#: data/resources/ui/shortcuts.ui:201
-msgctxt "shortcut window"
-msgid "Resize the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
-#: data/resources/ui/shortcuts.ui:207
-msgctxt "shortcut window"
-msgid "Resize the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:213
-msgctxt "shortcut window"
-msgid "Resize the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:219
-msgctxt "shortcut window"
-msgid "Resize the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Pisah kanan"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Pisah bawah"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr "Terminal"
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "Terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-msgid "Supports notifications when processes are completed out of view"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-#, fuzzy
-msgid "Window"
-msgstr "Jendela Baru"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Ubah nama sesi"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Sinkronisasi masukan"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sesi"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-#, fuzzy
-msgid "Save Output…"
-msgstr "Simpan Sebagai…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Buka"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr ""
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Terminal"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-#, fuzzy
-msgid "Select Image"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-#, fuzzy
-msgid "All Image Files"
-msgstr "Semua Berkas Teks"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Terminal"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Terminal"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-#, fuzzy
-msgid "Add Right"
-msgstr "Pisah Kanan"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Atur direktori kerja terminal"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Pintasan"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Eksekusi perintah yang terlewati"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Sunting Profil"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Perintah"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr "PerbaruiJudul"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Tinggi terminal"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Maksimalkan jendela terminal"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Nama sesi bawaan"
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Tampilkan judul terminal meskipun itu hanya satu-satunya terminal"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
 #: data/resources/ui/shortcuts.ui:61
 #, fuzzy
 msgctxt "shortcut window"
 msgid "View session switcher"
 msgstr "Lihat bilah samping sesi"
 
+#: data/resources/ui/shortcuts.ui:67
+msgctxt "shortcut window"
+msgid "Switch to next session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:73
+msgctxt "shortcut window"
+msgid "Switch to previous session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:79
+msgctxt "shortcut window"
+msgid "Switch to session 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:85
+msgctxt "shortcut window"
+msgid "Switch to session 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:91
+msgctxt "shortcut window"
+msgid "Switch to session 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:97
+msgctxt "shortcut window"
+msgid "Switch to session 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:103
+msgctxt "shortcut window"
+msgid "Switch to session 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:109
+msgctxt "shortcut window"
+msgid "Switch to session 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:115
+msgctxt "shortcut window"
+msgid "Switch to session 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:121
+msgctxt "shortcut window"
+msgid "Switch to session 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:127
+msgctxt "shortcut window"
+msgid "Switch to session 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:133
+msgctxt "shortcut window"
+msgid "Switch to session 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:144
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Session"
+msgstr "Sesi"
+
+#: data/resources/ui/shortcuts.ui:149
+msgctxt "shortcut window"
+msgid "File"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:153
+msgctxt "shortcut window"
+msgid "Close the current session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:159
+msgctxt "shortcut window"
+msgid "Save the current session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:165
+msgctxt "shortcut window"
+msgid "Save the current session with new filename"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:171
+msgctxt "shortcut window"
+msgid "Open a saved session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Terminal"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Terminal"
+
+#: data/resources/ui/shortcuts.ui:197
+msgctxt "shortcut window"
+msgid "Resize"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:201
+msgctxt "shortcut window"
+msgid "Resize the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:207
+msgctxt "shortcut window"
+msgid "Resize the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:213
+msgctxt "shortcut window"
+msgid "Resize the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:219
+msgctxt "shortcut window"
+msgid "Resize the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Ubah nama sesi"
+
+#: data/resources/ui/shortcuts.ui:237
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Sinkronisasi masukan"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr ""
+
 #: data/resources/ui/shortcuts.ui:401
 msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr ""
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:467
 #, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Terdapat proses yang masih berjalan, tetap tutup?"
+msgctxt "shortcut window"
+msgid "Reset the terminal"
+msgstr "Terminal"
 
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:491
 #, fuzzy
-msgid "Do not show this again"
-msgstr "Jangan tampilkan pesan ini lagi"
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Terminal"
 
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
-msgstr "Pilih Lencana Warna"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
@@ -3835,26 +1996,76 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
-msgid "Export Color Scheme"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
+msgid "Supports notifications when processes are completed out of view"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-11-03 14:46+0000\n"
 "Last-Translator: Gabriele Lucci <gabrielelucci.0@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/terminix/"
@@ -18,961 +18,1137 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.9-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Comando"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Testo"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Avanzate"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Incolla"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Cancella"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Nome"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Nuovo"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Modifica"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Elimina"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Opzioni di ricerca"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Campanella del terminale"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "File %s non è uno schema di colori JSON compatibile"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "La tavolozza combinazione di colori richiede 16 colori"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Azzera"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profili"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Codifica"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opzioni del Layout"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Attiva"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titolo"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Carico di sessione"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Comando"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:360
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Titolo terminale"
+
+#: source/gx/terminix/appwindow.d:364
+#, fuzzy
+msgid "Add terminal down"
+msgstr "Mantieni il terminale aperto"
+
+#: source/gx/terminix/appwindow.d:369
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Chiude il terminale"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Apri…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Sincronizza input"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Non mostrare più questo messaggio"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Il File '%s' non esiste."
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nuova sessione"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nuova finestra"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "preferenze"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Tasti di scelta rapida"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Informazioni"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Esci"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Riconoscimenti"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Impostare la directory di lavoro del terminale"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DIRECTORY"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Impostare il profilo di partenza"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:606
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Impostare la directory di lavoro del terminale"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Aprire la sessione specificata"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Inviare un'azione all'istanza corrente di Terminix"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Eseguire il comando passato"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Massimizzare la finestra del terminale"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Massimizzare la finestra del terminale"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Schermo intero la finestra del terminale"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Messa a fuoco finestra esistente"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argomento nascosto per passare l'UUID del terminale"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Sembra esserci un problema con la configurazione del terminale.\n"
+"Questo problema non è grave, ma correggerla migliorerà la tua esperienza.\n"
+"Clicca sul link qui sotto per ulteriori informazioni:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Problema di configurazione rilevato"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Non mostrare più questo messaggio"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Modifica Profilo %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Nuovo profilo"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Generale"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Comando"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Colore"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Scorrimento"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Compatibilità"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Avanzate"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Nome del profilo"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Dimensione del terminale"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "colonne"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "righe"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Azzera"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Cursore"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Blocco"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "IBeam"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Sottolineatura"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Modalità di lampeggio"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Sistema"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "attivo"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "disattivato"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Campanella del terminale"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Nessuno"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Titolo terminale"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Sud europeo"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Aspetto del testo"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Permettere il testo in grassetto"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Ridisegna durante il ridimensionamento"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Tipo di carattere personalizzato"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Scegliere un tipo di carattere per il terminale"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Combinazione di colori"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Tavolozza dei colori"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Opzioni"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Utilizzare colori del tema per primo piano/sfondo"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Avanzate"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Trasparenza"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Dim non focalizzata"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Testo"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Sfondo"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Selezionare il colore di primo piano del cursore"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Selezionare il colore di sfondo del cursore"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Evidenziare"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Selezionare il colore di evidenziazione in primo piano"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Selezionare il colore di sfondo di evidenziazione"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Dim"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Seleziona il colore della dim"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Seleziona %s colore"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Selezionare il colore di sfondo"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Selezionare il colore di primo piano"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "In primo piano"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Nero"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Rosso"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Verde"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Arancione"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Blu"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Viola"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turchese"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Grigio"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Seleziona %s colore"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Selezionare colore chiaro %s"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Combinazione di colori"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Mostra barra di scorrimento"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Scorri con nuovo output"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 #, fuzzy
 msgid "Scroll on keystroke"
 msgstr "Scrolla sulla battitura"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Scrollback limite per:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Tasto BACKSPACE genera"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatico"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "CTRL-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Sequenza di escape"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Canc genera"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Codifica"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Caratteri con larghezza ambigua"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Stretta"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Largo"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Eseguire il comando come una shell di login"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Eseguire un comando personalizzato della mia shell"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Quando il comando termina"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Chiude il terminale"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Riavvia il comando"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Mantieni il terminale aperto"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "Tipo di carattere personalizzato"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Azione"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "File %s non è uno schema di colori JSON compatibile"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "La tavolozza combinazione di colori richiede 16 colori"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Impossibile individuare terminale lasciato"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Impossibile trovare la sessione per il terminale lasciato"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Predefinito"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profilo"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Emulatore di terminale per Linux basato su un VTE"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -983,22 +1159,16 @@ msgstr ""
 "Mozilla, v. 2.0. Se una copia della MPL non è stata distribuita con questo "
 "file, è possibile ottenere uno alla http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "Il team del widget GTK VTE, Terminix non sarebbe stato possibile senza il "
 "loro lavoro"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD per la fornitura di un eccellente wrapper per le GTK"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org per un eccellente linguaggio, D"
@@ -1138,287 +1308,39 @@ msgstr "vietnamita"
 msgid "Thai"
 msgstr "Tailandese"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nuova sessione"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nuova finestra"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "preferenze"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Tasti di scelta rapida"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Informazioni"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Esci"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Riconoscimenti"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Impostare la directory di lavoro del terminale"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DIRECTORY"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Impostare il profilo di partenza"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Aprire la sessione specificata"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Inviare un'azione all'istanza corrente di Terminix"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Eseguire il comando passato"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "ESEGUIRE"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Massimizzare la finestra del terminale"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Schermo intero la finestra del terminale"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Messa a fuoco finestra esistente"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argomento nascosto per passare l'UUID del terminale"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Sembra esserci un problema con la configurazione del terminale.\n"
-"Questo problema non è grave, ma correggerla migliorerà la tua esperienza.\n"
-"Clicca sul link qui sotto per ulteriori informazioni:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Problema di configurazione rilevato"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Non mostrare più questo messaggio"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Impossibile individuare terminale lasciato"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Impossibile trovare la sessione per il terminale lasciato"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Nome"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profilo"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Globale"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profili"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Azione"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Tasto di scelta rapida"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Tasti di scelta rapida"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Sovrascrivi collegamento esistente"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1426,1165 +1348,261 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Predefinito"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nuovo"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Modifica"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Elimina"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Attiva trasparenza, richiesto riavvio"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Stile del titolo del terminale"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normale"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Piccolo"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Nessuno"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Variante tema"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Leggero"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Scuro"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+#, fuzzy
+msgid "Background image"
+msgstr "Sfondo"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:644
+#, fuzzy
+msgid "Reset background image"
+msgstr "Selezionare il colore di sfondo"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Chiude il terminale"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Impostare la directory di lavoro del terminale"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Manda notifiche sul desktop a processo terminato"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Su una nuova istanza"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Dividi a Destra"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Dividi giù"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Incolla"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 #, fuzzy
 msgid "Warn when attempting unsafe paste"
 msgstr "Avverti quando è un incolla non sicuro"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opzioni del Layout"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Cancella"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Attiva"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titolo"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Carico di sessione"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Opzioni di ricerca"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Apri…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Sincronizza input"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Il File '%s' non esiste."
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr ""
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr ""
@@ -2624,1128 +1642,273 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
-msgstr ""
+msgstr "sessione"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Titolo terminale"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Mantieni il terminale aperto"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "Dimensione del terminale"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-msgid "Supports notifications when processes are completed out of view"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-#, fuzzy
-msgid "Window"
-msgstr "Nuova finestra"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
+#: data/resources/ui/shortcuts.ui:231
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Edit the session name"
 msgstr "Chiude il terminale"
 
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
+#: data/resources/ui/shortcuts.ui:237
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Synchronize the input"
 msgstr "sincronizza input"
 
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
-msgid "Session"
-msgstr "sessione"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
+msgid "Switch"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:134
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
 msgid "Find next"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:140
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
 msgid "Find previous"
 msgstr ""
 
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Titolo terminale"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-#, fuzzy
-msgid "Add terminal down"
-msgstr "Mantieni il terminale aperto"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Chiude il terminale"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-#, fuzzy
-msgid "Background image"
-msgstr "Sfondo"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-#, fuzzy
-msgid "Reset background image"
-msgstr "Selezionare il colore di sfondo"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
-msgid "Add"
+msgid "Clipboard"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Titolo terminale"
+msgid "Copy"
+msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Mantieni il terminale aperto"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Impostare la directory di lavoro del terminale"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Tasti di scelta rapida"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "Tipo di carattere personalizzato"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Eseguire il comando passato"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Comando"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Testo"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Titolo terminale"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Avanzate"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Massimizzare la finestra del terminale"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Chiude il terminale"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Impostare la directory di lavoro del terminale"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
+msgid "Paste"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:401
@@ -3753,81 +1916,79 @@ msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr "Incolla avanzato"
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Non mostrare più questo messaggio"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Sud europeo"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Seleziona %s colore"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
+#: data/resources/ui/shortcuts.ui:467
+msgctxt "shortcut window"
+msgid "Reset the terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
@@ -3836,27 +1997,76 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr "Stile del titolo del terminale"
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Combinazione di colori"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
+msgid "Supports notifications when processes are completed out of view"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-08-22 06:24+0000\n"
 "Last-Translator: Youngbin Han <sukso96100@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/terminix/"
@@ -15,961 +15,1155 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "명령어"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "제목"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "텍스트"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "고급"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "붙여넣기"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "취소"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "이름"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "새로 만들기"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "편집"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "삭제"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "적용"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "확인"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "검색 옵션"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "다음 찾기"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "이전 찾기"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "일치 경우"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "전체 단어 일치만"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "정규 표현식으로 일치"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "주변 감싸기"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "터미널"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "닫기"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "최대화"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "읽기전용"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "터미널 벨"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "프로파일 편집"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "이 터미널에 대해 입력 동기화 활성화 하기"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "파일 %s은(는) 색상 스키마 호환 JSON 파일이 아닙니다"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "색상표에 16 가지 색상이 필요합니다"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "출력 저장…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "초기화"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "초기화 하고 지우기"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "프로파일"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "인코딩"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "찾기…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "레이아웃 옵션…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "오른쪽에 추가"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "아래에 추가"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "복원"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "링크 열기"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "링크 주소 복사"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "복사"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "모두 선택"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "클립보드"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "입력 동기화"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "예상하지 못한 오류가 발생했습니다. %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "터미널 출력 저장"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "저장"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "모든 텍스트 파일"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "모든 파일"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다 %d"
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "자식 프로세스가 중지되었습니다."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "다시 시작"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "붙여넣지 마세요"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "어떻게든 붙여넣기"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "레이아웃 옵션"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "동작"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "제목"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "세션"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "명령어"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"활성 옵션은 항상 영향을 주며 바로 적용됩니다.\n"
+"세션 불러오기 옵션은 세션 파일을 불러올 때만 적용됩니다."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "세션 사이드바 보기"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "새 세션 만들기"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "오른쪽에 터미널 추가"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "아래에 터미널 추가"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "터미널에서 텍스트 찾기"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "세션 이름 바꾸기"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "새 세션 이름 입력"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "열기…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "다른 이름으로 저장…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "이름…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "입력 동기화"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "이 메시지 다시 보지 않기"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "모든 JSON 파일"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "파일 이름 '%s'이(가) 없습니다"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "세션 불러오기"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "열기"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "세션 불러오기 오류"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "세션 저장"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "새 세션"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "새 창"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "기본 설정"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "바로 가기"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "정보"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "끝내기"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "크레딧"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "터미널 작업 디렉터리 설정"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "디렉토리"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "시작 프로파일 설정"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "새 터미널 제목 설정"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "특정 세션 열기"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "현재 Terminix 인스턴스로 동작 보내기"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "전달된 명령어 실행"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "터미널 창 최대화"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "터미널 창 최대화"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "터미널 창을 전체화면으로"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "기존 창에 포커스 두기"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "새 프로세스로 추가적인 인스턴스 시작(권장하지 않음)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "창 크기를 정하세요; 예시: 80x24, 또는 80x24+200+200 (행x열+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"터미널 설정에 이슈가 있는 것으로 보입니다.\n"
+"이 이슈는 심각하지 않습니다. 그러나 고친다면 사용 경험이 향상됩니다.\n"
+"자세한 정보는 아래 링크를 누르세요."
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "설정 이슈 감지됨"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "이 메시지 다시 보지 않기"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "편집중인 프로파일: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "새 프로파일"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "일반"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "명령어"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "색상"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "스크롤링"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "호환성"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "고급"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "프로파일 이름"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "터미널 크기"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "행"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "열"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "초기화"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "커서"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "블록"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "I빔"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "밑줄"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "깜빡임 모드"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "시스템"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "켬"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "끔"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "터미널 벨"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "없음"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "소리"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "아이콘"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "아이콘 및 소리"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "터미널 제목"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "남유럽어"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "텍스트 모양새"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "굵은 글씨 허용"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "크기 조절시 자동으로 줄바꿈 하기"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "사용자 정의 글꼴"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "터미널 글꼴 선택"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "색상 스키마"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "사용자 정의"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "색상 팔레트"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "옵션"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "전경/배경 에 대해 테마 색상 사용"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "고급"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "투명도"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "포커스 해제시 어두운 색상"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "텍스트"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "배경"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "커서 전경 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "커서 배경 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "강조"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "강조 전경 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "강조 배경 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "어두운 색상"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "어두운 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "%s색 선택"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "배경 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "전경 색상 선택"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "전경"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "검정"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "빨강"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "녹색"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "주황"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "파랑"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "보라"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "청록"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "회색"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "%s색 선택"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "밝은 %s색 선택"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "색상 스키마"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "스크롤바 보이기"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "출력시 스크롤하기"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "키 누를 때 스크롤하기"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "스크롤 제한:"
 
 # Terminix gettext pot file
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Backspace 키 누를 때 생성할 것"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "자동"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "이스케이프 시퀀스"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Delete 키 누를 때 생성할 것"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "인코딩"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "모호한 폭의 문자"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "좁음"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "넓음"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "로그인 셸로 명령어 실행"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "내 셸 대신 사용자 정의 명령어 실행"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "명령어가 종료될 때"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "터미널 나가기"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "명령어 다시 시작"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "터미널 열림 유지"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "사용자 정의 링크"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"정규표현식 정의에 기반하여 터미널에서 누를 수 있는 사용자 정의 링크 목록."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "프로파일 자동 변경"
+
+#: source/gx/terminix/profilewindow.d:1075
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
+"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
+"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
+"리 둘다 없는 입력은 허용되지 않습니다."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
+"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
+"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
+"리 둘다 없는 입력은 허용되지 않습니다."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "일치값"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "추가"
+
+#: source/gx/terminix/profilewindow.d:1108
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "새 일치값 추가"
+
+#: source/gx/terminix/profilewindow.d:1129
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "일치값 수정"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "표현식 %s 는 올바른 정규표현식이 아닙니다"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "정규표현식"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "대소문자 구분 한함"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "사용자 정의 링크 편집"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "동작"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "프로파일 편집"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "파일 %s은(는) 색상 스키마 호환 JSON 파일이 아닙니다"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "색상표에 16 가지 색상이 필요합니다"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "중단된 터미널을 위치시킬 수 없습니다"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "중단된 터미널을 위한 세션을 위치시킬 수 없습니다"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "기본값"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "프로파일"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "리눅스용 VTE 기반 터미널 에뮬레이터"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -980,20 +1174,14 @@ msgstr ""
 "파일과 함께 배포되지 않은 경우, http://mozilla.org/MPL/2.0/ 에서 얻으실 수 있"
 "습니다."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "GTK VTE 위젯 팀, 그들의 노력 없이 Terminix 는 불가능 했을 것입니다"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD - 훌룡한 GTK 래퍼 제공"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org - 훌룡한 언어, D 제공"
@@ -1136,287 +1324,38 @@ msgstr "베트남어"
 msgid "Thai"
 msgstr "태국어"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "새 세션"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "새 창"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "기본 설정"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "바로 가기"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "정보"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "끝내기"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "크레딧"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "터미널 작업 디렉터리 설정"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "디렉토리"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "시작 프로파일 설정"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "특정 세션 열기"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "현재 Terminix 인스턴스로 동작 보내기"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "전달된 명령어 실행"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "터미널 창 최대화"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "터미널 창을 전체화면으로"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "기존 창에 포커스 두기"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"터미널 설정에 이슈가 있는 것으로 보입니다.\n"
-"이 이슈는 심각하지 않습니다. 그러나 고친다면 사용 경험이 향상됩니다.\n"
-"자세한 정보는 아래 링크를 누르세요."
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "설정 이슈 감지됨"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "이 메시지 다시 보지 않기"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "중단된 터미널을 위치시킬 수 없습니다"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "중단된 터미널을 위한 세션을 위치시킬 수 없습니다"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "이름"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "프로파일"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "전역"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "모양새"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "프로파일"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "메뉴에 보일 인코딩:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "활성화됨"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "동작"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "단축키"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "바로 가기 활성화"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "이미 있는 바로가기 덮어쓰기"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1426,977 +1365,191 @@ msgstr ""
 "바로가기 %s 는 이미 %s 로 지정되어 있습니다.\n"
 "다른 동작을 위해 바로가기를 비활성화 하고 여기에 지정할까요?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "기본값"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "새로 만들기"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "편집"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "삭제"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "투명도 활성화 하기(다시 시작 필요함)"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "터미널 제목 스타일"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "보통"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "작음"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "없음"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "테마 종류"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "밝음"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "어두움"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "배경 이미지"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "이미지 선택"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "모든 이미지 파일"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "배경 이미지 초기화"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "크기"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "타일"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "가운데"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "늘리기"
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "세션 이름 편집"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "스플라이터에 대해 넓은 핸들 사용하기"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "포커스 해제된 터미널 어둡게 하기"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "새 터미널 제목 설정"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "터미널 내용 저장"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "행동"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "새 세션을 만들 때 세션 설정 입력받기"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "마우스가 위에서 움직일 때 터미널에 포커스 하기"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "타이핑 할 때 마우스 포인터 자동으로 숨기기"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "프로세스가 완료될때 데스크톱 알림 보내기"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "새 인스턴스 생성시"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "오른쪽으로 분할"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "아래로 분할"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "창에 포커스"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "붙여넣기"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "위험한 붙여넣기를 할 때 경고하기"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "붙여넣기 한 것이 주석 또는 변수 선언문일 경우 첫 문자 삭제하기"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "레이아웃 옵션"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "선택할 때 텍스트를 자동으로 클립보드로 복사하기"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "확인"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "취소"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "동작"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "제목"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "세션"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"활성 옵션은 항상 영향을 주며 바로 적용됩니다.\n"
-"세션 불러오기 옵션은 세션 파일을 불러올 때만 적용됩니다."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "검색 옵션"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "일치 경우"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "전체 단어 일치만"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "정규 표현식으로 일치"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "주변 감싸기"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "터미널"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "닫기"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "최대화"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "프로파일 편집"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "이 터미널에 대해 입력 동기화 활성화 하기"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "저장…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "찾기…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "레이아웃 옵션…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "읽기전용"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "초기화 하고 지우기"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "분할"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "복원"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "링크 열기"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "링크 주소 복사"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "복사"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "모두 선택"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "클립보드"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "입력 동기화"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "예상하지 못한 오류가 발생했습니다. %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "터미널 출력 저장"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "모든 텍스트 파일"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "모든 파일"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다 %d"
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "자식 프로세스가 중지되었습니다."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "다시 시작"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "붙여넣지 마세요"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "어떻게든 붙여넣기"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "'%s'은(는) 디렉터리가 아니므로, 무시합니다"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "'%s'이(가) 없으므로 파라미터 세션을 무시합니다"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2405,191 +1558,73 @@ msgstr ""
 "세션 불러오기와 프로파일/작업 디렉터리/실행 명령어 설정을 하실 수 없습니다. "
 "하나 또는 다른것을 선택하세요"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "세션 사이드바 보기"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "새 세션 만들기"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "세션 이름 바꾸기"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "새 세션 이름 입력"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "열기…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "저장"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "다른 이름으로 저장…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "이름…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "입력 동기화"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "모든 JSON 파일"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "파일 이름 '%s'이(가) 없습니다"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "세션 불러오기"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "세션 불러오기 오류"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "세션 저장"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "비활성화됨"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "GTK 버전이 너무 오래 되었습니다, 적어도 GTK %d.%d.%d 버전이 필요합니다!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "예상하지 못한 예외 발생"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "오류: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Terminix에서 열기…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "%s에서 터미널 열기"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Terminix에서 열기…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "%s에서 터미널 열기"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "여기서 Terminix 열기…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "이 디렉터리에서 Terminix 열기"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "여기서 Terminix 열기…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "이 디렉터리에서 Terminix 열기"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "응용프로그램"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "응용프로그램"
@@ -2629,257 +1664,248 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "세션 사이드바 보기"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "세션 사이드바 보기"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "다음 세션으로 전환"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "이전 세션으로 전환"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "세션 1번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "세션 2번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "세션 3번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "세션 4번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "세션 5번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "세션 6번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "세션 7번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "세션 8번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "세션 9번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "세션 10번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "세션"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "파일"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "현재 세션 닫기"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "현재 세션 저장하기"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "새 파일 이름으로 현재 세션 저장하기"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "저장된 세션 열기"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "추가"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "오른쪽에 터미널 추가"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "아래에 터미널 추가"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "크기 조절"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "위쪽으로 터미널 크기 조절"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "아래쪽으로 터미널 크기 조절"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "왼쪽으로 터미널 크기 조절"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "오른쪽으로 터미널 크기 조절"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "기타"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "세션 이름 편집"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "입력 동기화"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
 msgid "Switch"
 msgstr "전환"
 
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
+#: data/resources/ui/shortcuts.ui:249
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "다음 터미널로 전환"
 
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
+#: data/resources/ui/shortcuts.ui:255
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "이전 터미널로 전환"
 
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
+#: data/resources/ui/shortcuts.ui:261
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "위쪽 터미널로 전환"
 
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
+#: data/resources/ui/shortcuts.ui:267
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "아래쪽 터미널로 전환"
 
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
+#: data/resources/ui/shortcuts.ui:273
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "왼쪽 터미널로 전환"
 
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
+#: data/resources/ui/shortcuts.ui:279
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "오른쪽 터미널로 전환"
 
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
+#: data/resources/ui/shortcuts.ui:291
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "터미널 1번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
+#: data/resources/ui/shortcuts.ui:297
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "터미널 2번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
+#: data/resources/ui/shortcuts.ui:303
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "터미널 3번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
+#: data/resources/ui/shortcuts.ui:309
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "터미널 4번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
+#: data/resources/ui/shortcuts.ui:315
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "터미널 5번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
+#: data/resources/ui/shortcuts.ui:321
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "터미널 6번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
+#: data/resources/ui/shortcuts.ui:327
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "터미널 7번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
+#: data/resources/ui/shortcuts.ui:333
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "터미널 8번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
+#: data/resources/ui/shortcuts.ui:339
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "터미널 9번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
+#: data/resources/ui/shortcuts.ui:345
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "터미널 10번으로 전환"
 
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "분할"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "오른쪽으로 분할"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "아래로 분할"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
 #: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
 msgctxt "shortcut window"
 msgid "Find"
 msgstr "찾기"
 
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
+#: data/resources/ui/shortcuts.ui:371
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "다음 찾기"
@@ -2889,165 +1915,148 @@ msgstr "다음 찾기"
 # in the Shortcut preferences and in the future
 # the shortcut overview if available in Gnome 3.20
 # ***********************************************
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
+#: data/resources/ui/shortcuts.ui:377
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "이전 찾기"
 
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
 msgid "Clipboard"
 msgstr "클립보드"
 
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "복사"
 
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "붙여넣기"
 
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "고급"
+
+#: data/resources/ui/shortcuts.ui:407
 msgctxt "shortcut window"
 msgid "Select all"
 msgstr "모두 선택"
 
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
+#: data/resources/ui/shortcuts.ui:415
 msgctxt "shortcut window"
 msgid "Zoom"
 msgstr "확대"
 
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
+#: data/resources/ui/shortcuts.ui:419
 msgctxt "shortcut window"
 msgid "Zoom in"
 msgstr "확대"
 
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
+#: data/resources/ui/shortcuts.ui:425
 msgctxt "shortcut window"
 msgid "Zoom out"
 msgstr "축소"
 
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
+#: data/resources/ui/shortcuts.ui:431
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "확대 원래대로"
 
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "기타"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "터미널 내용 저장"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "터미널 닫기"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "터미널 최대화 하기"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "현재 프로파일 설정"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "터미널 초기화 하기"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "터미널 초기화 하고 지우기"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "읽기전용 활성화/비활성화 하기"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "레이아웃 옵션"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "터미널 번호 삽입"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "터미널 제목 스타일"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "그놈을 위한 타일링 터미널"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "새 터미널"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "그놈을 위한 타일링 터미널"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix 는 타일링 터미널 에뮬레이터 입니다."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "다음과 같은 것을 할 수 있게 해 줍니다:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
 msgstr "터미널을 가로 또는 세로로 분할하여 원하는 방식으로 배치하세요"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
 "windows"
 msgstr "창 안이나 창 사이에서 끌어옮겨 터미널을 재배열 할 수 있습니다"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "터미널을 끌어옮겨 새 창으로 분리 할 수 있습니다"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3056,17 +2065,14 @@ msgstr ""
 "터미널 사이 입력을 동기화 할 수 있으며 한 터미널에서의 입력이 다른 터미널에 "
 "복제 됩니다"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "터미널 그루핑은 디스크에 저장하거나 불러올 수 있습니다"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "터미널은 사용자 정의 제목을 지원합니다"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3075,17 +2081,14 @@ msgstr ""
 "색상 스키마는 파일에 보관되며 사용자 정의 색상 스키마는 단순히 새 파일 생성으"
 "로 생성 될 수 있습니다"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "투명한 배경"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "뷰 밖에서 프로세스를 끝날때에 대한 알림 지원"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3096,801 +2099,6 @@ msgstr ""
 "자 노력 했습니다. 결과적으로, 이 앱은 클라이언트 측 데코레이션을 사용하며, 필"
 "요한 경우 비활성화 될 수 있습니다."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix 는 그놈과 유니티에서 시험하였습니다."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "창 크기를 정하세요; 예시: 80x24, 또는 80x24+200+200 (행x열+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "창"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "세션 이름 편집"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "입력 동기화"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "세션"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "출력 저장…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "열기"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "다음 찾기"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "이전 찾기"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "새 프로세스로 추가적인 인스턴스 시작(권장하지 않음)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "오른쪽에 터미널 추가"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "아래에 터미널 추가"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "터미널에서 텍스트 찾기"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "소리"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "아이콘"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "아이콘 및 소리"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "프로파일 자동 변경"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "일치값"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "추가"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "새 일치값 추가"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "일치값 수정"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "배경 이미지"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "이미지 선택"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "모든 이미지 파일"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "배경 이미지 초기화"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "크기"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "타일"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "가운데"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "늘리기"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "추가"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "오른쪽에 터미널 추가"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "아래에 터미널 추가"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "선택할 때 텍스트를 자동으로 클립보드로 복사하기"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "오른쪽에 추가"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "아래에 추가"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "새 터미널 제목 설정"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
-"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
-"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
-"리 둘다 없는 입력은 허용되지 않습니다"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "바로 가기 활성화"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "사용자 정의 링크"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"정규표현식 정의에 기반하여 터미널에서 누를 수 있는 사용자 정의 링크 목록."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
-"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
-"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
-"리 둘다 없는 입력은 허용되지 않습니다."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "표현식 %s 는 올바른 정규표현식이 아닙니다"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "정규표현식"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "대소문자 구분 한함"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "사용자 정의 링크 편집"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "적용"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "터미널 번호 삽입"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "전달된 명령어 실행"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
-"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
-"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
-"리 둘다 없는 입력은 허용되지 않습니다."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "프로파일 편집"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "명령어"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "제목"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "텍스트"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "터미널 제목"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "고급"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "터미널 창 최대화"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "세션 이름 편집"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "새 터미널 제목 설정"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "세션 사이드바 보기"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "고급"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "이 메시지 다시 보지 않기"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "남유럽어"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "%s색 선택"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Terminix에서 열기…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "%s에서 터미널 열기"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Terminix에서 열기…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "여기서 Terminix 열기…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "이 디렉터리에서 Terminix 열기"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "터미널 제목 스타일"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "색상 스키마"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "터미널 내용 저장"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-07-30 19:47+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/terminix/"
@@ -19,960 +19,1120 @@ msgstr ""
 "%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Failas %s nėra su JSON failu suderinamas spalvų rinkinys"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Spalvų rinkinio paletė reikalauja 16 spalvų"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Atstatyti"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr ""
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr ""
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr ""
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr ""
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr ""
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr ""
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Naujas profilis"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Suderinamumas"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Profilio pavadinimas"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Terminalo dydis"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Atstatyti"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Žymeklis"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Dvitėjinė sija"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Pabraukimas"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Mirksėjimo veiksena"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Spalvų rinkinys"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Spalvų paletė"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Parametrai"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Fonas"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Spalvų rinkinys"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr ""
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Failas %s nėra su JSON failu suderinamas spalvų rinkinys"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Spalvų rinkinio paletė reikalauja 16 spalvų"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr ""
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -980,20 +1140,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1133,284 +1287,38 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr ""
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr ""
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr ""
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr ""
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr ""
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr ""
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr ""
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1418,1164 +1326,256 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr ""
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr ""
@@ -2615,1107 +1615,269 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr ""
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-msgid "Supports notifications when processes are completed out of view"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
+#: data/resources/ui/shortcuts.ui:231
 msgctxt "shortcut window"
 msgid "Edit the session name"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
+#: data/resources/ui/shortcuts.ui:237
 msgctxt "shortcut window"
 msgid "Synchronize the input"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
-msgid "Session"
+msgid "Switch"
 msgstr ""
 
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:134
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
 msgid "Find next"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:140
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
 msgid "Find previous"
 msgstr ""
 
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
-msgid "Add"
+msgid "Clipboard"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
-msgid "Add terminal right"
+msgid "Copy"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Terminalo dydis"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
+msgid "Paste"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:401
@@ -3723,78 +1885,79 @@ msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr ""
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
+#: data/resources/ui/shortcuts.ui:467
+msgctxt "shortcut window"
+msgid "Reset the terminal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
@@ -3802,27 +1965,76 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Spalvų rinkinys"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
+msgid "Supports notifications when processes are completed out of view"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-11-07 17:38+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
-"Language-Team: Dutch "
-"<https://hosted.weblate.org/projects/terminix/translations/nl/>\n"
+"Language-Team: Dutch <https://hosted.weblate.org/projects/terminix/"
+"translations/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,960 +18,1154 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr "StatusBijwerken"
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr "CommandoUitvoeren"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr "MeldingVersturen"
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr "TitelBijwerken"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr "BelAfspelen"
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr "TekstVersturen"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr "WachtwoordInvoeren"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Deze opdracht vraagt om administrator-toegang tot uw computer"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Het kopiëren van opdrachten vanaf het internet kan gevaarlijk zijn. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Zorg ervoor dat u begrijpt wat alle delen van deze opdracht uitvoeren."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformeren"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Spaties omzetten naar tabs"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "CRLF en CR converteren naar LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Geavanceerd plakken"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Plakken"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Naam"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Nieuw"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Bewerken"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Wederkerend teken opnemen met wachtwoord"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Wachtwoord invoeren"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Toevoegen"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Wachtwoord"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Wachtwoord bevestigen"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Oké"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Wachtwoord toevoegen"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Wachtwoord bewerken"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Zoekopties"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Volgende zoeken"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Vorige zoeken"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Hoofdlettergevoelig"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Alleen gehele woorden"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Alleen reguliere expressies"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Tekstomloop"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Sluiten"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximaliseren"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Invoer-synchronisatie uitschakelen voor dit terminalvenster"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Alleen-lezen"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Terminalbel"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Profiel bewerken"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Dit venster bevat actieve processen. Wilt u het venster tóch sluiten?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Invoer-synchronisatie inschakelen voor dit terminalvenster"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Het bestand %s is geen JSON-compatibel kleurenschemabestand"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Het laden van de  %s-bibliotheek is mislukt; de wachtwoordfunctionaliteit is "
+"niet beschikbaar."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Het kleurenschemapalet vereist 16 kleuren"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Bibliotheek is niet geladen"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Uitvoer opslaan…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Herstellen"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Terugzetten en wissen"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profielen"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Tekstcodering"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Zoeken…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Indelingsopties…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Rechts toevoegen"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Onder toevoegen"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Herstellen"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Link openen"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Linkadres kopiëren"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Kopiëren"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Alles selecteren"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Klembord"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Invoer synchroniseren"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Er is een onverwachte fout opgetreden; geen verdere informatie beschikbaar"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Er is een onverwachte fout opgetreden: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Terminaluitvoer opslaan"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Opslaan"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Alle tekstbestanden"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Alle bestanden"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Het dochterproces is normaal afgerond met de status %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Het dochterproces is afgebroken door signaal %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Het dochterproces is afgebroken."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Herstarten"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Niet plakken"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Tóch plakken"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Indelingsopties"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Actief"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Laden van sessie"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Opdracht"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Actieve opties zijn altijd actief en worden onmiddelijk toegepast.\n"
+"Laden van sessie-opties worden alleen toegepast bij het laden van een "
+"sessiebestand."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Sessie-zijbalk weergeven"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Nieuwe sessie creëren"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Terminal rechts toevoegen"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Terminal onder toevoegen"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Naar tekst zoeken in de terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Sessienaam wijzigen"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Voer een nieuwe sessienaam in"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Openen…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Opslaan als…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Naam…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Invoer synchroniseren"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Dit venster bevat actieve processen. Wilt u het venster tóch sluiten?"
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr "Dit bericht niet meer weergeven"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Alle JSON-bestanden"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "De bestandsnaam '%s' bestaat niet"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Sessie laden"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Openen"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+"De sessie kan niet worden geladen omdat er een onverwachte fout is "
+"opgetreden."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Er is een fout opgetreden tijdens het laden van de sessie"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Sessie opslaan"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nieuwe sessie"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nieuw venster"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Sneltoetsen"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Over"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Afsluiten"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Met dank aan"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Stel de terminal-werkmap in"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "MAP"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Stel het startprofiel in"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "PROFIEL_NAAM"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Stel de nieuwe terminaltitel in"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TITEL"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Open de opgegeven sessie"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "SESSIE_NAAM"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Verstuur een actie naar het huidige Terminix-proces"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "ACTIE_NAAM"
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr "Parameter uitvoeren als opdracht"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "OPDRACHT"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maximaliseer het terminalvenster"
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr "Terminalvenster minimaliseren"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Volledige scherm-modus"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Focus het huidige venster"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Nieuwe vensters starten als nieuw proces (niet aanbevolen)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Stel de venstergrootte in; bijv.: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "AFMETINGEN"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Opent een venster in quake-modus of weergeeft/verwerpt een actief quake-"
+"venster"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr "Terminix-versie en vereiste componenten-versies weergeven"
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Verborgen argument om door te geven aan de terminal UUID"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Er lijkt een probleem te zijn met de configuratie van de terminal. Het "
+"probleem\n"
+"is niet ernstig maar het oplossen ervan zal uw terminal-ervaring verbeteren. "
+"Voor\n"
+"meer informatie, klik op de onderstaande link:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Configuratieprobleem ontdekt"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Dit bericht niet meer weergeven"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Bezig met bewerken van profiel: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Nieuw profiel"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Algemeen"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Opdracht"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Kleur"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Scrollen"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Compatibiliteit"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Profielnaam"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Terminalgrootte"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "kolommen"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "rijen"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Herstellen"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Cursor"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Blok"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Verticale streep"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Onderliggende streep"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Knippermodus"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Systeem"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Ingeschakeld"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Uitgeschakeld"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Terminalbel"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Geen"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Geluid"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Pictogram"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Pictogram en geluid"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Terminaltitel"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr "Logo"
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr "Logo-positie"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr "Noordwest"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr "Noordoost"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr "Zuidwest"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr "Zuidoost"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Tekstuiterlijk"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Vetgedrukte tekst toestaan"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Tekstterugloop passend maken bij herschalen"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Aangepast lettertype"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Kies een terminal-lettertype"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Kleurenschema"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Aangepast"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr "Exporteren"
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Kleurenpalet"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Opties"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Themakleuren gebruiken voor voorgrond/achtergrond"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Geavanceerd"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Doorzichtigheid"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Ongefocusde verduistering"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Tekst"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Achtergrond"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Selecteer voorgrondkleur van cursor"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Selecteer achtergrondkleur van cursor"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Markeren"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Selecteer voorgrondkleur van markering"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Selecteer achtergrondkleur van markering"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Verduisteren"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Selecteer verduisteringskleur"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr "Selecteer badgekleur"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Selecteer achtergrondkleur"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Selecteer voorgrondkleur"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Voorgrond"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Zwart"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Rood"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Groen"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Oranje"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Blauw"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Paars"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turkoois"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Grijs"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Selecteer %s kleur"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Selecteer %s lichte kleur"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+msgid "Export Color Scheme"
+msgstr "Kleurenschema exporteren"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Scrollbalk weergeven"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Scrollen bij uitvoer"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Scrollen bij toetsaanslag"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Scrolluitvoer beperken tot:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Backspace-toets genereert"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Escape-volgorde"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Delete-toets genereert"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Tekstcodering"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Tekens met eenduidige breedte"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Smal"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Breed"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Opdracht uitvoeren als inlog-shell"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Een aangepast commando uitvoeren in plaats van mijn shell"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Als de opdracht is afgerond"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Terminal afsluiten"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Opdracht herstarten"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Terminalvenster openhouden"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Aangepaste links"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Een gebruikers-gedefinieerde lijst van links die kunnen worden aangeklikt in "
+"de terminal gebaseerd op reguliere expressies."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr "Triggers"
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Triggers zijn reguliere expressies die worden gebruikt om de uitvoertekst in "
+"de terminal te controleren. Als een overeenkomst is aangetroffen zal de "
+"ingestelde actie worden uitgevoerd."
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Automatische profieloverschakeling"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
+"waarden.\n"
+"Waarden moeten worden ingevoerd in de notatie <i>gebruikersnaam@hostnaam:"
+"map</i>. De hostnaam of map kan leeg worden gelaten maar de dubbele punt "
+"moet ten alle tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als "
+"de map is niet toegestaan."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
+"waarden.\n"
+"Waarden moeten worden ingevoerd in de notatie <i>hostnaam:map</i>. De "
+"hostnaam of map kan leeg worden gelaten maar de dubbele punt moet ten alle "
+"tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als de map is niet "
+"toegestaan."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Overeenkomen"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Toevoegen"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr "Voer de overeen te komen gebruikersnaam@hostnaam:map in"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Voer de overeen te komen hostnaam:map in"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Nieuw overeenkomst toevoegen"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr "Bewerk de overeen te komen gebruikersnaam@hostnaam:map"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Bewerk de overeen te komen hostnaam:map"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Overeenkomst bewerken"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "De expressie %s is een ongeldige regex"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Regex"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Hoofdletterongevoelig"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Aangepaste links bewerken"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Actie"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parameter"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Aantal regels voor triggerdoorvoering beperken tot:"
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr "Triggers bewerken"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Het bestand %s is geen JSON-compatibel kleurenschemabestand"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Het kleurenschemapalet vereist 16 kleuren"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Er is een probleem opgetreden bij het vinden van de gedaalde terminal"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+"Er is een probleem opgetreden bij het vinden van de sessie van de gedaalde "
+"terminal"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Standaard"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profiel"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Een op VTE gebaseerde terminal-applicatie voor Linux"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -982,20 +1176,14 @@ msgstr ""
 "versie 2.0. Als er bij het verspreiden van dit bestand geen kopie van de MPL "
 "is meegeleverd, kunt u deze verkrijgen op http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "GTK VTE-widget-team. Terminix zou niet mogelijk zijn zonder hun werk"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD voor het beschikbaar stellen van een geweldige GTK-wrapper"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org voor de geweldige D-taal"
@@ -1135,291 +1323,38 @@ msgstr "Vietnamees"
 msgid "Thai"
 msgstr "Thais"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nieuwe sessie"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nieuw venster"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Voorkeuren"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Sneltoetsen"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Over"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Afsluiten"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Met dank aan"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Stel de terminal-werkmap in"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "MAP"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Stel het startprofiel in"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "PROFIEL_NAAM"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Open de opgegeven sessie"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "SESSIE_NAAM"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Verstuur een actie naar het huidige Terminix-proces"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "ACTIE_NAAM"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Voer de doorgegeven opdracht uit"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "UITVOEREN"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maximaliseer het terminalvenster"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Volledige scherm-modus"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Focus het huidige venster"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Verborgen argument om door te geven aan de terminal UUID"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Er lijkt een probleem te zijn met de configuratie van de terminal. Het "
-"probleem\n"
-"is niet ernstig maar het oplossen ervan zal uw terminal-ervaring verbeteren. "
-"Voor\n"
-"meer informatie, klik op de onderstaande link:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Configuratieprobleem ontdekt"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Dit bericht niet meer weergeven"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Er is een probleem opgetreden bij het vinden van de gedaalde terminal"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-"Er is een probleem opgetreden bij het vinden van de sessie van de gedaalde "
-"terminal"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Naam"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profiel"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Globaal"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Uiterlijk"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profielen"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr "Quake"
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Tekstcoderingen die moeten worden weergegeven in het menu:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Actie"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Sneltoets"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Sneltoetsen inschakelen"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Bestaande sneltoets overschrijven"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1430,978 +1365,188 @@ msgstr ""
 "Wilt u de sneltoets van de andere actie uitschakelen en toewijzen aan deze "
 "actie?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Standaard"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nieuw"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Bewerken"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Verwijderen"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Doorzichtigheid inschakelen; herstart vereist"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Titelstijl van terminal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normaal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Klein"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Geen"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Themastijl"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Licht"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Donker"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Achtergrondafbeelding"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Afbeelding selecteren"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Alle afbeeldingsbestanden"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Achtergrondafbeelding verwijderen"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Schalen"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Tegelen"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Centreren"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Uitrekken"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Standaard sessienaam"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Brede handgreep gebruiken voor splitsingen"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Ongefocusde terminalvensters dimmen"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Zijbalk aan de rechterkant plaatsen"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Terminaltitel weergeven, zelfs als het de enige terminal is"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "Grootte"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr "Hoogtepercentage"
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr "Breedtepercentage"
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Terminal weergeven op alle werkbladen"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr "Hint instellen voor vensterbeheerder om animaties uit te schakelen"
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr "Venster sluiten bij verliezen van focus"
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr "Terminal weergeven op actief beeldscherm"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Weergeven op specifiek beeldscherm"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Vragen bij creëren van nieuwe sessie"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Focus een terminal wanneer de muis eroverheen zweeft"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Cursor verbergen tijdens typen"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Terminal sluiten door met de middelste muisknop te klikken op de titel"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Venster sluiten wanneer de laatste sessie wordt afgesloten"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Bureaubladmelding weergeven bij afronden van proces"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Bij nieuw proces"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Splitsen naar rechts"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Splitsen naar onderen"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Venster focussen"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Plakken"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr "Altijd geavanceerd plakken gebruiken"
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Waarschuwen bij plakken van onveilige opdracht"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "Eerste teken weglaten bij plakken van een comment of variabel"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Indelingsopties"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Geselecteerde tekst automatisch kopiëren naar het klembord"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Oké"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Annuleren"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Actief"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Laden van sessie"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Actieve opties zijn altijd actief en worden onmiddelijk toegepast.\n"
-"Laden van sessie-opties worden alleen toegepast bij het laden van een "
-"sessiebestand."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Zoekopties"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Hoofdlettergevoelig"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Alleen gehele woorden"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Alleen reguliere expressies"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Tekstomloop"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Sluiten"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximaliseren"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Invoer-synchronisatie uitschakelen voor dit terminalvenster"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Profiel bewerken"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Dit venster bevat actieve processen. Wilt u het venster tóch sluiten?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Invoer-synchronisatie inschakelen voor dit terminalvenster"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Opslaan…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Zoeken…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Indelingsopties…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Alleen-lezen"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Terugzetten en wissen"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Splitsen"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Herstellen"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Link openen"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Linkadres kopiëren"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Kopiëren"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Alles selecteren"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Klembord"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Invoer synchroniseren"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Er is een onverwachte fout opgetreden; geen verdere informatie beschikbaar"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Er is een onverwachte fout opgetreden: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Terminaluitvoer opslaan"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Alle tekstbestanden"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Alle bestanden"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Het dochterproces is normaal afgerond met de status %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Het dochterproces is afgebroken door signaal %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Het dochterproces is afgebroken."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Herstarten"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Deze opdracht vraagt om administrator-toegang tot uw computer"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Het kopiëren van opdrachten vanaf het internet kan gevaarlijk zijn. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Zorg ervoor dat u begrijpt wat alle delen van deze opdracht uitvoeren."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Niet plakken"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Tóch plakken"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "'%s' wordt genegeerd omdat het geen map is"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "'%s' bestaat niet en daarom wordt de parametersessie genegeerd"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2410,194 +1555,72 @@ msgstr ""
 "U kunt geen sessie laden en een profiel-/werkmap- en/of opdracht uitvoeren-"
 "optie instellen; kies één van de twee"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Sessie-zijbalk weergeven"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr "U kunt de actie-parameter alleen gebruiken binnen Terminix"
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Nieuwe sessie creëren"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Sessienaam wijzigen"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Voer een nieuwe sessienaam in"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Openen…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Opslaan"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Opslaan als…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Naam…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Invoer synchroniseren"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Alle JSON-bestanden"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "De bestandsnaam '%s' bestaat niet"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Sessie laden"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
-"De sessie kan niet worden geladen omdat er een onverwachte fout is "
-"opgetreden."
+"U kunt de quake-modus niet gebruiken met de parameters voor maximaliseren, "
+"minimaliseren of afmetingen"
 
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Er is een fout opgetreden tijdens het laden van de sessie"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Sessie opslaan"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "U GTK-versie is verouderd; u moet op zijn minst beschikken over versie %d.%d."
 "%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Er is een onverwachte fout opgetreden"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Fout: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
+msgstr "Terminix openen op afstand…"
+
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Terminix op afstand openen in %s"
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
 msgstr "Openen in Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Terminix openen in %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr "Terminix op afstand hier openen…"
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr "Terminix op afstand openen in deze map"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Terminix hier openen…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Terminix openen in deze map"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Applicatie"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Applicatie"
@@ -2637,402 +1660,376 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Sessie-zijbalk weergeven"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Sessieschakelaar weergeven"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Overschakelen naar volgende sessie"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Overschakelen naar vorige sessie"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Overschakelen naar sessie 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Overschakelen naar sessie 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Overschakelen naar sessie 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Overschakelen naar sessie 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Overschakelen naar sessie 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Overschakelen naar sessie 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Overschakelen naar sessie 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Overschakelen naar sessie 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Overschakelen naar sessie 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Overschakelen naar sessie 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sessie"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Bestand"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Huidige sessie sluiten"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Huidige sessie opslaan"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Huidige sessie opslaan onder nieuwe bestandsnaam"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Opgeslagen sessie openen"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Toevoegen"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Terminal rechts toevoegen"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Terminal onder toevoegen"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Herschalen"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Terminal omhoog herschalen"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Terminal omlaag herschalen"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Terminal naar links herschalen"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Terminal naar rechts herschalen"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Overschakelen"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Overschakelen naar volgende terminal"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Overschakelen naar vorige terminal"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Overschakelen naar de terminal hierboven"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Overschakelen naar de terminal hieronder"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Overschakelen naar de linkerterminal"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Overschakelen naar de rechterterminal"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Overschakelen naar terminal 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Overschakelen naar terminal 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Overschakelen naar terminal 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Overschakelen naar terminal 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Overschakelen naar terminal 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Overschakelen naar terminal 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Overschakelen naar terminal 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Overschakelen naar terminal 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Overschakelen naar terminal 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Overschakelen naar terminal 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Splitsen"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Naar rechts splitsen"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Omlaag splitsen"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Zoeken"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Volgende zoeken"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Vorige zoeken"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Klembord"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Kopiëren"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Plakken"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Alles selecteren"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Zoom"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Inzoomen"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Uitzoomen"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Zoom herstellen"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Overig"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Sessienaam bewerken"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Invoer synchroniseren"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Overschakelen"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Overschakelen naar volgende terminal"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Overschakelen naar vorige terminal"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Overschakelen naar de terminal hierboven"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Overschakelen naar de terminal hieronder"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Overschakelen naar de linkerterminal"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Overschakelen naar de rechterterminal"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Overschakelen naar terminal 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Overschakelen naar terminal 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Overschakelen naar terminal 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Overschakelen naar terminal 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Overschakelen naar terminal 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Overschakelen naar terminal 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Overschakelen naar terminal 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Overschakelen naar terminal 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Overschakelen naar terminal 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Overschakelen naar terminal 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Zoeken"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Volgende zoeken"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Vorige zoeken"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Klembord"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Kopiëren"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Plakken"
+
+#: data/resources/ui/shortcuts.ui:401
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Geavanceerd plakken"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Alles selecteren"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Zoom"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Inzoomen"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Uitzoomen"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Zoom herstellen"
+
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Terminal-inhoud opslaan"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Terminal sluiten"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Terminal maximaliseren"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Huidige profielvoorkeuren opslaan"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Terminal terugzetten op standaardwaarden"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Terminal wissen en terugzetten op standaardwaarden"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Alleen-lezen aan/uit"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Indelingsopties"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Terminalcijfer invoeren"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Wachtwoord invoeren"
+
+#: data/resources/ui/shortcuts.ui:503
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Schakelen tussen titelstijlen"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Een terminal voor Gnome met tegelmogelijkheid"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Nieuwe terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Een terminal voor GNOME met tegelmogelijkheid"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix is een terminalapplicatie met tegelmogelijkheid."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Het stelt u in staat om:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
@@ -3040,7 +2037,6 @@ msgstr ""
 "Terminals indelen op welke manier dan ook door ze horizontaal of verticaal "
 "te splitsen"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3049,14 +2045,12 @@ msgstr ""
 "Terminals kunnen anders worden ingedeeld middels slepen-en-neerzetten binnen "
 "en tussen vensters"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr ""
 "Terminal kunnen worden veranderd in een nieuw venster middels slepen-en-"
 "neerzetten"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3065,19 +2059,16 @@ msgstr ""
 "De invoer kan worden gesynchroniseerd tussen terminals zodat opdrachten uit "
 "de ene terminal kunnen worden hergebruikt in andere terminals"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr ""
 "Gegroepeerde terminals kunnen worden opgeslagen naar en geladen vanaf een "
 "schijf"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "De terminals hebben ondersteuning voor aangepaste titels"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3086,18 +2077,15 @@ msgstr ""
 "Kleurenschema's worden opgeslagen in bestanden en aangepaste kleurenschema's "
 "kunnen worden gecreëerd door het creëren van een nieuw bestand"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Doorzichtige achtergrond"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr ""
 "Ondersteunt meldingen voor processen die buiten het zicht worden voltooid"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3109,792 +2097,6 @@ msgstr ""
 "resulteert in het gebruik van client-side-decorations maar deze kunnen, "
 "indien nodig, worden uitgeschakeld."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix is getest onder GNOME en Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Stel de venstergrootte in; bijv.: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "AFMETINGEN"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Venster"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Sessienaam bewerken"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Invoer synchroniseren"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sessie"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Uitvoer opslaan…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Openen"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Volgende zoeken"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Vorige zoeken"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Nieuwe vensters starten als nieuw proces (niet aanbevolen)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Terminal rechts toevoegen"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Terminal onder toevoegen"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Naar tekst zoeken in de terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Geluid"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Pictogram"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Pictogram en geluid"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Automatische profieloverschakeling"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Overeenkomen"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Toevoegen"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Nieuw overeenkomst toevoegen"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Voer de overeen te komen hostnaam:map in"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Overeenkomst bewerken"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Bewerk de overeen te komen hostnaam:map"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Achtergrondafbeelding"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Afbeelding selecteren"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Alle afbeeldingsbestanden"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Achtergrondafbeelding verwijderen"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Schalen"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Tegelen"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Centreren"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Uitrekken"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Toevoegen"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Terminal rechts toevoegen"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Terminal onder toevoegen"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Geselecteerde tekst automatisch kopiëren naar het klembord"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Rechts toevoegen"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Onder toevoegen"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Stel de nieuwe terminaltitel in"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TITEL"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
-"waarden.\n"
-"Waarden moeten worden ingevoerd in de notatie <i>hostnaam:map</i>. De "
-"hostnaam of map kan leeg worden gelaten maar de dubbele punt moet ten alle "
-"tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als de map is niet "
-"toegestaan"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Sneltoetsen inschakelen"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Aangepaste links"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Een gebruikers-gedefinieerde lijst van links die kunnen worden aangeklikt in "
-"de terminal gebaseerd op reguliere expressies."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
-"waarden.\n"
-"Waarden moeten worden ingevoerd in de notatie <i>hostnaam:map</i>. De "
-"hostnaam of map kan leeg worden gelaten maar de dubbele punt moet ten alle "
-"tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als de map is niet "
-"toegestaan."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "De expressie %s is een ongeldige regex"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Regex"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Hoofdletterongevoelig"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Aangepaste links bewerken"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Toevoegen"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Terminalcijfer invoeren"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Het laden van de  %s-bibliotheek is mislukt; de wachtwoordfunctionaliteit is "
-"niet beschikbaar."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Bibliotheek is niet geladen"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Wederkerend teken opnemen met wachtwoord"
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Wachtwoord invoeren"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Wachtwoord"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Wachtwoord bevestigen"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Wachtwoord toevoegen"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Wachtwoord bewerken"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr "Parameter uitvoeren als opdracht"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "OPDRACHT"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Opent een venster in quake-modus of weergeeft/verwerpt een actief quake-"
-"venster"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "QUAKE"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-"U kunt de quake-modus niet gebruiken met de parameters voor maximaliseren, "
-"volledig scherm en afmetingen"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr "Triggers"
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Triggers zijn reguliere expressies die worden gebruikt om de uitvoertekst in "
-"de terminal te controleren. Als een overeenkomst is aangetroffen zal de "
-"ingestelde actie worden uitgevoerd."
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
-"waarden.\n"
-"Waarden moeten worden ingevoerd in de notatie <i>gebruikersnaam@hostnaam:"
-"map</i>. De hostnaam of map kan leeg worden gelaten maar de dubbele punt "
-"moet ten alle tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als "
-"de map is niet toegestaan."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr "Voer de overeen te komen gebruikersnaam@hostnaam:map in"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr "Bewerk de overeen te komen gebruikersnaam@hostnaam:map"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parameter"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr "Triggers bewerken"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr "StatusBijwerken"
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr "CommandoUitvoeren"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr "MeldingVersturen"
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr "TitelBijwerken"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr "BelAfspelen"
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr "TekstVersturen"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr "WachtwoordInvoeren"
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Zijbalk aan de rechterkant plaatsen"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Terminal weergeven op alle werkbladen"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Terminal weergeven op actief beeldscherm"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Weergeven op specifiek beeldscherm"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Terminalhoogte"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Terminal sluiten door met de middelste muisknop te klikken op de titel"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Venster sluiten wanneer de laatste sessie wordt afgesloten"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Wachtwoord invoeren"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformeren"
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Geavanceerd plakken"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr "Terminalvenster minimaliseren"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr "U kunt de actie-parameter alleen gebruiken binnen Terminix"
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-"U kunt de quake-modus niet gebruiken met de parameters voor maximaliseren, "
-"minimaliseren of afmetingen"
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Standaard sessienaam"
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Terminaltitel weergeven, zelfs als het de enige terminal is"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "Grootte"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr "Hoogtepercentage"
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr "Breedtepercentage"
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr "Hint instellen voor vensterbeheerder om animaties uit te schakelen"
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr "Altijd geavanceerd plakken gebruiken"
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Sessieschakelaar weergeven"
-
-#: data/resources/ui/shortcuts.ui:401
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Geavanceerd plakken"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr "Terminix-versie en vereiste componenten-versies weergeven"
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Dit venster bevat actieve processen. Wilt u het venster tóch sluiten?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
-msgstr "Dit bericht niet meer weergeven"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr "Logo"
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr "Logo-positie"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr "Noordwest"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr "Noordoost"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr "Zuidwest"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr "Zuidoost"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
-msgstr "Selecteer badgekleur"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr "Venster sluiten bij verliezen van focus"
-
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr "Terminix openen op afstand…"
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Terminix op afstand openen in %s"
-
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr "Openen in Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr "Terminix op afstand hier openen…"
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
-msgstr "Terminix op afstand openen in deze map"
-
-#: data/resources/ui/shortcuts.ui:503
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Schakelen tussen titelstijlen"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr "Exporteren"
-
-#: source/gx/terminix/profilewindow.d:728
-msgid "Export Color Scheme"
-msgstr "Kleurenschema exporteren"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
-msgstr "Terminal weergeven op actief beeldscherm"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Aantal regels voor triggerdoorvoering beperken tot:"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Spaties omzetten naar tabs"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "CRLF en CR converteren naar LF"
-
-#~ msgid "You can only use the the action parameter within Terminix"
-#~ msgstr "U kunt de actie-parameter alleen gebruiken binnen Terminix"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-09-29 10:00+0000\n"
 "Last-Translator: Piotr Sokół <psokol.l10n@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/terminix/"
@@ -18,960 +18,1154 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.9-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Polecenie"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Tytuł"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Tekst"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+"Wklejanie do terminala poleceń opublikowanych w sieci może być "
+"niebezpieczne. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+"Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Zaawansowane"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Wklej"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Nazwa"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "Identyfikator"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Nowy"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Zmodyfikuj"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Usuń"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Wprowadzanie hasła"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Zastosuj"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Hasło"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Potwierdzenie hasła"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Zatwierdź"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Dodawanie hasła"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Modyfikowanie hasła"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Wyświetla opcje wyszukiwania"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Wyszukuje następne wystąpienie"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Wyszukuje poprzednie wystąpienie"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Uwzględnianie wielkości liter"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Dopasowanie całych słów"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Dopasowanie do wyrażenia regularnego"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Przeszukanie od początku po osiągnięciu końca"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Zamknij"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Zmaksymalizuj"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Tylko do odczytu"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Dzwonek terminala"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Zmodyfikuj profil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Pewne procesy wciąż działają. Zamknąć mimo to?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Plik %s nie jest zgodny z formatem pliku JSON zestawu kolorów"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Nie można wczytać biblioteki %s. Przechowywanie haseł jest niedostępne."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Paleta zestawu kolorów wymaga 16 kolorów"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Nie wczytano biblioteki"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Zapisz zawartość…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Przywróć"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Przywróć i wyczyść"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profile"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Kodowanie znaków"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Wyszukaj…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Opcje układu…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+#, fuzzy
+msgid "Add Right"
+msgstr "Podzielenie w prawo"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Przywróć"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Otwórz odnośnik"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Skopiuj adres odnośnika"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Skopiuj"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Zaznacz wszystko"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Schowek"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Synchronizowanie wprowadzania"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Wystąpił nieoczekiwany błąd: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Zapisywanie zawartości terminala"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Zapisz"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Wszystkie pliki tekstowe"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Wszystkie pliki"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Proces podrzędny został zakończony w zwykły sposób, ze stanem %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Przerwano proces podrzędny sygnałem %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Przerwano proces podrzędny."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Uruchom ponownie"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Nie wklejaj"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Wklej mimo to"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opcje układu"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Bieżące"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Tytuł"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Wczytywanie sesji"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Polecenie"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Bieżące opcje działają cały czas i są wprowadzane natychmiastowo.\n"
+"Opcje wczytywania sesji są wprowadzane tylko podczas wczytywania pliku sesji."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Wyświetla pasek boczny sesji"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Tworzy nową sesję"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Dodaje terminal po prawej"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Dodaje terminal u dołu"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Wyszukuje tekst w terminalu"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Zmiana nazwy sesji"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Proszę wprowadzić nazwę sesji"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Otwórz…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Zapisz jako…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Nadaj nazwę…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Synchronizowanie"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Pewne procesy wciąż działają. Zamknąć mimo to?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Wszystkie pliki JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Plik „%s” nie istnieje"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Wczytywanie sesji"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Otwórz"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Błąd wczytywania sesji"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Zapisywanie sesji"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nowa sesja"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nowe okno"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Skróty klawiszowe"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "O programie"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Zakończ"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Zasługi"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Ustala katalog roboczy terminala"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "KATALOG"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Używa zdefiniowanego profilu"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "NAZWA_PROFILU"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Ustala tytuł nowego terminala"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TYTUŁ"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Otwiera określoną sesję"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "NAZWA_SESJI"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "NAZWA_CZYNNOŚCI"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Wykonuje określone polecenie"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "POLECENIE"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maksymalizuje rozmiar okna"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Maksymalizuje rozmiar okna"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Przełącza tryb pełnego ekranu"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Uaktywnia otwarte okno"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Uruchamia dodatkowe wystąpienie jako nowy proces (nie polecane)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Ustala rozmiar okna; np.: 80x24 lub 80x24+200+200 (KOLUMNYxWIERSZE+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "GEOMETRIA"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Otwiera okno w trybie quake lub przełącza widoczność okna otwartego w trybie "
+"quake"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINALA"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Natrafiono na problem z konfiguracją terminala.\n"
+"Błąd nie jest poważny, ale naprawienie go ułatwi pracę z programem.\n"
+"Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Wykryto błąd konfiguracji"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Modyfikowanie profilu: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Nowy profil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Ogólne"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Polecenie"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Kolory"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Przewijanie"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Zgodność"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Nazwa profilu"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "Identyfikator: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Rozmiar terminala"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "kolumn"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "wierszy"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Przywróć"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Kursor"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Blokowy"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "Linia pionowa"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Podkreślenie"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Tryb migania"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Systemowy"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Włączony"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Wyłączony"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Dzwonek terminala"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Brak"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Dźwięk"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Ikona"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Ikona i dźwięk"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Tytuł terminala"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Południowoeuropejskie"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Wygląd tekstu"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Zezwolenie na pogrubiony tekst"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Zawijanie podczas zmiany rozmiaru"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Własna czcionka"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Wybór czcionki terminala"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Zestaw kolorów"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Własny"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Paleta kolorów"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Opcje"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Kolory stylu dla tła i pierwszego planu"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Zaawansowane"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Przezroczystość"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Przyciemnienie nieaktywnych"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Tekst"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Tło"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Wybór koloru pierwszego planu kursora"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Wybór koloru tła kursora"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Zaznaczenie"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Wybór koloru pierwszego planu zaznaczenia"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Wybór koloru tła zaznaczenia"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Przyciemnienie"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Wybór koloru przyciemnienia"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Wybór koloru: %s"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Wybór koloru tła"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Wybór koloru pierwszego planu"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Pierwszy plan"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Czarny"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Czerwony"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Zielony"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Pomarańczowy"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Niebieski"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Fioletowy"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turkusowy"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Szary"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Wybór koloru: %s"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Wybór jasnego koloru: %s"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Zestaw kolorów"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Pasek przewijania"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Przewijanie po wypisaniu na wyjście"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Przewijanie po naciśnięciu klawisza"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Wielkość buforu przewijania:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Działanie klawisza Backspace"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatycznie"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "Znak DEL kodu ASCII"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Sekwencja sterująca"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "Znak wymazania TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Działanie klawisza Delete"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Kodowanie znaków"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Znaki o zmiennej szerokości"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Wąskie"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Szerokie"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Uruchamianie w roli powłoki startowej"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Uruchamianie własnego polecenia zamiast powłoki"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Działanie zakończenia polecenia"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Zakończenie działania terminala"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Ponowne uruchomienie polecenia"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Pozostawienia terminala otwartego"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Własne odnośniki"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Poniższa lista zawiera odnośniki zdefiniowane przez użytkownika na podstawie "
+"wyrażeń regularnych, które można kliknąć w terminalu."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr "Wyzwalacze"
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Wyzwalacze są wyrażeniami regularnymi porównywanymi ze standardowym wyjściem "
+"terminala. Wykrycie dopasowania powoduje wykonanie skonfigurowanej czynności."
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Automatyczne przełączanie profilów"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profile są automatycznie wybierane na podstawie wprowadzonych poniżej "
+"wartości.\n"
+"Wartości te należy wprowadzać w formacie <i>nazwa_komputera:katalog</i>. "
+"Można pominąć nazwę komputera lub ścieżkę katalogu ale należy zachować znak "
+"dwukropka. Niedozwolone są dopasowania pomijające nazwę komputera wraz ze "
+"ścieżką katalogu."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Dopasowanie"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Dodaj"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Dodawanie dopasowania"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Modyfikowanie dopasowania"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "Wyrażenie %s nie jest prawidłowym wyrażeniem regularnym"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Wyrażenie regularne"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Nieważna wielkość liter"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Modyfikowanie własnych odnośników"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Działanie"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parametr"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Zmodyfikuj profil"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Plik %s nie jest zgodny z formatem pliku JSON zestawu kolorów"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Paleta zestawu kolorów wymaga 16 kolorów"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Nie można odnaleźć porzuconego terminala"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Nie można odnaleźć sesji porzuconego terminala"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Domyślny"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -979,21 +1173,15 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "Zespół programistów widżetu GTK VTE, Terminix nie powstałby bez ich pracy"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD za udostępnienie świetnego interfejsu GTK"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org za doskonały język programowania, D"
@@ -1133,287 +1321,38 @@ msgstr "Wietnamskie"
 msgid "Thai"
 msgstr "Tajskie"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nowa sesja"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nowe okno"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Skróty klawiszowe"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "O programie"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Zakończ"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Zasługi"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Ustala katalog roboczy terminala"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "KATALOG"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Używa zdefiniowanego profilu"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "NAZWA_PROFILU"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Otwiera określoną sesję"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "NAZWA_SESJI"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "NAZWA_CZYNNOŚCI"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Wykonuje określone polecenie"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "POLECENIE"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maksymalizuje rozmiar okna"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Przełącza tryb pełnego ekranu"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Uaktywnia otwarte okno"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINALA"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Natrafiono na problem z konfiguracją terminala.\n"
-"Błąd nie jest poważny, ale naprawienie go ułatwi pracę z programem.\n"
-"Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Wykryto błąd konfiguracji"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Nie można odnaleźć porzuconego terminala"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Nie można odnaleźć sesji porzuconego terminala"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Nazwa"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Ogólne"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Wygląd"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profile"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Kodowania znaków wyświetlane w menu:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Włączony"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Działanie"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Klawisz skrótu"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Włączenie skrótów klawiszowych"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Zastępowanie istniejącego skrótu"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1423,981 +1362,194 @@ msgstr ""
 "Skrót %s jest już przypisany do czynności %s.\n"
 "Wyłączyć skrót dla innej czynności i przypisać go do bieżącej?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Domyślny"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nowy"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Zmodyfikuj"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Usuń"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Włączenie przezroczystości wymaga ponownego uruchomienia programu"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Pasek nagłówka terminala"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Zwykły"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Mały"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Brak"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Styl"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Jasny"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Ciemny"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Obraz tła"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Wybór obrazu"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Wszystkie pliki obrazów"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Czyści obraz tła"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Przeskalowany"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Rozmieszczony sąsiadująco"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Wyśrodkowany"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Rozciągnięty"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Nazwa domyślnej sesji"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Szerokie uchwyty elementów rozdzielających"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Przygaszanie nieaktywnych terminali"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Pasek boczny po prawej stronie"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Ustala tytuł nowego terminala"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "Rozmiar"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Terminal widoczny na wszystkich obszarach roboczych"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+#, fuzzy
+msgid "Hide window when focus is lost"
+msgstr "Zamknięcie okna po zakończeniu ostatniej sesji"
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Terminal widoczny na podstawowym ekranie"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Widoczny na określonym ekranie"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Zachowanie"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Dialog tworzenia nowej sesji"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Uaktywnianie terminala przenosząc nad niego wskaźnik myszy"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Ukrywanie wskaźnika myszy podczas pisania"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+"Zamykanie terminala kliknięciem środkowego przycisku myszy na pasku nagłówka"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Zamknięcie okna po zakończeniu ostatniej sesji"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Powiadamianie o zakończonych procesach"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Działanie nowego wystąpienia"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Podzielenie w prawo"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Podzielenie w dół"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Uaktywnienie okna"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Wklej"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
 # Notatki:
 # Dodaj notatkę
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Ostrzeganie o potencjalnie niebezpiecznej zawartości"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "Usuwanie pierwszego znaku komentarza lub deklaracji zmiennej"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opcje układu"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Kopiowanie tekstu po jego zaznaczeniu"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Zatwierdź"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Bieżące"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Tytuł"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Wczytywanie sesji"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Bieżące opcje działają cały czas i są wprowadzane natychmiastowo.\n"
-"Opcje wczytywania sesji są wprowadzane tylko podczas wczytywania pliku sesji."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Wyświetla opcje wyszukiwania"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Uwzględnianie wielkości liter"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Dopasowanie całych słów"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Dopasowanie do wyrażenia regularnego"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Przeszukanie od początku po osiągnięciu końca"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Zamknij"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Zmaksymalizuj"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Zmodyfikuj profil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Pewne procesy wciąż działają. Zamknąć mimo to?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Zapisz…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Wyszukaj…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Opcje układu…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Tylko do odczytu"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Przywróć i wyczyść"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Dzielenie"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Przywróć"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Otwórz odnośnik"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Skopiuj adres odnośnika"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Skopiuj"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Zaznacz wszystko"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Schowek"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Synchronizowanie wprowadzania"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Wystąpił nieoczekiwany błąd: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Zapisywanie zawartości terminala"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Wszystkie pliki tekstowe"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Wszystkie pliki"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Proces podrzędny został zakończony w zwykły sposób, ze stanem %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Przerwano proces podrzędny sygnałem %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Przerwano proces podrzędny."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Uruchom ponownie"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-"Wklejanie do terminala poleceń opublikowanych w sieci może być "
-"niebezpieczne. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-"Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Nie wklejaj"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Wklej mimo to"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Ignorowanie. Ciąg „%s” nie jest ścieżką katalogu."
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignorowanie parametru session. Sesja „%s” nie istnieje."
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2406,192 +1558,74 @@ msgstr ""
 "Nie można jednocześnie wczytać sesji i wskazać bieżącego profilu/katalogu "
 "roboczego/wykonywanego polecenia. Proszę wykonać jedną z tych czynności."
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Wyświetla pasek boczny sesji"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Tworzy nową sesję"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Zmiana nazwy sesji"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Proszę wprowadzić nazwę sesji"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Otwórz…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Zapisz"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Zapisz jako…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Nadaj nazwę…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Synchronizowanie"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Wszystkie pliki JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Plik „%s” nie istnieje"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Wczytywanie sesji"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Błąd wczytywania sesji"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Zapisywanie sesji"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "wyłączone"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "Zainstalowana wersja GTK jest przestarzała. Wymagana jest co najmniej wersja "
 "GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Wystąpił nieoczekiwany błąd"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Błąd: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Otwórz w Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Otwórz Terminix w %s"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Otwórz w Terminix…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Otwórz Terminix w %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "Otwórz Terminix tutaj…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "Otwiera Terminix w tym katalogu"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Otwórz Terminix tutaj…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Otwiera Terminix w tym katalogu"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Program"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Program"
@@ -2631,1145 +1665,271 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Wyświetlenie paska bocznego sesji"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
-msgctxt "shortcut window"
-msgid "Switch to next session"
-msgstr "Przełączenie następnej sesji"
-
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
-msgctxt "shortcut window"
-msgid "Switch to previous session"
-msgstr "Przełączenie poprzedniej sesji"
-
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
-msgctxt "shortcut window"
-msgid "Switch to session 1"
-msgstr "Przełączenie sesji 1"
-
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
-msgctxt "shortcut window"
-msgid "Switch to session 2"
-msgstr "Przełączenie sesji 2"
-
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
-msgctxt "shortcut window"
-msgid "Switch to session 3"
-msgstr "Przełączenie sesji 3"
-
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
-msgctxt "shortcut window"
-msgid "Switch to session 4"
-msgstr "Przełączenie sesji 4"
-
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
-msgctxt "shortcut window"
-msgid "Switch to session 5"
-msgstr "Przełączenie sesji 5"
-
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
-msgctxt "shortcut window"
-msgid "Switch to session 6"
-msgstr "Przełączenie sesji 6"
-
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
-msgctxt "shortcut window"
-msgid "Switch to session 7"
-msgstr "Przełączenie sesji 7"
-
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
-msgctxt "shortcut window"
-msgid "Switch to session 8"
-msgstr "Przełączenie sesji 8"
-
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
-msgctxt "shortcut window"
-msgid "Switch to session 9"
-msgstr "Przełączenie sesji 9"
-
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
-msgctxt "shortcut window"
-msgid "Switch to session 10"
-msgstr "Przełączenie sesji 10"
-
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
-msgid "Session"
-msgstr "Sesja"
-
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
-msgctxt "shortcut window"
-msgid "File"
-msgstr "Plik"
-
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
-msgctxt "shortcut window"
-msgid "Close the current session"
-msgstr "Zamknięcie bieżącej sesji"
-
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
-msgctxt "shortcut window"
-msgid "Save the current session"
-msgstr "Zapisanie bieżącej sesji"
-
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
-msgctxt "shortcut window"
-msgid "Save the current session with new filename"
-msgstr "Zapisanie bieżącej sesji pod nową nazwą pliku"
-
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
-msgctxt "shortcut window"
-msgid "Open a saved session"
-msgstr "Otwarcie zapisanej sesji"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
-#: data/resources/ui/shortcuts.ui:197
-msgctxt "shortcut window"
-msgid "Resize"
-msgstr "Zmiana rozmiaru"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
-#: data/resources/ui/shortcuts.ui:201
-msgctxt "shortcut window"
-msgid "Resize the terminal up"
-msgstr "Zmienienie rozmiaru terminala w górę"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
-#: data/resources/ui/shortcuts.ui:207
-msgctxt "shortcut window"
-msgid "Resize the terminal down"
-msgstr "Zmienienie rozmiaru terminala w dół"
-
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:213
-msgctxt "shortcut window"
-msgid "Resize the terminal left"
-msgstr "Zmienienie rozmiaru terminala w lewo"
-
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:219
-msgctxt "shortcut window"
-msgid "Resize the terminal right"
-msgstr "Zmienienie rozmiaru terminala w prawo"
-
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Przełączanie"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Przełączenie następnego terminala"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Przełączenie poprzedniego terminala"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Przełączenie górnego terminala"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Przełączenie dolnego terminala"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Przełączenie lewego terminala"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Przełączenie prawego terminala"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Przełączenie terminala 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Przełączenie terminala 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Przełączenie terminala 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Przełączenie terminala 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Przełączenie terminala 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Przełączenie terminala 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Przełączenie terminala 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Przełączenie terminala 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Przełączenie terminala 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Przełączenie terminala 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Dzielenie"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Podzielenie w prawo"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Podzielenie w dół"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Wyszukiwanie"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Wyszukanie następnego wystąpienia"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Wyszukanie poprzedniego wystąpienia"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Schowek"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Skopiowanie tekstu"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Wklejenie tekstu"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Zaznaczenie wszystkiego"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Rozmiar"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Powiększenie zawartości"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Pomniejszenie zawartości"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Przywrócenie zwykłego rozmiaru"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "Inne"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr "Zapisanie zawartości terminala"
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr "Zamknięcie terminala"
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr "Zmaksymalizowanie terminala"
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr "Wyświetlenie preferencji profilu"
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr "Przywrócenie terminala"
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr "Przywrócenie i wyczyszczenie terminala"
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr "Ustalenie tylko do odczytu"
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr "Wyświetlenie opcji układu"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-"Emuluje działanie terminala w środowisku GNOME wykorzystując interfejs kafli"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr "com.gexperts.Terminix"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Nowy terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-"Emuluje działanie terminala w środowisku GNOME wykorzystując interfejs kafli"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr "Terminix jest emulatorem terminala obsługującym kafle."
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr "Przezroczyste tło"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#, fuzzy
-msgid "Supports notifications when processes are completed out of view"
-msgstr "Powiadamianie o zakończonych procesach"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr "Terminix został przetestowany z GNOME i Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Ustala rozmiar okna; np.: 80x24 lub 80x24+200+200 (KOLUMNYxWIERSZE+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "GEOMETRIA"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Okno"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Zmienienie nazwy sesji"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Zsynchronizowanie wprowadzania znaków"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sesja"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Zapisz zawartość…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Otwórz"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Wyszukuje następne wystąpienie"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Wyszukuje poprzednie wystąpienie"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Uruchamia dodatkowe wystąpienie jako nowy proces (nie polecane)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Dodaje terminal po prawej"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Dodaje terminal u dołu"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Wyszukuje tekst w terminalu"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Dźwięk"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Ikona"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Ikona i dźwięk"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Automatyczne przełączanie profilów"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Dopasowanie"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Dodaj"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Dodawanie dopasowania"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Modyfikowanie dopasowania"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Obraz tła"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Wybór obrazu"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Wszystkie pliki obrazów"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Czyści obraz tła"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Przeskalowany"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Rozmieszczony sąsiadująco"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Wyśrodkowany"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Rozciągnięty"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Dodawanie"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Dodanie terminala po prawej"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Dodanie terminala u dołu"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Kopiowanie tekstu po jego zaznaczeniu"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-#, fuzzy
-msgid "Add Right"
-msgstr "Podzielenie w prawo"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Ustala tytuł nowego terminala"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TYTUŁ"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Profile są automatycznie wybierane na podstawie wprowadzonych poniżej "
-"wartości.\n"
-"Wartości te należy wprowadzać w formacie <i>nazwa_komputera:katalog</i>. "
-"Można pominąć nazwę komputera lub ścieżkę katalogu ale należy zachować znak "
-"dwukropka. Niedozwolone są dopasowania pomijające nazwę komputera wraz ze "
-"ścieżką katalogu."
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Włączenie skrótów klawiszowych"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Własne odnośniki"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Poniższa lista zawiera odnośniki zdefiniowane przez użytkownika na podstawie "
-"wyrażeń regularnych, które można kliknąć w terminalu."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profile są automatycznie wybierane na podstawie wprowadzonych poniżej "
-"wartości.\n"
-"Wartości te należy wprowadzać w formacie <i>nazwa_komputera:katalog</i>. "
-"Można pominąć nazwę komputera lub ścieżkę katalogu ale należy zachować znak "
-"dwukropka. Niedozwolone są dopasowania pomijające nazwę komputera wraz ze "
-"ścieżką katalogu."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "Wyrażenie %s nie jest prawidłowym wyrażeniem regularnym"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Wyrażenie regularne"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Nieważna wielkość liter"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Modyfikowanie własnych odnośników"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Zastosuj"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Zmienienie rozmiaru terminala w górę"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Nie można wczytać biblioteki %s. Przechowywanie haseł jest niedostępne."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Nie wczytano biblioteki"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Identyfikator"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Wprowadzanie hasła"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Hasło"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Potwierdzenie hasła"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Dodawanie hasła"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Modyfikowanie hasła"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Wykonuje określone polecenie"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "POLECENIE"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Otwiera okno w trybie quake lub przełącza widoczność okna otwartego w trybie "
-"quake"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "Tryb QUAKE"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-"Nie można otworzyć okna w trybie quake z parametrami maximize, fullscreen "
-"lub geometry"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr "Wyzwalacze"
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Wyzwalacze są wyrażeniami regularnymi porównywanymi ze standardowym wyjściem "
-"terminala. Wykrycie dopasowania powoduje wykonanie skonfigurowanej czynności."
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parametr"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Zmodyfikuj profil"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Polecenie"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Tytuł"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Tekst"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Pasek boczny po prawej stronie"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Terminal widoczny na wszystkich obszarach roboczych"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Terminal widoczny na podstawowym ekranie"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Widoczny na określonym ekranie"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Wysokość terminala"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-"Zamykanie terminala kliknięciem środkowego przycisku myszy na pasku nagłówka"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Zamknięcie okna po zakończeniu ostatniej sesji"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Wstaw hasło"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Zaawansowane"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Maksymalizuje rozmiar okna"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Nazwa domyślnej sesji"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Ustala tytuł nowego terminala"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "Rozmiar"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
 #: data/resources/ui/shortcuts.ui:61
 #, fuzzy
 msgctxt "shortcut window"
 msgid "View session switcher"
 msgstr "Wyświetla pasek boczny sesji"
+
+#: data/resources/ui/shortcuts.ui:67
+msgctxt "shortcut window"
+msgid "Switch to next session"
+msgstr "Przełączenie następnej sesji"
+
+#: data/resources/ui/shortcuts.ui:73
+msgctxt "shortcut window"
+msgid "Switch to previous session"
+msgstr "Przełączenie poprzedniej sesji"
+
+#: data/resources/ui/shortcuts.ui:79
+msgctxt "shortcut window"
+msgid "Switch to session 1"
+msgstr "Przełączenie sesji 1"
+
+#: data/resources/ui/shortcuts.ui:85
+msgctxt "shortcut window"
+msgid "Switch to session 2"
+msgstr "Przełączenie sesji 2"
+
+#: data/resources/ui/shortcuts.ui:91
+msgctxt "shortcut window"
+msgid "Switch to session 3"
+msgstr "Przełączenie sesji 3"
+
+#: data/resources/ui/shortcuts.ui:97
+msgctxt "shortcut window"
+msgid "Switch to session 4"
+msgstr "Przełączenie sesji 4"
+
+#: data/resources/ui/shortcuts.ui:103
+msgctxt "shortcut window"
+msgid "Switch to session 5"
+msgstr "Przełączenie sesji 5"
+
+#: data/resources/ui/shortcuts.ui:109
+msgctxt "shortcut window"
+msgid "Switch to session 6"
+msgstr "Przełączenie sesji 6"
+
+#: data/resources/ui/shortcuts.ui:115
+msgctxt "shortcut window"
+msgid "Switch to session 7"
+msgstr "Przełączenie sesji 7"
+
+#: data/resources/ui/shortcuts.ui:121
+msgctxt "shortcut window"
+msgid "Switch to session 8"
+msgstr "Przełączenie sesji 8"
+
+#: data/resources/ui/shortcuts.ui:127
+msgctxt "shortcut window"
+msgid "Switch to session 9"
+msgstr "Przełączenie sesji 9"
+
+#: data/resources/ui/shortcuts.ui:133
+msgctxt "shortcut window"
+msgid "Switch to session 10"
+msgstr "Przełączenie sesji 10"
+
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
+msgid "Session"
+msgstr "Sesja"
+
+#: data/resources/ui/shortcuts.ui:149
+msgctxt "shortcut window"
+msgid "File"
+msgstr "Plik"
+
+#: data/resources/ui/shortcuts.ui:153
+msgctxt "shortcut window"
+msgid "Close the current session"
+msgstr "Zamknięcie bieżącej sesji"
+
+#: data/resources/ui/shortcuts.ui:159
+msgctxt "shortcut window"
+msgid "Save the current session"
+msgstr "Zapisanie bieżącej sesji"
+
+#: data/resources/ui/shortcuts.ui:165
+msgctxt "shortcut window"
+msgid "Save the current session with new filename"
+msgstr "Zapisanie bieżącej sesji pod nową nazwą pliku"
+
+#: data/resources/ui/shortcuts.ui:171
+msgctxt "shortcut window"
+msgid "Open a saved session"
+msgstr "Otwarcie zapisanej sesji"
+
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Dodawanie"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Dodanie terminala po prawej"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Dodanie terminala u dołu"
+
+#: data/resources/ui/shortcuts.ui:197
+msgctxt "shortcut window"
+msgid "Resize"
+msgstr "Zmiana rozmiaru"
+
+#: data/resources/ui/shortcuts.ui:201
+msgctxt "shortcut window"
+msgid "Resize the terminal up"
+msgstr "Zmienienie rozmiaru terminala w górę"
+
+#: data/resources/ui/shortcuts.ui:207
+msgctxt "shortcut window"
+msgid "Resize the terminal down"
+msgstr "Zmienienie rozmiaru terminala w dół"
+
+#: data/resources/ui/shortcuts.ui:213
+msgctxt "shortcut window"
+msgid "Resize the terminal left"
+msgstr "Zmienienie rozmiaru terminala w lewo"
+
+#: data/resources/ui/shortcuts.ui:219
+msgctxt "shortcut window"
+msgid "Resize the terminal right"
+msgstr "Zmienienie rozmiaru terminala w prawo"
+
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "Inne"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Zmienienie nazwy sesji"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Zsynchronizowanie wprowadzania znaków"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Przełączanie"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Przełączenie następnego terminala"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Przełączenie poprzedniego terminala"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Przełączenie górnego terminala"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Przełączenie dolnego terminala"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Przełączenie lewego terminala"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Przełączenie prawego terminala"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Przełączenie terminala 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Przełączenie terminala 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Przełączenie terminala 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Przełączenie terminala 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Przełączenie terminala 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Przełączenie terminala 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Przełączenie terminala 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Przełączenie terminala 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Przełączenie terminala 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Przełączenie terminala 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Wyszukiwanie"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Wyszukanie następnego wystąpienia"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Wyszukanie poprzedniego wystąpienia"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Schowek"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Skopiowanie tekstu"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Wklejenie tekstu"
 
 #: data/resources/ui/shortcuts.ui:401
 #, fuzzy
@@ -3777,88 +1937,82 @@ msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr "Zaawansowane"
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Zaznaczenie wszystkiego"
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Rozmiar"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Powiększenie zawartości"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Pomniejszenie zawartości"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Przywrócenie zwykłego rozmiaru"
+
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
+msgstr "Zapisanie zawartości terminala"
+
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
+msgstr "Zamknięcie terminala"
+
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
+msgstr "Zmaksymalizowanie terminala"
+
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
+msgstr "Wyświetlenie preferencji profilu"
+
+#: data/resources/ui/shortcuts.ui:467
+msgctxt "shortcut window"
+msgid "Reset the terminal"
+msgstr "Przywrócenie terminala"
+
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
+msgstr "Przywrócenie i wyczyszczenie terminala"
+
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
+msgstr "Ustalenie tylko do odczytu"
+
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
+msgstr "Wyświetlenie opcji układu"
+
+#: data/resources/ui/shortcuts.ui:491
 #, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Pewne procesy wciąż działają. Zamknąć mimo to?"
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Zmienienie rozmiaru terminala w górę"
 
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
+#: data/resources/ui/shortcuts.ui:497
 #, fuzzy
-msgid "Do not show this again"
-msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Południowoeuropejskie"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Wybór koloru: %s"
-
-#: source/gx/terminix/prefwindow.d:753
-#, fuzzy
-msgid "Hide window when focus is lost"
-msgstr "Zamknięcie okna po zakończeniu ostatniej sesji"
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Otwórz w Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Otwórz Terminix w %s"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Otwórz w Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "Otwórz Terminix tutaj…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "Otwiera Terminix w tym katalogu"
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Wstaw hasło"
 
 #: data/resources/ui/shortcuts.ui:503
 #, fuzzy
@@ -3866,28 +2020,79 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr "Pasek nagłówka terminala"
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
+msgstr ""
+"Emuluje działanie terminala w środowisku GNOME wykorzystując interfejs kafli"
+
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
+msgstr "com.gexperts.Terminix"
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
+msgstr ""
+"Emuluje działanie terminala w środowisku GNOME wykorzystując interfejs kafli"
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
+msgstr "Terminix jest emulatorem terminala obsługującym kafle."
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr "Przezroczyste tło"
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #, fuzzy
-msgid "Export Color Scheme"
-msgstr "Zestaw kolorów"
+msgid "Supports notifications when processes are completed out of view"
+msgstr "Powiadamianie o zakończonych procesach"
 
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Terminal widoczny na podstawowym ekranie"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
+msgstr "Terminix został przetestowany z GNOME i Unity."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-11-06 00:53+0000\n"
 "Last-Translator: Daniel Miranda <danielkza2@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -15,961 +15,1150 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr "AtualizarEstado"
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr "ExecutarComando"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr "EnviarNotificação"
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr "AtualizarTítulo"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr "SinalizarAtenção"
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr "EnviarTexto"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr "InserirSenha"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Este comando requer acesso administrativo ao seu computador"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiar comandos da Internet pode ser perigoso. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Assegure-se de que entende o que cada parte desse comando faz."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformar"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Colagem avançada"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Colar"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Nome"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Novo"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Editar"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Excluir"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Incluir quebra de linha com senha"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Inserir Senha"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Aplicar"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Senha"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Confirmar Senha"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Adicionar Senha"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Editar Senha"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Opções de pesquisa"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Localizar a próxima occorência"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Localizar a ocorrência anterior"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Diferenciar maiúsculas/minúsculas"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Coincidir somente palavra inteira"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Coincidir como expressão regular"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Voltar ao início"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Fechar"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximizar"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Desabilitar sincronização de entrada neste terminal"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Somente leitura"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Sinal de atenção"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Processos ainda estão em execução. Deseja fechar mesmo assim?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Habilitar sincronização de entrada neste terminal"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"A biblioteca %s não pôde ser carregada, a funcionalidade de senha ficará "
+"indisponível."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "A paleta do esquema de cores requer 16 cores"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Biblioteca não carregada"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Salvar saída…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Redefinir"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Redefinir e limpar"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Perfis"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Codificação"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Localizar…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Opções de layout…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Adicionar terminal à direita"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Adicionar terminal abaixo"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Restaurar"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Abrir link"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Copiar endereço do link"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Copiar"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Selecionar tudo"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Ocorreu um erro inesperado: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Salvar saída do terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Salvar"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Todos os arquivos de texto"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Todos os arquivos"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "O processo filho encerrou normalmente com o estado %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "O processo filho foi abortado pelo sinal %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "O processo filho foi abortado."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Recarregar"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Não colar"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Colar mesmo assim"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Opções de leiaute"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Ativo"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Título"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Ao carregar sessão"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Comando"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Ativo: mudanças nessas opções são aplicadas imediatamente.\n"
+"Ao carregar sessão: mudanças nessas opções são aplicadas ao carregar um "
+"arquivo de sessão."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Visualizar barra lateral de sessões"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Criar uma nova sessão"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Adicionar terminal à direita"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Adicionar terminal abaixo"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Localizar texto no terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Renomear sessão"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Digite um novo nome para a sessão"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Abrir…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Salvar como…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Nome…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Múltiplas sessões estão em uso, fechar mesmo assim?"
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr "Não exibir esta mensagem novamente"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Todos os arquivos JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "O arquivo '%s' não existe"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Carregar sessão"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Abrir"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Erro ao carregar sessão"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Salvar sessão"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Nova sessão"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nova janela"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Preferências"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Atalhos do teclado"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Sobre"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Sair"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Créditos"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Definir o diretório de trabalho para o terminal"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DIRETÓRIO"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Definir o perfil inicial"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "NOME_DO_PERFIL"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Definir título do novo terminal"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TÍTULO"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Abrir a sessão especificada"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "NOME_DA_SESSÃO"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Enviar uma ação para a instância atual do Terminix"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "NOME_DA_AÇÃO"
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr "Executar o parâmetro como comando"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "COMANDO"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maximizar a janela do terminal"
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr "Minimizar a janela do terminal"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Alternar a janela do terminal para tela cheia"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Ativar a janela existente"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Iniciar instância adicional em novo processo (não recomendado)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Definir o tamanho da janela; por exemplo: 80x24 ou 80x24+200+200 "
+"(COLUNASxLINHAS+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "GEOMETRIA"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Abre nova janela, ou alterna visibilidade de janela existente (modo Quake)"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr "Mostrar versão do Terminix e de componentes dependentes"
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argumento oculto para fornecer o UUID do terminal"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID_DO_TERMINAL"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Parece haver um problema com a configuração do terminal.\n"
+"O problema não é grave, mas corrigi-lo irá melhorar a sua experiência.\n"
+"Clique no link a seguir para mais informações:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Problema de configuração detectado"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Não exibir esta mensagem novamente"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Editando perfil: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Geral"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Comando"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Cor"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Rolagem"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Avançado"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Nome do perfil"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Tamanho do terminal"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "colunas"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "linhas"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Redefinir"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Cursor"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Bloco"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "IBeam"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Sublinhado"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Piscar"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Configuração do sistema"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Ligado"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Desligado"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Sinal de atenção"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Nenhum"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Som"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Ícone"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Ícone e Som"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Título do terminal"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr "Noroeste"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr "Nordeste"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr "Sudoeste"
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr "Sudeste"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Aparência do texto"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Permitir negrito"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Reajustar ao redimensionar"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Fonte personalizada"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Escolher fonte do terminal"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Esquema de cores"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Personalizado"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr "Exportar"
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Paleta de cores"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Opções"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Utilizar cores de sistema para texto/fundo"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Avançado"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Transparência"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Escurecer quando fora de foco"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Texto"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Fundo"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Selecionar cor principal do cursor"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Selecionar cor de fundo do cursor"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Destacado"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Selecionar cor de texto destacado"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Selecionar cor de fundo destacado"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Escurecer"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Selecionar cor escura"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Selecionar cor %s"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Selecionar cor de fundo"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Selecionar cor do texto"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Texto"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Preto"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Vermelho"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Verde"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Laranja"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Azul"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Roxo"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turquesa"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Cinza"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Selecionar cor %s"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Selecionar cor %s clara"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+msgid "Export Color Scheme"
+msgstr "Exportar esquema de cores"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Mostrar barra de rolagem"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Rolar na saída"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Rolar ao digitar"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Limite de rolagem:"
 
 # Terminix gettext pot file
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Tecla Backspace gera"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automático"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Sequência de escape"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Tecla Delete gera"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Codificação"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Caracteres de largura ambígua"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Estreitar"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Alargar"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Executar comando como um shell de login"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Executar um comando personalizado ao invés do meu shell"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Após termino do comando"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Sair do terminal"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Reiniciar o comando"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Manter o terminal aberto"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Links personalizados"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Uma lista de links definidos pelo usuário que podem ser clicados no terminal "
+"com base em definições de expressões regulares."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr "Acionadores"
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Acionadores são expressões regulares comparadas com o texto de saída do "
+"terminal. Quando correspondências são detectadas, a ação configurada é "
+"executada."
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Seleção automática de perfil"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
+"Entradas usam o formato <i>usuário@nome-do-host:diretório</i>. O nome de "
+"host ou diretório podem ser omitidos, mas não ambos, e o caractere dois "
+"pontos precisa ser mantido."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
+"Entradas usam o formato <i>nome da máquina:diretório</i>. O nome da máquina "
+"ou diretório podem ser omitidos, mas não ambos, as entradas sem nome da "
+"máquina ou diretório não são permitidas."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Correspondências"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Adicionar"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr "Digite um padrão no formato usuário@nome-do-host:diretório"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Digite um padrão de nome do host:diretório"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Adicionar novo padrâo de correspondência"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr "Editar padrão no formato usuário@nome-do-host:diretório"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Editar padrão de nome do host:diretório"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Editar padrão de correspondência"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "A expressão %s não é uma expressão regular válida"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Expressão regular"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Diferencia maiúsculas e minúsculas"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Editar links personalizados"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Ação"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parâmetro"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr "Editar acionadores"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "A paleta do esquema de cores requer 16 cores"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Não foi possível localizar o terminal soltado"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Não foi possível localizar a sessão do terminal soltado"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Padrão"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Perfil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Um emulador de terminal para o Linux baseado no VTE"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -980,22 +1169,16 @@ msgstr ""
 "v. 2.0. Se uma cópia da MPL não foi distribuída com este arquivo, você pode "
 "obtê-la em http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "Time de ferramentas VTE do GTK, o Terminix não seria possível sem seu "
 "trabalho"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD por fornecer uma excelente biblioteca de integração com GTK"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org pela excelente linguagem de programação D"
@@ -1138,287 +1321,38 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandês"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Nova sessão"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nova janela"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Preferências"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Atalhos do teclado"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Sobre"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Sair"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Créditos"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Definir o diretório de trabalho para o terminal"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DIRETÓRIO"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Definir o perfil inicial"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "NOME_DO_PERFIL"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Abrir a sessão especificada"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "NOME_DA_SESSÃO"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Enviar uma ação para a instância atual do Terminix"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "NOME_DA_AÇÃO"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Executar o comando fornecido"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "EXECUTAR"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maximizar a janela do terminal"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Alternar a janela do terminal para tela cheia"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Ativar a janela existente"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argumento oculto para fornecer o UUID do terminal"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID_DO_TERMINAL"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Parece haver um problema com a configuração do terminal.\n"
-"O problema não é grave, mas corrigi-lo irá melhorar a sua experiência.\n"
-"Clique no link a seguir para mais informações:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Problema de configuração detectado"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Não foi possível localizar o terminal soltado"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Não foi possível localizar a sessão do terminal soltado"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Nome"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Perfil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Global"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Aparência"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Perfis"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr "Quake"
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Codificações exibidas no menu:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Ação"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Tecla de atalho"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Habilitar atalhos do teclado"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Sobrescrever atalho existente"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1428,979 +1362,190 @@ msgstr ""
 "O atalho %s já está atribuído para %s.\n"
 "Desabilitar a ação existente e substituí-la pela nova?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Padrão"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Novo"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Editar"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Excluir"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Habilitar transparência, requer re-início"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Estilo do título do terminal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Pequeno"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Nenhum"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Variante do tema"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Claro"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Escuro"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Imagem de fundo"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Selecionar imagem"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Todos os arquivos de imagem"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Reinicializar imagem de fundo"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Preencher"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Lado a lado"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Centralizar"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Estender"
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr "Nome da sessão padrão"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Utilizar uma borda larga para os divisores"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Escurecer terminais fora de foco"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Mostrar barra lateral na direita"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Mostrar o título do terminal mesmo que seja o único"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr "Tamanho"
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr "Porcento de altura"
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr "Porcento de largura"
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Mostrar o terminal em todos os espaços de trabalho"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr "Definir dica para o gerenciador de janelas desativar a animação"
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr "Esconder janela ao retirar foco"
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr "Exibir terminal apenas no monitor ativo"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Exibir terminal no monitor"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Alertar ao criar uma nova sessão"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Ativar terminal quando o cursor é colocado sobre ele"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Ocultar automaticamente o cursor ao digitar"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Fechar terminal com clique do meio no título"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Fechar janela ao encerrar a última sessão"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Enviar notificação para a área de trabalho quando o processo terminar"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Ao iniciar nova instância"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Dividir à direita"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Dividir abaixo"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Ativar janela existente"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Colar"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr "Sempre usar o diálogo de colagem avançada"
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Alertar ao tentar colar comando inseguro"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Retira o primeiro caractere da colagem se comentário ou declaração de "
 "variável"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Opções de leiaute"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Copiar texto automaticamente ao selecionar"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Ativo"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Título"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Ao carregar sessão"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Ativo: mudanças nessas opções são aplicadas imediatamente.\n"
-"Ao carregar sessão: mudanças nessas opções são aplicadas ao carregar um "
-"arquivo de sessão."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Opções de pesquisa"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Diferenciar maiúsculas/minúsculas"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Coincidir somente palavra inteira"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Coincidir como expressão regular"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Voltar ao início"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Fechar"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximizar"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Desabilitar sincronização de entrada neste terminal"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Processos ainda estão em execução. Deseja fechar mesmo assim?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Habilitar sincronização de entrada neste terminal"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Salvar…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Localizar…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Opções de layout…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Somente leitura"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Redefinir e limpar"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Dividir"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Restaurar"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Abrir link"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Copiar endereço do link"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Copiar"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Selecionar tudo"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Área de transferência"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Ocorreu um erro inesperado: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Salvar saída do terminal"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Todos os arquivos de texto"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Todos os arquivos"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "O processo filho encerrou normalmente com o estado %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "O processo filho foi abortado pelo sinal %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "O processo filho foi abortado."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Recarregar"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Este comando requer acesso administrativo ao seu computador"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiar comandos da Internet pode ser perigoso. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Assegure-se de que entende o que cada parte desse comando faz."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Não colar"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Colar mesmo assim"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Ignorando '%s' pois não é um diretório"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignorando parâmetro de sessão pois '%s' não existe"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2409,194 +1554,77 @@ msgstr ""
 "Você não pode carregar uma sessão e definir perfil/diretório de trabalho/"
 "comando a ser executado ao mesmo tempo. Por favor escolha entre um e outro"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Visualizar barra lateral de sessões"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr "Você só pode usar o parâmetro ação dentro do Terminix"
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Criar uma nova sessão"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
+"Você não pode usar o modo Quake com os parâmetros maximizar, tela cheia ou "
+"geometria"
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Renomear sessão"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Digite um novo nome para a sessão"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Abrir…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Salvar"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Salvar como…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Nome…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Todos os arquivos JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "O arquivo '%s' não existe"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Carregar sessão"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Erro ao carregar sessão"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Salvar sessão"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "desabilitado"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 "Sua versão do GTK é muito antiga, você precisa pelo menos do GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Ocorreu uma exceção inesperada"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Erro: "
 
 # ******************
 # Nautilus extension
 # ******************
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
+msgstr "Abrir Terminix Remoto…"
+
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Abrir Terminix Remoto em %s"
+
+# ******************
+# Nautilus extension
+# ******************
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
 msgstr "Abrir no Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Abrir Terminix em %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr "Abrir Terminix Remoto aqui…"
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr "Abrir Terminix Remoto neste diretório"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Abrir Terminix aqui…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Abrir Terminix neste diretório"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Aplicação"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Aplicação"
@@ -2636,257 +1664,247 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Visualizar barra lateral de sessões"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Visualizar alternador de sessão"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Alternar para a próxima sessão"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Alternar para a sessão anterior"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Alternar para a sessão 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Alternar para a sessão 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Alternar para a sessão 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Alternar para a sessão 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Alternar para a sessão 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Alternar para a sessão 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Alternar para a sessão 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Alternar para a sessão 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Alternar para a sessão 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Alternar para a sessão 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Sessão"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Arquivo"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Encerrar a sessão atual"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Salvar a sessão atual"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Salvar a sessão atual com um novo nome de arquivo"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Abrir uma sessão salva"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Adicionar"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Adicionar terminal à direita"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Adicionar terminal abaixo"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Redimensionar"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Redimensionar o terminal para cima"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Redimensionar o terminal para baixo"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Redimensionar o terminal para a esquerda"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Redimensionar o terminal para a direita"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "Outro"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Editar o nome da sessão"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Sincronizar a entrada"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
 msgid "Switch"
 msgstr "Alternar"
 
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
+#: data/resources/ui/shortcuts.ui:249
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "Alternar para o próximo terminal"
 
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
+#: data/resources/ui/shortcuts.ui:255
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "Alternar para o terminal anterior"
 
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
+#: data/resources/ui/shortcuts.ui:261
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "Alternar para o terminal de cima"
 
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
+#: data/resources/ui/shortcuts.ui:267
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "Alternar para o terminal de baixo"
 
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
+#: data/resources/ui/shortcuts.ui:273
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "Alternar para o terminal da esquerda"
 
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
+#: data/resources/ui/shortcuts.ui:279
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "Alternar para o terminal da direita"
 
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
+#: data/resources/ui/shortcuts.ui:291
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "Alternar para o terminal 1"
 
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
+#: data/resources/ui/shortcuts.ui:297
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "Alternar para o terminal 2"
 
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
+#: data/resources/ui/shortcuts.ui:303
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "Alternar para o terminal 3"
 
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
+#: data/resources/ui/shortcuts.ui:309
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "Alternar para o terminal 4"
 
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
+#: data/resources/ui/shortcuts.ui:315
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "Alternar para o terminal 5"
 
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
+#: data/resources/ui/shortcuts.ui:321
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "Alternar para o terminal 6"
 
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
+#: data/resources/ui/shortcuts.ui:327
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "Alternar para o terminal 7"
 
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
+#: data/resources/ui/shortcuts.ui:333
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "Alternar para o terminal 8"
 
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
+#: data/resources/ui/shortcuts.ui:339
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "Alternar para o terminal 9"
 
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
+#: data/resources/ui/shortcuts.ui:345
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "Alternar para o terminal 10"
 
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Dividir"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Dividir à direita"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Dividir abaixo"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
 #: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
 msgctxt "shortcut window"
 msgid "Find"
 msgstr "Localizar"
 
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
+#: data/resources/ui/shortcuts.ui:371
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "Localizar próximo"
@@ -2896,147 +1914,131 @@ msgstr "Localizar próximo"
 # in the Shortcut preferences and in the future
 # the shortcut overview if available in Gnome 3.20
 # ***********************************************
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
+#: data/resources/ui/shortcuts.ui:377
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "Localizar anterior"
 
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
 msgid "Clipboard"
 msgstr "Área de transferência"
 
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "Copiar"
 
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "Colar"
 
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
+#: data/resources/ui/shortcuts.ui:401
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Colagem avançada"
+
+#: data/resources/ui/shortcuts.ui:407
 msgctxt "shortcut window"
 msgid "Select all"
 msgstr "Selecionar tudo"
 
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
+#: data/resources/ui/shortcuts.ui:415
 msgctxt "shortcut window"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
+#: data/resources/ui/shortcuts.ui:419
 msgctxt "shortcut window"
 msgid "Zoom in"
 msgstr "Aumentar zoom"
 
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
+#: data/resources/ui/shortcuts.ui:425
 msgctxt "shortcut window"
 msgid "Zoom out"
 msgstr "Diminuir zoom"
 
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
+#: data/resources/ui/shortcuts.ui:431
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "Restaurar zoom padrão"
 
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "Outro"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Salvar o conteúdo do terminal"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Fechar o terminal"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Maximizar o terminal"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Preferências do perfil atual"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Redefinir o terminal"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Redefinir e limpar o terminal"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Alternar para somente leitura"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Opções de layout"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Inserir o número do terminal"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Inserir senha"
+
+#: data/resources/ui/shortcuts.ui:503
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Alternar estilo de título"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Um terminal em mosaico para o GNOME"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Novo Terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Um terminal em mosaico para o GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix é um emulador de terminal em mosaico."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Ele permite:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
@@ -3044,7 +2046,6 @@ msgstr ""
 "Dispor terminais de diferentes maneiras, dividindo-os horizontalmente ou "
 "verticalmente"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3053,12 +2054,10 @@ msgstr ""
 "Reorganizar terminais arrastando e soltando em uma mesma janela, ou entre "
 "janelas diferentes"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "Separar terminais em novas janelas arrastando e soltando"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3067,17 +2066,14 @@ msgstr ""
 "Sincronizar a entrada entre diferentes terminais, replicando comandos "
 "digitados em um terminal para outros"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "Carregar e salvar grupos de terminais de/para o disco"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Atribuir títulos personalizados aos terminais"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3086,17 +2082,14 @@ msgstr ""
 "Criar e armazenar novos esquemas de cores personalizados apenas manipulando "
 "arquivos"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Utilizar plano de fundo transparente"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "Receber notificações quando processos terminarem em segundo plano"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3107,798 +2100,6 @@ msgstr ""
 "usuário do GNOME (GNOME HIG). Portanto, decorações de janela internas são "
 "utilizadas, mas podem ser desabilitadas se necessário."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "O Terminix foi testado nos ambientes GNOME e Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Definir o tamanho da janela; por exemplo: 80x24 ou 80x24+200+200 "
-"(COLUNASxLINHAS+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "GEOMETRIA"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Janela"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Editar o nome da sessão"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Sincronizar a entrada"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Sessão"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Salvar saída…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Abrir"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Localizar a próxima occorência"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Localizar a ocorrência anterior"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Iniciar instância adicional em novo processo (não recomendado)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Adicionar terminal à direita"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Localizar texto no terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Som"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Ícone"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Ícone e Som"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Seleção automática de perfil"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Correspondências"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Adicionar"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Adicionar novo padrâo de correspondência"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Digite um padrão de nome do host:diretório"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Editar padrão de correspondência"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Editar padrão de nome do host:diretório"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Imagem de fundo"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Selecionar imagem"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Todos os arquivos de imagem"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Reinicializar imagem de fundo"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Preencher"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Lado a lado"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Centralizar"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Estender"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Adicionar"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Adicionar terminal à direita"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Copiar texto automaticamente ao selecionar"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Adicionar terminal à direita"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Definir título do novo terminal"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TÍTULO"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>nome do host:diretório</i>. O nome do host ou "
-"diretório podem ser omitidos, mas não ambos. As entradas com nenhum nome do "
-"host ou diretório não são permitidas"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Habilitar atalhos do teclado"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Links personalizados"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Uma lista de links definidos pelo usuário que podem ser clicados no terminal "
-"com base em definições de expressões regulares."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>nome da máquina:diretório</i>. O nome da máquina "
-"ou diretório podem ser omitidos, mas não ambos, as entradas sem nome da "
-"máquina ou diretório não são permitidas."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "A expressão %s não é uma expressão regular válida"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Expressão regular"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Diferencia maiúsculas e minúsculas"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Editar links personalizados"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Aplicar"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Inserir o número do terminal"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"A biblioteca %s não pôde ser carregada, a funcionalidade de senha ficará "
-"indisponível."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Biblioteca não carregada"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Incluir quebra de linha com senha"
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Inserir Senha"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Senha"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Confirmar Senha"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Adicionar Senha"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Editar Senha"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr "Executar o parâmetro como comando"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "COMANDO"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Abre nova janela, ou alterna visibilidade de janela existente (modo Quake)"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "QUAKE"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-"Não é possível usar o modo Quake com os parâmetros maximize, fullscreen ou "
-"geometry"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr "Acionadores"
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Acionadores são expressões regulares comparadas com o texto de saída do "
-"terminal. Quando correspondências são detectadas, a ação configurada é "
-"executada."
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>usuário@nome-do-host:diretório</i>. O nome de "
-"host ou diretório podem ser omitidos, mas não ambos, e o caractere dois "
-"pontos precisa ser mantido."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr "Digite um padrão no formato usuário@nome-do-host:diretório"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr "Editar padrão no formato usuário@nome-do-host:diretório"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parâmetro"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr "Editar acionadores"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr "AtualizarEstado"
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr "ExecutarComando"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr "EnviarNotificação"
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr "AtualizarTítulo"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr "SinalizarAtenção"
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr "EnviarTexto"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr "InserirSenha"
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Mostrar barra lateral na direita"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Mostrar o terminal em todos os espaços de trabalho"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Exibir terminal apenas no monitor primário"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Exibir terminal no monitor"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Altura do terminal"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Fechar terminal com clique do meio no título"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Fechar janela ao encerrar a última sessão"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Inserir senha"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformar"
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Colagem avançada"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr "Minimizar a janela do terminal"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr "Você só pode usar o parâmetro ação dentro do Terminix"
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-"Você não pode usar o modo Quake com os parâmetros maximizar, tela cheia ou "
-"geometria"
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr "Nome da sessão padrão"
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Mostrar o título do terminal mesmo que seja o único"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr "Tamanho"
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr "Porcento de altura"
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr "Porcento de largura"
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr "Definir dica para o gerenciador de janelas desativar a animação"
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr "Sempre usar o diálogo de colagem avançada"
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Visualizar alternador de sessão"
-
-#: data/resources/ui/shortcuts.ui:401
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Colagem avançada"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr "Mostrar versão do Terminix e de componentes dependentes"
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Múltiplas sessões estão em uso, fechar mesmo assim?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr "Noroeste"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr "Nordeste"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr "Sudoeste"
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
-msgstr "Sudeste"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Selecionar cor %s"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr "Esconder janela ao retirar foco"
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
-msgstr "Abrir Terminix Remoto…"
-
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Abrir Terminix Remoto em %s"
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
-msgstr "Abrir no Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr "Abrir Terminix Remoto aqui…"
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
-msgstr "Abrir Terminix Remoto neste diretório"
-
-#: data/resources/ui/shortcuts.ui:503
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Alternar estilo de título"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr "Exportar"
-
-#: source/gx/terminix/profilewindow.d:728
-msgid "Export Color Scheme"
-msgstr "Exportar esquema de cores"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
-msgstr "Exibir terminal apenas no monitor ativo"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#~ msgid "You can only use the the action parameter within Terminix"
-#~ msgstr "Só é possível utilizar o parâmetro action de dentro do Terminix"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-08-29 23:13+0000\n"
 "Last-Translator: Ivan Ivanov <garuwex@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/terminix/"
@@ -21,960 +21,1154 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Команда"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Заголовок"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Текст"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Эта команда запрашивает административный доступ к вашему компьютеру"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Копирование команд из интернета может быть опасным. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Убедитесь, что вы понимаете, что делает каждая часть этой команды."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Расширенные"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Вставить"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Отменить"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Имя"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Новый"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Изменить"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Удалить"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Применить"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Хорошо"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Параметры поиска"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Найти следующее"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Найти предыдущее"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Учитывать регистр"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Только полные слова"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "По регулярному выражению"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Автоматически переходить к началу"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Терминал"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Закрыть"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Развернуть"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Выключить синхронизацию ввода для этого терминала"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Только чтение"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Подавать гудок"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Редактировать профиль"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Есть процессы, которые все ещё работают. Все равно закрыть?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Выключить синхронизацию ввода для этого терминала"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Файл %s не является цветовой схемой совместимой с файлом формата JSON"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Цветовая схема палитры требует 16 цветов"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Сохранить содержимое…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Сброс"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Сброс и очистка"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Профили"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Кодировка"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Найти…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Параметры оформления…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Добавить справа"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Добавить снизу"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Восстановить"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Открыть ссылку"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Копировать адрес ссылки"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Скопировать"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Выбрать всё"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Буфер обмена"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Синхронизировать ввод"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Произошла неожиданная ошибка, дополнительная информация отсутствует"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Произошла неожиданная ошибка: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Сохранить вывод терминала"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Сохранить"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Все текстовые файлы"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Все файлы"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Дочерний процесс завершился нормально со статусом %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Дочерний процесс был прерван сигналом %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Дочерний процесс был прерван."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Перезапустить"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Не вставлять"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Все равно вставить"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Параметры оформления"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Активный"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Заголовок"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Загрузка сеанса"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Команда"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Активные вариантами всегда являются действующими и вступают в силу "
+"немедленно."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Показать сеанс в боковой панели"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Создать новый сеанс"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Добавить терминал направо"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Добавить терминал вниз"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Найти текст в терминале"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Смена названия сеанса"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Введите имя сеанса"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Открыть…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Сохранить как…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Имя…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Синхронизировать ввод"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Есть процессы, которые все ещё работают. Все равно закрыть?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Больше не показывать это сообщение"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Все JSON файлы"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Имя файла '%s' не существует"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Загрузить сеанс"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Открыть"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Не удалось загрузить сеанс из-за неожиданной ошибки."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Ошибка загрузки сеанса"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Сохранить сеанс"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Новый сеанс"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Новое окно"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Параметры"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Комбинации клавиш"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "О программе"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Завершить"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Признательности"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Установить рабочую папку терминала"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "КАТАЛОГ"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Установить стартовый профиль"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "ИМЯ-ПРОФИЛЯ"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Установить название нового терминала"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "ЗАГОЛОВОК"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Открыть специальную сессию"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "ИМЯ-СЕАНСА"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Отправить действие в текущий экземпляр Terminix"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "ИМЯ-ДЕЙСТВИЯ"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Выполнить переданную команду"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Развернуть окно терминала"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Развернуть окно терминала"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Полноэкранный режим окна терминала"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Зафиксировать окно терминала"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+"Запустить дополнительный экземпляр в качестве нового процесса (Не "
+"рекомендуется)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Установить размер окна; например: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "ГЕОМЕТРИЯ"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Скрытый аргумент UUID для передачи терминалу"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "UUID-ТЕРМИНАЛА"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Такое сообщение появляется когда возникает проблема с конфигурацией "
+"терминала.\n"
+"Эта проблема не является серьезной, но исправление её улучшит эксплуатацию "
+"приложения.\n"
+"Нажмите на ссылку ниже для получения дополнительной информации:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Найдена ошибка конфигурации"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Больше не показывать это сообщение"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Редактирование профиля: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Новый профиль"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Общие"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Команда"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Цвета"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Совместимость"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Расширенные"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Имя профиля"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "Идентификатор: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Размер терминала"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "столбцов"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "рядов"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Сброс"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Форма курсора"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Блок"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "I-образный"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Подчёркивание"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Режим мерцания"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Система"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Вкл"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Выкл"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Подавать гудок"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Отсуствует"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Звук"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Значок"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Значок и звук"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Заголовок терминала"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Южноевропейская"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Оформление текста"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Разрешить полужирный текст"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Переносить при изменении размера"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Пользовательский шрифт"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Выбрать шрифт терминала"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Цветовая схема"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Пользовательская"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Палитра"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Настройки"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Использовать цвета темы"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Расширенные"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Прозрачность"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Фокусировка неактивного состояния"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Текст"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Фон"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Выбрать основной цвет курсора терминала"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Выбрать цвет фона курсора терминала"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Подсветка"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Выбрать основной цвет подсветки терминала"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Выбрать цвет подсветки терминала"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Неактивного состояние"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Выбрать цвет неактивного состояния терминала"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Выбрать %s цвет"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Выбрать цвет фона"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Выбрать основной цвет"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Передний план"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Черный"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Красный"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Зеленый"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Оранжевый"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Синий"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Пурпурный"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Бирюзовый"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Серый"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Выбрать %s цвет"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Выбрать светло-%s цвет"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Цветовая схема"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Показать полосу прокрутки"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Прокручивать при выводе"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Прокручивать при нажатии клавиши"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Обратная прокрутка:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Клавиша «Backspace» генерирует"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Автоматически"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Управляющая последовательность"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Клавиша «Delete» генерирует"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Кодировка"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Символы неоднозначной ширины"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Узкие"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Широкие"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Запускать команду как оболочку входа"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Запускать другую команду вместо моей оболочки"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "При выходе из команды"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Выйти из терминала"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Перезапустить команду"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Держать терминал открытым"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Пользовательские ссылки"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Список определенных пользователем ссылок, которые можно нажать в терминале "
+"на основе регулярных определений выражений."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Автоматическое переключение профиля"
+
+#: source/gx/terminix/profilewindow.d:1075
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Профили автоматически выбирается на основании значений, введенных здесь.\n"
+"Значения вводятся с помощью <i>hostname:directory</i> формата. Либо имя "
+"хоста или каталог могут быть пропущены, но знак двоеточие должен "
+"присутствовать. Записи с не именем хоста или каталога не допускаются."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Профили автоматически выбирается на основании значений, введенных здесь.\n"
+"Значения вводятся с помощью <i>hostname:directory</i> формата. Либо имя "
+"хоста или каталог могут быть пропущены, но знак двоеточие должен "
+"присутствовать. Записи с не именем хоста или каталога не допускаются."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Совпадения"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Добавить"
+
+#: source/gx/terminix/profilewindow.d:1108
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "Введите именем хоста: каталог, чтобы соответствовать"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Введите именем хоста: каталог, чтобы соответствовать"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Добавить новое совподение"
+
+#: source/gx/terminix/profilewindow.d:1129
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "Редактировать именем хоста: каталог, чтобы соответствовать"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Редактировать именем хоста: каталог, чтобы соответствовать"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Редактировать совпадения"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "Выражение %s не является допустимым регулярным выражением"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Регулярное выражение"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Без учета регистра"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Редактировать пользовательские ссылки"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Действие"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Редактировать профиль"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Файл %s не является цветовой схемой совместимой с файлом формата JSON"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Цветовая схема палитры требует 16 цветов"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Не удалось обнаружить потерянный терминал"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Не удалось найти потерянный сеанс для терминала"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "По умолчанию"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Профиль"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Эмулятор терминала для Linux основанный на VTE"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -985,20 +1179,14 @@ msgstr ""
 "2.0. Если копия MPL не была распределена с этим файлом, Вы можете получить "
 "ее по этому адресу http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "Terminix не был бы возможен без работы виджетов команды GTK VTE"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD для обеспечения такой превосходной GTK оболочки"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org для такого превосходного языка как - D"
@@ -1138,289 +1326,38 @@ msgstr "Вьетнамская"
 msgid "Thai"
 msgstr "Тайская"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Новый сеанс"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Новое окно"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Параметры"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Комбинации клавиш"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "О программе"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Завершить"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Признательности"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Установить рабочую папку терминала"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "КАТАЛОГ"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Установить стартовый профиль"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "ИМЯ-ПРОФИЛЯ"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Открыть специальную сессию"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "ИМЯ-СЕАНСА"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Отправить действие в текущий экземпляр Terminix"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "ИМЯ-ДЕЙСТВИЯ"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Выполнить переданную команду"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "ВЫПОЛНИТЬ"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Развернуть окно терминала"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Полноэкранный режим окна терминала"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Зафиксировать окно терминала"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Скрытый аргумент UUID для передачи терминалу"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "UUID-ТЕРМИНАЛА"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Такое сообщение появляется когда возникает проблема с конфигурацией "
-"терминала.\n"
-"Эта проблема не является серьезной, но исправление её улучшит эксплуатацию "
-"приложения.\n"
-"Нажмите на ссылку ниже для получения дополнительной информации:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Найдена ошибка конфигурации"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Больше не показывать это сообщение"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Не удалось обнаружить потерянный терминал"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Не удалось найти потерянный сеанс для терминала"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Имя"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Профиль"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Основные"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Оформление"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Профили"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Кодировки, доступные в меню:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Включено"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Действие"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Комбинации клавиш"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Включение ярлыков"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Перепись существующей комбинации клавиш"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1431,976 +1368,191 @@ msgstr ""
 "Отключить комбинацию клавиш для других действий и назначить здесь вместо "
 "этого?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "По умолчанию"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Новый"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Изменить"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Удалить"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Включение прозрачности требует перезагрузки"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Стиль заголовока терминала"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Обычный"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Мелкий"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Отсуствует"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Вариант темы"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Светлый"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Тёмный"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Фоновое изображение"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Выбор изображения"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Все файлы изображений"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Сброс фонового изображения"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Маштабировать"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Повторять"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "По центру"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Растянуть"
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Редактирование имя сеанса"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Использовать широкие отступы"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Фокусировка неактивного состояния"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Установить название нового терминала"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Сохранить содержимое терминала"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Поведение"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Подсказка при создании нового сеанса"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Фокусировать терминал когда мышь над ним"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Скрывать указатель мыши при наборе"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Посылать извещение при окончании процесса"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Открывать новые терминалы"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Разделить справа"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Разделить снизу"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Показать текущее окно"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Вставить"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Предупреждать при попытке небезопасной вставки"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "Обрезать первый символ вставки если это комментарий или переменная"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Параметры оформления"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Автоматически копировать текст в буфер обмена при выделение"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Хорошо"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Отменить"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Активный"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Заголовок"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Загрузка сеанса"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Активные вариантами всегда являются действующими и вступают в силу "
-"немедленно."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Параметры поиска"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Учитывать регистр"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Только полные слова"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "По регулярному выражению"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Автоматически переходить к началу"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Терминал"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Закрыть"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Развернуть"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Выключить синхронизацию ввода для этого терминала"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Редактировать профиль"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Есть процессы, которые все ещё работают. Все равно закрыть?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Выключить синхронизацию ввода для этого терминала"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Сохранить…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Найти…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Параметры оформления…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Только чтение"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Сброс и очистка"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Разделение"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Восстановить"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Открыть ссылку"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Копировать адрес ссылки"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Скопировать"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Выбрать всё"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Буфер обмена"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Синхронизировать ввод"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Произошла неожиданная ошибка, дополнительная информация отсутствует"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Произошла неожиданная ошибка: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Сохранить вывод терминала"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Все текстовые файлы"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Все файлы"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Дочерний процесс завершился нормально со статусом %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Дочерний процесс был прерван сигналом %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Дочерний процесс был прерван."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Перезапустить"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Эта команда запрашивает административный доступ к вашему компьютеру"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Копирование команд из интернета может быть опасным. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Убедитесь, что вы понимаете, что делает каждая часть этой команды."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Не вставлять"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Все равно вставить"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Игнорирование, так как '%s' не является каталогом"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Игнорирование параметров сессии, так как '%s' не существует"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2409,190 +1561,72 @@ msgstr ""
 "Вы не можете загрузить сессию и установить profile/working directory/execute "
 "параметр команды, пожалуйста, выберите один или другой"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Показать сеанс в боковой панели"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Создать новый сеанс"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Смена названия сеанса"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Введите имя сеанса"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Открыть…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Сохранить"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Сохранить как…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Имя…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Синхронизировать ввод"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Все JSON файлы"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Имя файла '%s' не существует"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Загрузить сеанс"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Не удалось загрузить сеанс из-за неожиданной ошибки."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Ошибка загрузки сеанса"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Сохранить сеанс"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "выключен"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "Ваша версия GTK устарела, вам нужно установите последнию GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Произошло неожиданное исключение"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Ошибка: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Открыть в Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Открыть Terminix в %s"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Открыть в Terminix…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Открыть Terminix в %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "Открыть Terminix здесь…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "Открыть Terminix в этой папке"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Открыть Terminix здесь…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Открыть Terminix в этой папке"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Приложение"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Приложение"
@@ -2632,402 +1666,379 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Показать сеанс в боковой панели"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Показать сеанс в боковой панели"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Переключить на следующий сеанс"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Переключить на предыдущий сеанс"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Переключить на сеанс 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Переключить на сеанс 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Переключить на сеанс 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Переключить на сеанс 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Переключить на сеанс 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Переключить на сеанс 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Переключить на сеанс 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Переключить на сеанс 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Переключить на сеанс 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Переключить на сеанс 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Сеанс"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Файл"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Закрыть текущую сессию"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Сохранить текущей сессии"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Сохранить текущую сессию с новым именем"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Открытие сохраненной сессии"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Добавить"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Добавить терминал направо"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Добавить терминал вниз"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Изменение размера"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Изменение размера верхнего терминала"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Изменение размера нижнего терминала"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Изменение размера левого терминала"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Изменение размера правого терминала"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Переключение"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Переключить на следующий терминал"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Переключить на предыдущий терминал"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Переключить на терминал сверху"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Переключить на терминал снизу"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Переключить на терминал слева"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Переключить на терминал справа"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Переключить на терминал 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Переключить на терминал 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Переключить на терминал 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Переключить на терминал 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Переключить на терминал 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Переключить на терминал 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Переключить на терминал 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Переключить на терминал 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Переключить на терминал 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Переключить на терминал 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Разделение"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Разделить справа"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Разделить снизу"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Поиск"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Найти следующее"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Найти предыдущее"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Буфер обмена"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Копировать"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Вставить"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Выбрать всё"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Маштаб"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Увеличить масштаб"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Уменьшить масштаб"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Исходный размер"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Другие"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Редактирование имя сеанса"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Синхронизировать ввод"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Переключение"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Переключить на следующий терминал"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Переключить на предыдущий терминал"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Переключить на терминал сверху"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Переключить на терминал снизу"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Переключить на терминал слева"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Переключить на терминал справа"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Переключить на терминал 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Переключить на терминал 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Переключить на терминал 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Переключить на терминал 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Переключить на терминал 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Переключить на терминал 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Переключить на терминал 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Переключить на терминал 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Переключить на терминал 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Переключить на терминал 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Поиск"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Найти следующее"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Найти предыдущее"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Буфер обмена"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Копировать"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Вставить"
+
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Расширенные"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Выбрать всё"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Маштаб"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Увеличить масштаб"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Уменьшить масштаб"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Исходный размер"
+
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Сохранить содержимое терминала"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Закрыть терминал"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Развернуть на полный экран"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Текущие настройки профиля"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Сброс"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Сброс и очистка"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Только чтение"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Параметры оформления"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Вставьте номер терминала"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Стиль заголовока терминала"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Тайлинговый терминал для Gnome"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Новый терминал"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Тайлинговый терминал для GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix является тайлинговым эмулятором терминала."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Это позволяет:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
@@ -3035,7 +2046,6 @@ msgstr ""
 "Компоновать терминалы можно любым способом, путем разделения их по "
 "горизонтали или по вертикали"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3044,12 +2054,10 @@ msgstr ""
 "Терминалы могут быть перестроены с помощью перетаскивания как внутри, так и "
 "между окнами"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "Терминалы могут быть отделены в новое окно с помощью перетаскивания"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3058,17 +2066,14 @@ msgstr ""
 "Ввод может быть синхронизирован между терминалами, поэтому команды набранные "
 "в одном терминале, повторяются на другие"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "Группировка терминалов может быть сохранена и загружена с диска"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Терминалы поддерживают пользовательские названия"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3077,17 +2082,14 @@ msgstr ""
 "Цветовые схемы сохраняются в файлах и пользовательские цветовые схемы могут "
 "быть созданы путем простого создания нового файла"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Прозрачный фон"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "Поддержка уведомлений, когда процессы завершаются вне поля зрения"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3099,800 +2101,6 @@ msgstr ""
 "результате, оно используется на стороне клиента-украшения, хотя оно может "
 "быть отключено, если это необходимо."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix был протестирован с GNOME и Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Установить размер окна; например: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "ГЕОМЕТРИЯ"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Окно"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Редактирование имя сеанса"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Синхронизировать ввод"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Сеанс"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Сохранить содержимое…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Открыть"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Найти следующее"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Найти предыдущее"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-"Запустить дополнительный экземпляр в качестве нового процесса (Не "
-"рекомендуется)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Добавить терминал направо"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Добавить терминал вниз"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Найти текст в терминале"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Звук"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Значок"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Значок и звук"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Автоматическое переключение профиля"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Совпадения"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Добавить"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Добавить новое совподение"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Введите именем хоста: каталог, чтобы соответствовать"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Редактировать совпадения"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Редактировать именем хоста: каталог, чтобы соответствовать"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Фоновое изображение"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Выбор изображения"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Все файлы изображений"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Сброс фонового изображения"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Маштабировать"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Повторять"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "По центру"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Растянуть"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Добавить"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Добавить терминал направо"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Добавить терминал вниз"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Автоматически копировать текст в буфер обмена при выделение"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Добавить справа"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Добавить снизу"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Установить название нового терминала"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "ЗАГОЛОВОК"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Профили автоматически выбирается на основании значений, введенных здесь.\n"
-"Значения вводятся с помощью <i>hostname:directory</i> формата. Либо имя "
-"хоста или каталог могут быть пропущены, но знак двоеточие должен "
-"присутствовать. Записи с не именем хоста или каталога не допускаются"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Включение ярлыков"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Пользовательские ссылки"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Список определенных пользователем ссылок, которые можно нажать в терминале "
-"на основе регулярных определений выражений."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Профили автоматически выбирается на основании значений, введенных здесь.\n"
-"Значения вводятся с помощью <i>hostname:directory</i> формата. Либо имя "
-"хоста или каталог могут быть пропущены, но знак двоеточие должен "
-"присутствовать. Записи с не именем хоста или каталога не допускаются."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "Выражение %s не является допустимым регулярным выражением"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Регулярное выражение"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Без учета регистра"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Редактировать пользовательские ссылки"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Применить"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Вставьте номер терминала"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Выполнить переданную команду"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Профили автоматически выбирается на основании значений, введенных здесь.\n"
-"Значения вводятся с помощью <i>hostname:directory</i> формата. Либо имя "
-"хоста или каталог могут быть пропущены, но знак двоеточие должен "
-"присутствовать. Записи с не именем хоста или каталога не допускаются."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "Введите именем хоста: каталог, чтобы соответствовать"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "Редактировать именем хоста: каталог, чтобы соответствовать"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Редактировать профиль"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Команда"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Заголовок"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Текст"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Заголовок терминала"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Расширенные"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Развернуть окно терминала"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Редактирование имя сеанса"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Установить название нового терминала"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Показать сеанс в боковой панели"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Расширенные"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Есть процессы, которые все ещё работают. Все равно закрыть?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Больше не показывать это сообщение"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Южноевропейская"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Выбрать %s цвет"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Открыть в Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Открыть Terminix в %s"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Открыть в Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "Открыть Terminix здесь…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "Открыть Terminix в этой папке"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Стиль заголовока терминала"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Цветовая схема"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Сохранить содержимое терминала"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-09-15 08:49+0000\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/terminix/"
@@ -18,960 +18,1156 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.8\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Kommando"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Titel"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Text"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Det här kommandot efterfrågar administratörsåtkomst till din dator"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Att kopiera kommandon från internet kan vara farligt. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Säkerställ att du förstår vad varje del av det här kommandot gör."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Avancerat"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Klistra in"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Namn"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Ny"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Redigera"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Ta bort"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Infoga lösenord"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Verkställ"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Lösenord"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Bekräfta lösenord"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Lägg till lösenord"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Redigera lösenord"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Sökalternativ"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Gör skillnad på gemener/VERSALER"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Sök endast hela ord"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Matcha som reguljärt uttryck"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Börja om från början"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Stäng"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Maximera"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Inaktivera inmatningssynkronisering för denna terminal"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Skrivskyddad"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Terminalljud"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Redigera profil"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Det finns fortfarande processer som är igång, stäng i alla fall?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Aktivera inmatningssynkronisering för denna terminal"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Filen %s är inte en JSON-fil som följer färgschemat"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Biblioteket %s kunde inte läsas in, lösenordsfunktionalitet är ej "
+"tillgänglig."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Palett för färgschema kräver 16 färger"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Bibliotek ej inläst"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Spara utdata…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Återställ"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Återställ och töm"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profiler"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Kodning"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Sök…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Layoutalternativ…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Lägg till åt höger"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Lägg till nedåt"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Återställ"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Öppna länk"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Kopiera länkadress"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Kopiera"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Markera allt"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Urklipp"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Synkronisera inmatning"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Oväntat fel inträffade, ingen ytterligare information tillgänglig"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Oväntat fel inträffade: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Spara terminalutdata"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Spara"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Alla textfiler"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Alla filer"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Underprocessen avslutades normalt med status %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Underprocessen terminerades av signal %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Underprocessen terminerades."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Starta om"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Klistra inte in"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Klistra in i alla fall"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Layoutalternativ"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Aktivt"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Sessionsinläst"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Kommando"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktiva alternativ är alltid aktiva och tillämpas omedelbart.\n"
+"Sessionsinlästa alternativ tillämpas då en sessionsfil läses in."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Visa sessionssidopanel"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Skapa en ny session"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Lägg till terminal åt höger"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Lägg till terminal nedåt"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Sök nästa i terminal"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Ändra sessionsnamn"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Ange ett nytt namn för sessionen"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Öppna…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Spara som…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Namn…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Synkronisera inmatning"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Det finns fortfarande processer som är igång, stäng i alla fall?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Visa inte detta meddelande igen"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Alla JSON-filer"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Filenamnet ”%s” existerar inte"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Läs in session"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Öppna"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Kunde inte läsa in session på grund av ett oväntat fel."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Fel vid inläsning av session"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Spara session"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Ny session"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Nytt fönster"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Kortkommandon"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Om"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Avsluta"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Tack till"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Ställ in arbetskatalogen för terminalen"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "KATALOG"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Ställ in startprofilen"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "PROFILNAMN"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Ställ in titeln för den nya terminalen"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "TITEL"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Öppna den angivna sessionen"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "SESSIONSNAMN"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Skicka en åtgärd till aktuell Terminix-instans"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "ÅTGÄRDSNAMN"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Kör det skickade kommandot"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Maximera terminalfönstret"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Maximera terminalfönstret"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Helskärm för terminalfönstret"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Fokusera det befintliga fönstret"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Starta ytterligare instans som ny process (Rekommenderas ej)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Ställ in fönsterstorleken; till exempel: 80x24, eller 80x24+200+200 (KOLxRAD"
+"+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "GEOMETRI"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Dolt argument för att skicka terminal-UUID"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL-UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Det verkar ha uppstått problem med konfigurationen av terminalen.\n"
+"Detta är inte allvarligt, men att rätta till det kommer förbättra din "
+"användarupplevelse.\n"
+"Klick på länken nedan för mer information:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Konfigurationsproblem upptäckt"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Visa inte detta meddelande igen"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Redigerar profil: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Ny profil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Allmänt"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Kommando"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Färg"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Rullning"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Avancerat"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Profilnamn"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Terminalstorlek"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "kolumner"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "rader"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Återställ"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Markör"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Block"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "I-balk"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Understreck"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Blinkningsläge"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "System"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "På"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Av"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Terminalljud"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Ingen"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Ljud"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Ikon"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Ikon och ljud"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Terminaltitel"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Sydeuropeisk"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Textutseende"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Tillåt fet text"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Justera radbrytningar vid storleksförändring"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Anpassat typsnitt"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Välj ett terminaltypsnitt"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Färgschema"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Anpassat"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Färgpalett"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Alternativ"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Använd temafärger för förgrund/bakgrund"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Avancerat"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Transparens"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Ofokuserad dämpad"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Text"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Bakgrund"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Välj förgrundsfärg för markör"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Välj bakgrundsfärg för markör"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Färgmarkering"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Välj förgrundsfärg för färgmarkering"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Välj bakgrundsfärg för färgmarkering"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Dämpad"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Välj färg för dämpad"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Välj %s färg"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Välj bakgrundsfärg"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Välj förgrundsfärg"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Förgrund"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Svart"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Röd"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Grön"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Orange"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Blå"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Lila"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turkos"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Grå"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Välj %s färg"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Välj %s färg (ljus)"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Färgschema"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Visa rullningslist"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Rulla vid utdata"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Rulla vid tangentnedtryckning"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Begränsa rullningshistorik till:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Backstegstangenten genererar"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Automatisk"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Kontrollsekvens"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Delete-tangenten genererar"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Kodning"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Tecken med tvetydig bredd"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Smal"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Bred"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Kör kommando som ett inloggningsskal"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Kör ett eget kommando istället för mitt skal"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Då kommandot avslutar"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Avsluta terminal"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Starta om kommandot"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Håll terminalen öppen"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "Anpassat typsnitt"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"En lista över användardefinierade länkar som kan klickas på i terminalen "
+"baserad på reguljära uttrycksdefinitioner."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Automatisk profilväxling"
+
+#: source/gx/terminix/profilewindow.d:1075
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
+"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
+"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
+"varken värdnamn eller katalog tillåts inte"
+
+#: source/gx/terminix/profilewindow.d:1077
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
+"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
+"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
+"varken värdnamn eller katalog tillåts inte"
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Matchning"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Lägg till"
+
+#: source/gx/terminix/profilewindow.d:1108
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "Ange värdnamn:katalog att matcha"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Ange värdnamn:katalog att matcha"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Lägg till ny matchning"
+
+#: source/gx/terminix/profilewindow.d:1129
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "Redigera värdnamn:katalog att matcha"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Redigera värdnamn:katalog att matcha"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Redigera matchning"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Skiftlägesokänslig"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Åtgärd"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Parameter"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Redigera profil"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Filen %s är inte en JSON-fil som följer färgschemat"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Palett för färgschema kräver 16 färger"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Kunde inte hitta släppt terminal"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Kunde inte hitta session för släppt terminal"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Standard"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "En VTE-baserad terminalemulator för Linux"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -982,22 +1178,16 @@ msgstr ""
 "2.0. Om ingen kopia av MPL distribuerades med denna fil kan du erhålla en på "
 "http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "Gruppen för VTE-komponenter i GTK, Terminix skulle inte vara möjligt utan "
 "deras arbete"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD för att ha tillhandahållit ett utmärkt GTK-omslag"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org för det fantastiska språket D"
@@ -1137,288 +1327,38 @@ msgstr "Vietnamesisk"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Ny session"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Nytt fönster"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Inställningar"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Kortkommandon"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Om"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Avsluta"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Tack till"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Ställ in arbetskatalogen för terminalen"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "KATALOG"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Ställ in startprofilen"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "PROFILNAMN"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Öppna den angivna sessionen"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "SESSIONSNAMN"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Skicka en åtgärd till aktuell Terminix-instans"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "ÅTGÄRDSNAMN"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Kör det skickade kommandot"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "KÖR"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Maximera terminalfönstret"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Helskärm för terminalfönstret"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Fokusera det befintliga fönstret"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Dolt argument för att skicka terminal-UUID"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL-UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Det verkar ha uppstått problem med konfigurationen av terminalen.\n"
-"Detta är inte allvarligt, men att rätta till det kommer förbättra din "
-"användarupplevelse.\n"
-"Klick på länken nedan för mer information:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Konfigurationsproblem upptäckt"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Visa inte detta meddelande igen"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Kunde inte hitta släppt terminal"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Kunde inte hitta session för släppt terminal"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Namn"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Globala"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Utseende"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profiler"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Kodningar som visas i meny:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Åtgärd"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Snabbtangent"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Aktivera genvägar"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Skriv över befintligt kortkommando"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1429,977 +1369,193 @@ msgstr ""
 "Inaktivera kortkommandot för den andra åtgärden och tilldela det här "
 "istället?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Standard"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Ny"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Redigera"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Ta bort"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Aktivera transparens, kräver omstart"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Titelstil för terminal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Liten"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Ingen"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Temavariant"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Ljus"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Mörk"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Bakgrundsbild"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Välj bild"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Alla bildfiler"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Återställ bakgrundsbild"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Skala"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Sida vid sida"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Centrera"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Sträck ut"
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Redigera sessionsnamnet"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Använd ett brett handtag för delare"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Dämpa ofokuserade terminaler"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Ställ in titeln för den nya terminalen"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Visa terminal på alla arbetsytor"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+#, fuzzy
+msgid "Hide window when focus is lost"
+msgstr "Stäng fönster då sista session stängs"
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Visa terminal på primär skärm"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Visa på specifik skärm"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Beteende"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Fråga då en ny session skapas"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Fokusera en terminal då musen hålls över den"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Dölj automatiskt muspekaren då du skriver"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Stäng fönster då sista session stängs"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Skicka skrivbordsaviseringar då process klar"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Vid ny instans"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Dela åt höger"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Dela nedåt"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Fokusera fönster"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Klistra in"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Varna vid försök till osäker inklistring"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Ta bort första tecken i inklistring om kommentar eller variabeldeklaration"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Layoutalternativ"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Kopiera automatiskt text till urklipp vid markering"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Aktivt"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Sessionsinläst"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktiva alternativ är alltid aktiva och tillämpas omedelbart.\n"
-"Sessionsinlästa alternativ tillämpas då en sessionsfil läses in."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Sökalternativ"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Gör skillnad på gemener/VERSALER"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Sök endast hela ord"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Matcha som reguljärt uttryck"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Börja om från början"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Stäng"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Maximera"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Inaktivera inmatningssynkronisering för denna terminal"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Redigera profil"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Det finns fortfarande processer som är igång, stäng i alla fall?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Aktivera inmatningssynkronisering för denna terminal"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Spara…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Sök…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Layoutalternativ…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Skrivskyddad"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Återställ och töm"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Dela"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Återställ"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Öppna länk"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Kopiera länkadress"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Kopiera"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Markera allt"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Urklipp"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Synkronisera inmatning"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Oväntat fel inträffade, ingen ytterligare information tillgänglig"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Oväntat fel inträffade: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Spara terminalutdata"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Alla textfiler"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Alla filer"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Underprocessen avslutades normalt med status %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Underprocessen terminerades av signal %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Underprocessen terminerades."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Starta om"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Det här kommandot efterfrågar administratörsåtkomst till din dator"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Att kopiera kommandon från internet kan vara farligt. "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Säkerställ att du förstår vad varje del av det här kommandot gör."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Klistra inte in"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Klistra in i alla fall"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Ignorerar eftersom ”%s” inte är en katalog"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Ignorerar sessionsparameter eftersom ”%s” inte existerar"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2408,190 +1564,72 @@ msgstr ""
 "Du kan inte läsa in en session och ställa in ett alternativ för profil/"
 "arbetskatalog/exekvering, välj det ena eller det andra"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Visa sessionssidopanel"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Skapa en ny session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Ändra sessionsnamn"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Ange ett nytt namn för sessionen"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Öppna…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Spara"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Spara som…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Namn…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Synkronisera inmatning"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Alla JSON-filer"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Filenamnet ”%s” existerar inte"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Läs in session"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Kunde inte läsa in session på grund av ett oväntat fel."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Fel vid inläsning av session"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Spara session"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "inaktiverad"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "Din GTK-version är för gammal, du behöver minst GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Ett oväntat undantag inträffade"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Fel: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Öppna i Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Öppna Terminix i %s"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Öppna i Terminix…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Öppna Terminix i %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "Öppna Terminix här…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "Öppna Terminix i denna katalog"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Öppna Terminix här…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Öppna Terminix i denna katalog"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Program"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Program"
@@ -2631,402 +1669,380 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Visa sessionssidopanel"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Visa sessionssidopanel"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Växla till nästa session"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Växla till föregående session"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Växla till session 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Växla till session 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Växla till session 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Växla till session 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Växla till session 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Växla till session 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Växla till session 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Växla till session 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Växla till session 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Växla till session 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Session"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Arkiv"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Stäng aktuell session"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Spara aktuell session"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Spara aktuell session med nytt filnamn"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Öppna en sparad session"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Lägg till"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Lägg till terminal åt höger"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Lägg till terminal nedåt"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Ändra storlek"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Ändra storlek på terminalen uppåt"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Ändra storlek på terminalen nedåt"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Ändra storlek på terminalen åt vänster"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Ändra storlek på terminalen åt höger"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Växla"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Växla till nästa terminal"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Växla till föregående terminal"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Växla till den övre terminalen"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Växla till den nedre terminalen"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Växla till den vänstra terminalen"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Växla till den högra terminalen"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Växla till terminal 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Växla till terminal 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Växla till terminal 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Växla till terminal 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Växla till terminal 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Växla till terminal 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Växla till terminal 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Växla till terminal 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Växla till terminal 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Växla till terminal 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Dela"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Dela åt höger"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Dela nedåt"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Sök"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Sök nästa"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Sök föregående"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Urklipp"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Kopiera"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Klistra in"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Markera allt"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Zooma"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Zooma in"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Zooma ut"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Zooma till normal storlek"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Annat"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Redigera sessionsnamnet"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Synkronisera inmatningen"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Växla"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Växla till nästa terminal"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Växla till föregående terminal"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Växla till den övre terminalen"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Växla till den nedre terminalen"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Växla till den vänstra terminalen"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Växla till den högra terminalen"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Växla till terminal 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Växla till terminal 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Växla till terminal 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Växla till terminal 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Växla till terminal 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Växla till terminal 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Växla till terminal 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Växla till terminal 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Växla till terminal 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Växla till terminal 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Sök"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Urklipp"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Avancerat"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Markera allt"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Zooma"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Zooma in"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Zooma ut"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Zooma till normal storlek"
+
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Spara terminalinnehåll"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Stäng terminal"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Maximera terminal"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Aktuella profilinställningar"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Återställ terminalen"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Återställ och töm terminalen"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Växla skrivskydd"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Layoutalternativ"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Ändra storlek på terminalen uppåt"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Infoga lösenord"
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Titelstil för terminal"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "En sida-vid-sida-terminal för GNOME"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Ny terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "En sida-vid-sida-terminal för GNOME"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix är en terminalemulator där terminaler placeras sida vid sida."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Den låter dig:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
@@ -3034,7 +2050,6 @@ msgstr ""
 "Ändra layout för terminaler på vilket sätt som helst genom att dela dem "
 "horisontellt eller vertikalt"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
@@ -3043,14 +2058,12 @@ msgstr ""
 "Terminaler kan omplaceras genom att dra och släppa dem både inom och mellan "
 "fönster"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr ""
 "Terminaler kan kopplas loss till ett nytt fönster genom att dra och släppa "
 "dem"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3059,17 +2072,14 @@ msgstr ""
 "Inmatning kan synkroniseras mellan terminaler så att kommandon som skrivs in "
 "i en terminal upprepas till de andra"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "Grupperingen av terminaler kan sparas och läsas in från disk"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Terminaler stöder anpassade titlar"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3078,17 +2088,14 @@ msgstr ""
 "Färgscheman lagras i filer och anpassade färgscheman kan enkelt skapas genom "
 "att skapa en ny fil"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Transparent bakgrund"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "Stöder aviseringar då processer utom synhåll blir klara"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3099,805 +2106,6 @@ msgstr ""
 "mänskliga gränssnitt (HIG). Som ett resultat av detta använder det "
 "dekorationer från klientsidan, men det kan inaktiveras om nödvändigt."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix har testats med GNOME och med Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Ställ in fönsterstorleken; till exempel: 80x24, eller 80x24+200+200 (KOLxRAD"
-"+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "GEOMETRI"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Fönster"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Redigera sessionsnamnet"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Synkronisera inmatningen"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Session"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Spara utdata…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Öppna"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Sök nästa"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Sök föregående"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Starta ytterligare instans som ny process (Rekommenderas ej)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Lägg till terminal åt höger"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Lägg till terminal nedåt"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Sök nästa i terminal"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Ljud"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Ikon"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Ikon och ljud"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Automatisk profilväxling"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Matchning"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Lägg till"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Lägg till ny matchning"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Ange värdnamn:katalog att matcha"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Redigera matchning"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Redigera värdnamn:katalog att matcha"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Bakgrundsbild"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Välj bild"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Alla bildfiler"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Återställ bakgrundsbild"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Skala"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Sida vid sida"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Centrera"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Sträck ut"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Lägg till"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Lägg till terminal åt höger"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Lägg till terminal nedåt"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Kopiera automatiskt text till urklipp vid markering"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Lägg till åt höger"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Lägg till nedåt"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Ställ in titeln för den nya terminalen"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "TITEL"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
-"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
-"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
-"varken värdnamn eller katalog tillåts inte"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Aktivera genvägar"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "Anpassat typsnitt"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"En lista över användardefinierade länkar som kan klickas på i terminalen "
-"baserad på reguljära uttrycksdefinitioner."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
-"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
-"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
-"varken värdnamn eller katalog tillåts inte"
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Skiftlägesokänslig"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Verkställ"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Ändra storlek på terminalen uppåt"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Biblioteket %s kunde inte läsas in, lösenordsfunktionalitet är ej "
-"tillgänglig."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Bibliotek ej inläst"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Infoga lösenord"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Lösenord"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Bekräfta lösenord"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Lägg till lösenord"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Redigera lösenord"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Kör det skickade kommandot"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
-"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
-"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
-"varken värdnamn eller katalog tillåts inte"
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "Ange värdnamn:katalog att matcha"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "Redigera värdnamn:katalog att matcha"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Parameter"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Redigera profil"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Kommando"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Titel"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Text"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Visa terminal på alla arbetsytor"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Visa terminal på primär skärm"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Visa på specifik skärm"
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Terminaltitel"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Stäng fönster då sista session stängs"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Infoga lösenord"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Avancerat"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Maximera terminalfönstret"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Redigera sessionsnamnet"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Ställ in titeln för den nya terminalen"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Visa sessionssidopanel"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Avancerat"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Det finns fortfarande processer som är igång, stäng i alla fall?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Visa inte detta meddelande igen"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Sydeuropeisk"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Välj %s färg"
-
-#: source/gx/terminix/prefwindow.d:753
-#, fuzzy
-msgid "Hide window when focus is lost"
-msgstr "Stäng fönster då sista session stängs"
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Öppna i Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Öppna Terminix i %s"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Öppna i Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "Öppna Terminix här…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "Öppna Terminix i denna katalog"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Titelstil för terminal"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Färgschema"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Visa terminal på primär skärm"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/terminix.pot
+++ b/po/terminix.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:28+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,960 +16,1119 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:872
+msgid "Do not show this again"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr ""
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr ""
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr ""
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr ""
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr ""
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:611
+msgid "Minimize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr ""
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+msgid "Select Badge Color"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+msgid "Export Color Scheme"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr ""
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr ""
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -977,20 +1136,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1130,284 +1283,38 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr ""
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr ""
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr ""
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr ""
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr ""
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr ""
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr ""
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1415,1165 +1322,256 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+msgid "Default session name"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+msgid "Show the terminal title even if its the only terminal"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr ""
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+msgid "Open Remote Terminix…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, python-format
+msgid "Open Remote Terminix In %s"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:76
+msgid "Open In Terminix…"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+msgid "Open Remote Terminix Here…"
+msgstr ""
+
+#: data/nautilus/open-terminix.py:88
+msgid "Open Remote Terminix In This Directory"
+msgstr ""
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr ""
@@ -2613,1120 +1611,269 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr ""
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-msgid "Supports notifications when processes are completed out of view"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
+#: data/resources/ui/shortcuts.ui:231
 msgctxt "shortcut window"
 msgid "Edit the session name"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
+#: data/resources/ui/shortcuts.ui:237
 msgctxt "shortcut window"
 msgid "Synchronize the input"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
-msgid "Session"
+msgid "Switch"
 msgstr ""
 
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:134
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
 msgid "Find next"
 msgstr ""
 
-#: source/gx/terminix/terminal/search.d:140
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
 msgid "Find previous"
 msgstr ""
 
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
-msgid "Add"
+msgid "Clipboard"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
-msgid "Add terminal right"
+msgid "Copy"
 msgstr ""
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-msgid "Minimize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-msgid "Default session name"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:680
-msgid "Show the terminal title even if its the only terminal"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-msgctxt "shortcut window"
-msgid "View session switcher"
+msgid "Paste"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:401
@@ -3734,78 +1881,79 @@ msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr ""
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-msgid "There are multiple sessions open, close anyway?"
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-msgid "Do not show this again"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southeast"
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-msgid "Select Badge Color"
+#: data/resources/ui/shortcuts.ui:467
+msgctxt "shortcut window"
+msgid "Reset the terminal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:65
-msgid "Open Remote Terminix…"
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:66
-#, python-format
-msgid "Open Remote Terminix In %s"
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:76
-msgid "Open In Terminix…"
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:87
-msgid "Open Remote Terminix Here…"
-msgstr ""
-
-#: data/nautilus/open-terminix.py:88
-msgid "Open Remote Terminix In This Directory"
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
@@ -3813,26 +1961,76 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
-msgid "Export Color Scheme"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
+msgid "Supports notifications when processes are completed out of view"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-06-06 14:04+0000\n"
 "Last-Translator: Giray Devlet <giray.devlet@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/terminix/"
@@ -18,960 +18,1144 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "Komut"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Başlık"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "Metin"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Bu komut bilgisayara yönetici erişimi istemekte"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "İnternetden komut kopyalamak tehlike arz edebilir "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Komutun her bölümünün ne yaptığını anladığından emmin ol."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Gelişmiş"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Yapıştır"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "İptal"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "İsim"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Yeni"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Düzenle"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Sil"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Tamam"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Arama Seçenekleri"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Büyük - Küçük Harf Duyarlı"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Bütün kelimle bul"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Regular Expression olarak bul"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Başa sar"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Kapa"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Enbüyüt"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Girdi senkronizasyonunu bu terminal için kapa"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Salt-Okunur"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Terminal çanı"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Profil Düzenle"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Çalışan işlemler mevcut, yinede kapatalım mı?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Girdi senkronizasyonunu bu terminal için aç"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "%s uygun bir renk planı JSON dosyası değil"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Renk planı paleti 16 renk gerektirmektedir"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Sıfırla ve Temizle"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Profiller"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Kodlama"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Bul…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Yerleşim Seçenekleri…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+#, fuzzy
+msgid "Add Right"
+msgstr "Sağa doğru böl"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Geri al"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Link'i Aç"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Link Adresini Kopyala"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Kopyala"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Hepsini Seç"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Pano"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Grirdiyi Senkronize et"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Beklenmeyen bir hata oluştu, daha fazla bilgi mevcut değil"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Beklenmeyen hata oluştu: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Terminal Çıktısını Kaydet"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Kaydet"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Bütün Metin Dosyaları"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Bütün Dosyalar"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Alt işlem beklenmedik bir şekilde kapandı: %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Alt işlem sinyal %d ile durduruldu."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Alt işlem durduruldu."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Tekrar başlat"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Yapıştırma"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Yinede Yapıştır"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Düzenleme Ayaları"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Etkin"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Başlık"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Oturum Yükle"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Komut"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Etkin ayalar her zaman etkin olup hemen gerçerli kılınır.\n"
+"Oturum Yükleme ayaları sadece oturum dosyası yüklenince etkin olur."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Oturum kenar çubuğunü göster"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Yeni oturum aç"
+
+#: source/gx/terminix/appwindow.d:360
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Terminal başlığı"
+
+#: source/gx/terminix/appwindow.d:364
+#, fuzzy
+msgid "Add terminal down"
+msgstr "Terminali açık tut"
+
+#: source/gx/terminix/appwindow.d:369
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Terminalden çık"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Oturum ismini değiştir"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Oturum için yeni isim gir"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Aç…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Yeni Adla Kaydet…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "İsim…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Girdiyi Senkronize et"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Çalışan işlemler mevcut, yinede kapatalım mı?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Bu mesjaı tekrar gösterme"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Bütün JSON Dosyaları"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "'%s' dosyası bulunamadı"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Oturum Yükle"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Beklenmeyen bir hatadan dolayı oturum yüklenemedi."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Oturum Yükeleme Hatası"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Oturumu Kaydet"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Yeni Oturum"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Yeni Pencere"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Tercihler"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Kısa yollar"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Hakkında"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Çıkış"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Teşekkürler"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DIZIN"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Başlangıç profilini seç"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:606
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Belirtilmiş oturumu seç"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Geçerli Terminix'e eylem yolla"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Yollanan komutu çalıştır"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Terminal penceresini enbüyüt"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Terminal penceresini enbüyüt"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Terminal pençeresini tam ekran yap"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Var olan pencereye odakla"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Terminal UUIDsine yollanacak gizli değişken"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Terminal ayarlarında bir sorun varmış gibi gözüküyor.\n"
+"Sorun ciddi olmamakla birlikte, bunu düzeltmek deneyiminizi "
+"iyileştirecektir.\n"
+"Daha fazla bilgi için aşağıdaki bilgiye klikleyin:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Ayar sorunu tespit edildi"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Bu mesjaı tekrar gösterme"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Düzenlenecek Profil: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Yeni Profil"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Genel"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Komut"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Renk"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Akma"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Uyumluluk"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Profil ismi"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Terminal boyutu"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "sütunl"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "satır"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Sıfırla"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "İmleç"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Blok"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "I-şekli"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Alt-çizgi"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Yanar söner kipi"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Sistem"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Açık"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Kapalı"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Terminal çanı"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Hiçbiri"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Terminal başlığı"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Güney Avrupa"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Metin görünümü"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Kalın metine izin ver"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Boyutlandırmada metni sar"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Özel font"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Terminal fontu seç"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Renk düzeni"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Özel"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Renk paleti"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Seçenekler"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Ön/Arka plan için temanın renklerini kullan"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Gelişmiş"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Saydamlık"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Odaklanmadığında karart"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Metin"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Arkaplan"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "İmleç önplan rengini seç"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "İmleç arkaplan rengini seç"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Vurgulama"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Önplan vurgulama rengini seç"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Arkaplan vurgulama rengini seç"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Karartma"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Karartma rengini seç"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "%s rengi seç"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Arkaplan rengini seç"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Önplan rengini seç"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Önplan"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Siyah"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Kırmızı"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Yeşil"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Turuncu"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Mavi"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Mor"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Turkuaz"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Gri"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "%s rengi seç"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "%s açık rengi seç"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Renk düzeni"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Kaydırma çubuğunu göster"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Çıktı esnasında kaydır"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Tuş basımında kaydır"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Kaydırmayı kısıtla:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Backspace tuşu üretir"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Otomatik"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Escape sekansı"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Delete tuşu üretir"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Kodlama"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Belirsiz-genişlikteki hafler"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Dar"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Geniş"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Komutu oturum açılış kabuğu olarak çalıştır"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Kabuk yerine özel komut çalıştır"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Komut sonlanınca"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Terminalden çık"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Komutu yeniden çalıştır"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Terminali açık tut"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "Özel font"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+#, fuzzy
+msgid "Match"
+msgstr "Büyük - Küçük Harf Duyarlı"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Eylem"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Profil Düzenle"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "%s uygun bir renk planı JSON dosyası değil"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Renk planı paleti 16 renk gerektirmektedir"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Bırakılan terminalin konumu tespi edilemedi"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Bırakılan terminal için oturum bulunamadı"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Varsayılan"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Profil"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Linux için VTE tabanlı terminal emülatörü"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -982,22 +1166,16 @@ msgstr ""
 "MPL'in bir kopyası bu dosya ekte olmadığı takdirde http://mozilla.org/"
 "MPL/2.0/ adresinden bir tane edinebilirsiniz."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 "GTK VTE widget takımı, Terminix onların çalışmları olmaksızın mümkün "
 "olmayacaktı"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD'e böyle mükemmel bir GTK sarıcı sağladıkları için"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org'a böyle harika bir dil için"
@@ -1137,289 +1315,39 @@ msgstr "Vietnamca"
 msgid "Thai"
 msgstr "Thaica"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Yeni Oturum"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Yeni Pencere"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Tercihler"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Kısa yollar"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Hakkında"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Çıkış"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Teşekkürler"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DIZIN"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Başlangıç profilini seç"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Belirtilmiş oturumu seç"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Geçerli Terminix'e eylem yolla"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Yollanan komutu çalıştır"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-#, fuzzy
-msgid "EXECUTE"
-msgstr "EXECUTE"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Terminal penceresini enbüyüt"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Terminal pençeresini tam ekran yap"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Var olan pencereye odakla"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Terminal UUIDsine yollanacak gizli değişken"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Terminal ayarlarında bir sorun varmış gibi gözüküyor.\n"
-"Sorun ciddi olmamakla birlikte, bunu düzeltmek deneyiminizi "
-"iyileştirecektir.\n"
-"Daha fazla bilgi için aşağıdaki bilgiye klikleyin:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Ayar sorunu tespit edildi"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Bu mesjaı tekrar gösterme"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Bırakılan terminalin konumu tespi edilemedi"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Bırakılan terminal için oturum bulunamadı"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "İsim"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Global"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Görünüm"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Profiller"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Menü de gösterilen Kodlamalar:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Etkin"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Eylem"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Kısayol Tuşu"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Kısa yollar"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Varolan Kısayolun Üzerine Yaz"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1429,976 +1357,194 @@ msgstr ""
 "%s kısayolu %s'e tayin edilmiş.\n"
 "Önceki kısayolu iptal edip buraya tayin et?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Varsayılan"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Yeni"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Düzenle"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Sil"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Şefaflık etkinleştir, yeniden başlatma gerektirir"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Terminal başlık tarzı"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Normal"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Küçük"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Hiçbiri"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Tema variyasyonu"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Açık"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Koyu"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+#, fuzzy
+msgid "Background image"
+msgstr "Arkaplan"
+
+#: source/gx/terminix/prefwindow.d:620
+#, fuzzy
+msgid "Select Image"
+msgstr "Hepsini Seç"
+
+#: source/gx/terminix/prefwindow.d:623
+#, fuzzy
+msgid "All Image Files"
+msgstr "Bütün Metin Dosyaları"
+
+#: source/gx/terminix/prefwindow.d:644
+#, fuzzy
+msgid "Reset background image"
+msgstr "Arkaplan rengini seç"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Oturum ismini değiştir"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Ayraçlar için geniş kulp kullan"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Odaklanmamıs terminali karart"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Davranış"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Yeni oturum açarken sorgula"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Fare üstündeyken terminale odakla"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Fare imlecini yazareken gizle"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Masaüstüne işlem bitince haber ver"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Yeni Örnekte"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Sağa doğru böl"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Aşağı doğru böl"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Pencereye odaklan"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Yapıştır"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Emminyetsiz yapıştırmada beni uyar"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "Açıklama (comment) veya değişken yapıştırken ilk harfi a"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Düzenleme Ayaları"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Tamam"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "İptal"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Etkin"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Başlık"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Oturum Yükle"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
-"Etkin ayalar her zaman etkin olup hemen gerçerli kılınır.\n"
-"Oturum Yükleme ayaları sadece oturum dosyası yüklenince etkin olur."
 
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Arama Seçenekleri"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Büyük - Küçük Harf Duyarlı"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Bütün kelimle bul"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Regular Expression olarak bul"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Başa sar"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Kapa"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Enbüyüt"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Girdi senkronizasyonunu bu terminal için kapa"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Profil Düzenle"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Çalışan işlemler mevcut, yinede kapatalım mı?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Girdi senkronizasyonunu bu terminal için aç"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Kaydet…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Bul…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Yerleşim Seçenekleri…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Salt-Okunur"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Sıfırla ve Temizle"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Yarık Ekran"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Geri al"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Link'i Aç"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Link Adresini Kopyala"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Kopyala"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Hepsini Seç"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Pano"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Grirdiyi Senkronize et"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Beklenmeyen bir hata oluştu, daha fazla bilgi mevcut değil"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Beklenmeyen hata oluştu: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Terminal Çıktısını Kaydet"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Bütün Metin Dosyaları"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Bütün Dosyalar"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Alt işlem beklenmedik bir şekilde kapandı: %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Alt işlem sinyal %d ile durduruldu."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Alt işlem durduruldu."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Tekrar başlat"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Bu komut bilgisayara yönetici erişimi istemekte"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "İnternetden komut kopyalamak tehlike arz edebilir "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Komutun her bölümünün ne yaptığını anladığından emmin ol."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Yapıştırma"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Yinede Yapıştır"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "'%s' dizin olmadığı için önemsemiyorum"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Oturum parametresi '%s' var olmadığı için önemsemiyorum"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2407,190 +1553,72 @@ msgstr ""
 "Aynı anda hem oturum yükleyip hem de profil/çalışma dizini/komut "
 "seçemiyoruz, lütfen birini yada diğerini seç"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Oturum kenar çubuğunü göster"
-
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Yeni oturum aç"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Oturum ismini değiştir"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Oturum için yeni isim gir"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Aç…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Kaydet"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Yeni Adla Kaydet…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "İsim…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Girdiyi Senkronize et"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Bütün JSON Dosyaları"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "'%s' dosyası bulunamadı"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Oturum Yükle"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Beklenmeyen bir hatadan dolayı oturum yüklenemedi."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Oturum Yükeleme Hatası"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Oturumu Kaydet"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
+
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "etkisiz"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "GTK sürümün çok eski, en azından GTK %d.%d.%d. lazım!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Kuraldışı bir durum oluştu"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Hata: "
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Terminix de aç…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Terminixi %s'de aç"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Terminix de aç…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Terminixi %s'de aç"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "Terminix'i Burada Aç…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "Terminix'i bu dizinde aç"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Terminix'i Burada Aç…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Terminix'i bu dizinde aç"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Uygulama"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Uygulama"
@@ -2630,1133 +1658,273 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Oturum kenar çubuğunu göster"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
-msgctxt "shortcut window"
-msgid "Switch to next session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
-msgctxt "shortcut window"
-msgid "Switch to previous session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
-msgctxt "shortcut window"
-msgid "Switch to session 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
-msgctxt "shortcut window"
-msgid "Switch to session 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
-msgctxt "shortcut window"
-msgid "Switch to session 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
-msgctxt "shortcut window"
-msgid "Switch to session 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
-msgctxt "shortcut window"
-msgid "Switch to session 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
-msgctxt "shortcut window"
-msgid "Switch to session 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
-msgctxt "shortcut window"
-msgid "Switch to session 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
-msgctxt "shortcut window"
-msgid "Switch to session 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
-msgctxt "shortcut window"
-msgid "Switch to session 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
-msgctxt "shortcut window"
-msgid "Switch to session 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
-msgid "Session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
-msgctxt "shortcut window"
-msgid "File"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
-msgctxt "shortcut window"
-msgid "Close the current session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
-msgctxt "shortcut window"
-msgid "Save the current session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
-msgctxt "shortcut window"
-msgid "Save the current session with new filename"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
-msgctxt "shortcut window"
-msgid "Open a saved session"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
-#: data/resources/ui/shortcuts.ui:197
-msgctxt "shortcut window"
-msgid "Resize"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
-#: data/resources/ui/shortcuts.ui:201
-msgctxt "shortcut window"
-msgid "Resize the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
-#: data/resources/ui/shortcuts.ui:207
-msgctxt "shortcut window"
-msgid "Resize the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:213
-msgctxt "shortcut window"
-msgid "Resize the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:219
-msgctxt "shortcut window"
-msgid "Resize the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "Terminal"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-msgid "Transparent background"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-msgid "Supports notifications when processes are completed out of view"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr ""
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Terminal başlığı"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-#, fuzzy
-msgid "Add terminal down"
-msgstr "Terminali açık tut"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Terminalden çık"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-#, fuzzy
-msgid "Match"
-msgstr "Büyük - Küçük Harf Duyarlı"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-#, fuzzy
-msgid "Background image"
-msgstr "Arkaplan"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-#, fuzzy
-msgid "Select Image"
-msgstr "Hepsini Seç"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-#, fuzzy
-msgid "All Image Files"
-msgstr "Bütün Metin Dosyaları"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-#, fuzzy
-msgid "Reset background image"
-msgstr "Arkaplan rengini seç"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Terminal başlığı"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Terminali açık tut"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-#, fuzzy
-msgid "Add Right"
-msgstr "Sağa doğru böl"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Kısa yollar"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "Özel font"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Yollanan komutu çalıştır"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Profil Düzenle"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Komut"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "Başlık"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "Metin"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "Terminal başlığı"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Gelişmiş"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Terminal penceresini enbüyüt"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Oturum ismini değiştir"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
 #: data/resources/ui/shortcuts.ui:61
 #, fuzzy
 msgctxt "shortcut window"
 msgid "View session switcher"
 msgstr "Oturum kenar çubuğunü göster"
+
+#: data/resources/ui/shortcuts.ui:67
+msgctxt "shortcut window"
+msgid "Switch to next session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:73
+msgctxt "shortcut window"
+msgid "Switch to previous session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:79
+msgctxt "shortcut window"
+msgid "Switch to session 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:85
+msgctxt "shortcut window"
+msgid "Switch to session 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:91
+msgctxt "shortcut window"
+msgid "Switch to session 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:97
+msgctxt "shortcut window"
+msgid "Switch to session 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:103
+msgctxt "shortcut window"
+msgid "Switch to session 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:109
+msgctxt "shortcut window"
+msgid "Switch to session 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:115
+msgctxt "shortcut window"
+msgid "Switch to session 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:121
+msgctxt "shortcut window"
+msgid "Switch to session 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:127
+msgctxt "shortcut window"
+msgid "Switch to session 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:133
+msgctxt "shortcut window"
+msgid "Switch to session 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
+msgid "Session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:149
+msgctxt "shortcut window"
+msgid "File"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:153
+msgctxt "shortcut window"
+msgid "Close the current session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:159
+msgctxt "shortcut window"
+msgid "Save the current session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:165
+msgctxt "shortcut window"
+msgid "Save the current session with new filename"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:171
+msgctxt "shortcut window"
+msgid "Open a saved session"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Terminal başlığı"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Terminali açık tut"
+
+#: data/resources/ui/shortcuts.ui:197
+msgctxt "shortcut window"
+msgid "Resize"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:201
+msgctxt "shortcut window"
+msgid "Resize the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:207
+msgctxt "shortcut window"
+msgid "Resize the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:213
+msgctxt "shortcut window"
+msgid "Resize the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:219
+msgctxt "shortcut window"
+msgid "Resize the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr ""
 
 #: data/resources/ui/shortcuts.ui:401
 #, fuzzy
@@ -3764,87 +1932,80 @@ msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr "Gelişmiş"
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Çalışan işlemler mevcut, yinede kapatalım mı?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Bu mesjaı tekrar gösterme"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
+#: data/resources/ui/shortcuts.ui:443
+msgctxt "shortcut window"
+msgid "Save terminal contents"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Güney Avrupa"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "%s rengi seç"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
+#: data/resources/ui/shortcuts.ui:449
+msgctxt "shortcut window"
+msgid "Close terminal"
 msgstr ""
 
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Terminix de aç…"
+#: data/resources/ui/shortcuts.ui:455
+msgctxt "shortcut window"
+msgid "Maximize terminal"
+msgstr ""
 
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Terminixi %s'de aç"
+#: data/resources/ui/shortcuts.ui:461
+msgctxt "shortcut window"
+msgid "Current profile preferences"
+msgstr ""
 
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Terminix de aç…"
+#: data/resources/ui/shortcuts.ui:467
+msgctxt "shortcut window"
+msgid "Reset the terminal"
+msgstr ""
 
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "Terminix'i Burada Aç…"
+#: data/resources/ui/shortcuts.ui:473
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
+msgstr ""
 
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "Terminix'i bu dizinde aç"
+#: data/resources/ui/shortcuts.ui:479
+msgctxt "shortcut window"
+msgid "Toggle read only"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:485
+msgctxt "shortcut window"
+msgid "Layout options"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
 
 #: data/resources/ui/shortcuts.ui:503
 #, fuzzy
@@ -3852,27 +2013,76 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr "Terminal başlık tarzı"
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Renk düzeni"
-
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on active monitor"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
+msgid "Transparent background"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
+msgid "Supports notifications when processes are completed out of view"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,973 +5,1161 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:28+0100\n"
 "PO-Revision-Date: 2016-11-08 15:30+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: Ukrainian "
-"<https://hosted.weblate.org/projects/terminix/translations/uk/>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/terminix/"
+"translations/uk/>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr "Оновити стан"
+
+#: source/gx/terminix/preferences.d:202
+msgid "ExecuteCommand"
+msgstr "Виконати команду"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr "Надіслати сповіщення"
+
+#: source/gx/terminix/preferences.d:204
+msgid "UpdateTitle"
+msgstr "Оновити заголовок"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr "Дати гудок"
+
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr "Надіслати повідомлення"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr "Вставити пароль"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Ця команда прохає адміністраторські права до вашого комп'ютера"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Копіювання команд з інтернету можуть бути небезпечні."
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Переконайтесь, що кожна частина цієї команди робить."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Додатково"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "Вставити"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "Назва"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr "Ідентифікатор"
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "Додати"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "Редагувати"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "Вилучити"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Враховувати повернення символу з паролем"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Вставити пароль"
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "Застосувати"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Пароль"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Підтвердити пароль"
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "Гаразд"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Додати пароль"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Редагувати пароль"
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "Параметри пошуку"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "Знайти наступне"
+
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "Знайти попереднє"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "Враховувати регістр"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "Враховувати тільки цілі слова"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "Враховувати як формальний вираз"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "Обгорнути довкола"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "Термінал"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "Закрити"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "Розгорнути"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "Вимкнути синхронізування вводу для цього терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "Тільки для читання"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "Гудки терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "Редагувати профіль"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "Ще є запущені процеси, однаково закрити?"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "Увімкнути синхронізування вводу для цього терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Файл %s — не схема кольорів, яка сумісна з файлами JSON"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Бібліотеку %s неможливо завантажити, можливість введення паролю недоступна."
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Палітра схеми кольорів потребує 16 кольорів"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr "Бібліотеку не завантажено"
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "Зберегти вивід…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "Скинути"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "Скинути і очистити"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "Профілі"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "Кодування"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "Знайти…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "Параметри компонування…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "Додати праворуч"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "Додати додолу"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "Відновити"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "Відкрити посилання"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "Скопіювати адресу посилання"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "Скопіювати"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "Вибрати все"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "Буфер"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "Синхронізувати введення"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Трапилася неочікувана помилка, додаткових відомостей немає"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Трапилась неочікувана помилка: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "Зберегти вивід терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "Зберегти"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "Всі текстові файли"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "Всі файли"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Підпроцес вийшов нормально зі станом %d"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Підпроцес завершено сигналом %d."
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "Підпроцес завершено."
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "Перезапустити"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "Не вставляти"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "Однаково вставити"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "Параметри компонування"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "Чинний"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "Заголовок"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "Завантаження сеансу"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "Команда"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Чинні параметри завжди діють і негайно застосовуються.\n"
+"Параметри завантаження сеансу застосовуються тільки, коли завантажується "
+"файл сеансу."
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "Переглянути бокову панель сеансів"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "Створити новий сеанс"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "Додати термінал праворуч"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "Додати термінал додолу"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "Знайти текст у терміналі"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "Змінити назву сеансу"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "Ввести нову назву для сеансу"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "Відкрити…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "Зберегти як…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "Назва…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "Синхронізувати введення"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Ще є запущені процеси, однаково закрити?"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Більше не показувати це повідомлення"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "Усі файли JSON"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Файл з назвою «%s» не існує"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "Завантажити сеанс"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "Відкрити"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "Неможливо завантажити сеанс через неочікувану помилку."
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "Помилка завантаження сеансу"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "Зберегти сеанс"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "Створити сеанс"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "Створити вікно"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "Параметри"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "Скорочення"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "Про програму"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "Вийти"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "Подяки"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "Вказати робочий каталог термінала"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "КАТАЛОГ"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "Вказати початковий профіль"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "НАЗВА_ПРОФІЛЮ"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "Вказати заголовок нового термінала"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "ЗАГОЛОВОК"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "Відкрити певний сеанс"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "НАЗВА_СЕАНСУ"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "Надіслати дію до поточного зразку Terminix"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "НАЗВА_ДІЇ"
+
+#: source/gx/terminix/application.d:609
+msgid "Execute the parameter as a command"
+msgstr "Виконати параметр як команду"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr "КОМАНДА"
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "Розгорнути вікно термінала"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Розгорнути вікно термінала"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "Повноекранне вікно термінала"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "Сфокусувати наявне вікно"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Запускати додатковий зразок як новий процес (не бажано)"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Вказати розмір вікна, наприклад: 80x24 або 80x24+200+200 (СТОВПЦІxРЯДКИ+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "ГЕОМЕТРІЯ"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Відкриває вікно в обвальному режимі або перемикає видимість поточного "
+"обвального режиму"
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Прихований аргумент, який передається в UUID терміналу"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Схоже, це помилка в налаштуваннях терміналу.\n"
+"Це несерйозна помилка, однак її виправлення покращить роботу.\n"
+"Натисніть на посилання нижче для подробиць:"
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "Виявлено проблему в налаштуваннях"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "Більше не показувати це повідомлення"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "Профіль редагування: %s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "Створити профіль"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "Загальне"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "Команда"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "Колір"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "Прокручування"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "Сумісність"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "Додатково"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "Назва профілю"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "Ідентифікатор: %s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "Розмір терміналу"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "стовпці"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "рядки"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "Скинути"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "Курсор"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "Блок"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "IBeam"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "Підкреслення"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "Режим блимання"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "Система"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "Увімкнено"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "Вимкнено"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "Гудки терміналу"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "Немає"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "Звук"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "Піктограма"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "Піктограма та звук"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "Заголовок терміналу"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "Південноєвропейське"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "Вигляд тексту"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "Дозволити жирний текст"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "Підлаштовувати під розмір"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "Інший шрифт"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "Виберіть шрифт терміналу"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "Схема кольорів"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "Інша"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "Палітра кольорів"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "Параметри"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "Використовувати кольори для тексту й тла"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "Додатково"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "Прозорість"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "Несфокусоване затемнювання"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "Текст"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "Тло"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "Вибрати колір тексту курсора"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "Вибрати колір тла курсора"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "Підсвічування"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "Вибрати колір підсвічування тексту"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "Вибрати колір підсвічування тла"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "Затемнювання"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "Вибрати колір затемнювання"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Вибрати %s колір"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "Вибрати колір тла"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "Вибрати колір тексту"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "Текст"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "Чорний"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "Червоний"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "Зелений"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "Оранжевий"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "Синій"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "Фіолетовий"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "Бірюзовий"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "Сірий"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "Вибрати %s колір"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "Вибрати світлий %s колір"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Схема кольорів"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "Показувати прокручування"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "Прокручувати при виведенні"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "Прокручувати клавішами"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "Обмежено прокручування до:"
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "Клавіша «Backspace» породжує"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "Керівні послідовності"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "Клавіша «Delete» породжує"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "Кодування"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "Неоднозначної ширини символи"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "Вузькі"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "Широкі"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "Запустити команду як оболонку входу"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "Запустити іншу команду замість моєї оболонки"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "Коли виходите з команди"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "Вийти з терміналу"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "Перезапустити команду"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "Утримувати термінал відкритим"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "Власні посилання"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"перелік користувацьких посилань, на які можна натиснути в терміналі на "
+"основі означень формальних виразів."
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr "Перемикачі"
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Перемикачі — формальні вирази, які перевіряють текст виводу в терміналі. "
+"Коли виникає збіг, виконується певна налаштована дії."
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "Автоматичне перемикання профілів"
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Профілі автоматично вибирають на основі значення введених тут.\n"
+"Значення введено через формат <i>користувач@вузол:каталог</i>. Або вузол, "
+"або каталог можуть бути порожні, але стовпці мають бути. Записи без вузла і "
+"каталогу — заборонені."
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Профілі автоматично вибирають на основі значення введених тут.\n"
+"Значення введено через формат <i>вузол:каталог</i>. Або вузол, або каталог "
+"можуть бути порожні, але стовпці мають бути. Записи без вузла і каталогу — "
+"заборонені."
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "Збіги"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "Додати"
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr "Ввести користувач@вузол:каталог для збігу"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "Ввести вузол:каталог для збігу"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "Додати новий збіг"
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr "Редагувати користувач@вузол:каталог для збігу"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "Редагувати вузол:каталог для збігу"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "Редагувати збіг"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "Вираз %s — недійсний"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "Формальний вираз"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "Без урахування регістру"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "Редагувати власні посилання"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "Дія"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr "Параметр"
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Edit Triggers"
+msgstr "Редагувати перемикачі"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Файл %s — не схема кольорів, яка сумісна з файлами JSON"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Палітра схеми кольорів потребує 16 кольорів"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "Неможливо знайти втрачений термінал"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "Неможливо знайти сеанс втраченого термінала"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "Типово"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "Профіль"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "Емулятор терміналу для Linux оснований на VTE"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -982,20 +1170,14 @@ msgstr ""
 "2.0. Якщо копія ліцензії MPL не подана з цим файлом, можете її одержати на "
 "http://mozilla.org/MPL/2.0/."
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "Команда віджету GTK VTE, Terminix не було б можливо  без їхньої праці"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD за надання такої чудової обгортки над GTK"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org за таку чудову мови, D"
@@ -1135,287 +1317,38 @@ msgstr "В'єтнамське"
 msgid "Thai"
 msgstr "Тайське"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "Створити сеанс"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "Створити вікно"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "Параметри"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "Скорочення"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "Про програму"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "Вийти"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "Подяки"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "Вказати робочий каталог термінала"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "КАТАЛОГ"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "Вказати початковий профіль"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "НАЗВА_ПРОФІЛЮ"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "Відкрити певний сеанс"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "НАЗВА_СЕАНСУ"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "Надіслати дію до поточного зразку Terminix"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "НАЗВА_ДІЇ"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "Виконати передану команду"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "ВИКОНАТИ"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "Розгорнути вікно термінала"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "Повноекранне вікно термінала"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "Сфокусувати наявне вікно"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Прихований аргумент, який передається в UUID терміналу"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Схоже, це помилка в налаштуваннях терміналу.\n"
-"Це несерйозна помилка, однак її виправлення покращить роботу.\n"
-"Натисніть на посилання нижче для подробиць:"
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "Виявлено проблему в налаштуваннях"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "Більше не показувати це повідомлення"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "Неможливо знайти втрачений термінал"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "Неможливо знайти сеанс втраченого термінала"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "Назва"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "Профіль"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "Загальне"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "Вигляд"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "Профілі"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr "Обвал"
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "Кодування в меню:"
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "Дія"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "Клавіша скорочення"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "Увімкнути скорочення"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "Перезаписати наявні скорочення"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1425,978 +1358,193 @@ msgstr ""
 "Скорочення  %s уже призначено на %s.\n"
 "Вимкнути скорочення для іншої дії і призначити сюди натомість?"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "Типово"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Додати"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "Редагувати"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "Вилучити"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "Увімкнути прозорість, вимагає перезапуск"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "Стиль заголовку термінала"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "Звичайний"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "Малий"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "Немає"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "Варіант теми"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "Світлий"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "Темний"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "Зображення тла"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "Вибрати зображення"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "Усі файли зображення"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "Скинути зображення тла"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "Шкала"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "Черепиця"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "Центр"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "Розтягнення"
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "Редагувати назву сеансу"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "Використовувати широкі відступи"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "Затемнювати несфокусовані термінали"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr "Розмістити бокову панель праворуч"
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "Вказати заголовок нового термінала"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr "Показувати термінал на всіх робочих просторах"
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+#, fuzzy
+msgid "Hide window when focus is lost"
+msgstr "Закрити вікно, коли останній сеанс закрито"
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Показувати термінал на основному екрані"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr "Показувати на певному екрані"
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "Запитувати, якщо створюється новий сеанс"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "Фокусуватись на терміналі, коли мишка над ним"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "Автоматично ховати вказівник миші, коли щось вводите"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Закрити термінал натиском на середню кнопку миші на заголовку"
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr "Закрити вікно, коли останній сеанс закрито"
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "Надсилати сповіщення, коли дія закінчиться"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "Відкривати новий термінал"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "Розділити праворуч"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "Розділити додолу"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "Сфокусувати вікно"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "Вставити"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "Попереджати про небезпечні вставлення"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr ""
 "Обрізати перший символ вставлення, якщо це коментар або оголошення змінної"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "Параметри компонування"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Автоматично копіювати текст у буфер, коли його вибираєте"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "Гаразд"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "Чинний"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "Заголовок"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "Завантаження сеансу"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Чинні параметри завжди діють і негайно застосовуються.\n"
-"Параметри завантаження сеансу застосовуються тільки, коли завантажується "
-"файл сеансу."
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "Параметри пошуку"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "Враховувати регістр"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "Враховувати тільки цілі слова"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "Враховувати як формальний вираз"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "Обгорнути довкола"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "Термінал"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "Закрити"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "Розгорнути"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "Вимкнути синхронізування вводу для цього терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "Редагувати профіль"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "Ще є запущені процеси, однаково закрити?"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "Увімкнути синхронізування вводу для цього терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "Зберегти…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "Знайти…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "Параметри компонування…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "Тільки для читання"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "Скинути і очистити"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "Розділити"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "Відновити"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "Відкрити посилання"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "Скопіювати адресу посилання"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "Скопіювати"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "Вибрати все"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "Буфер"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "Синхронізувати введення"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Трапилася неочікувана помилка, додаткових відомостей немає"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Трапилась неочікувана помилка: %s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "Зберегти вивід терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "Всі текстові файли"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "Всі файли"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Підпроцес вийшов нормально зі станом %d"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Підпроцес завершено сигналом %d."
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "Підпроцес завершено."
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "Перезапустити"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Ця команда прохає адміністраторські права до вашого комп'ютера"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Копіювання команд з інтернету можуть бути небезпечні."
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Переконайтесь, що кожна частина цієї команди робить."
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "Не вставляти"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "Однаково вставити"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "Нехтування, бо %s» — не каталог"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "Нехтування параметра сеансу, бо «%s» не існує"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2405,190 +1553,74 @@ msgstr ""
 "Неможливо завантажувати сеанс і вказувати параметри команд профілю/каталогу/"
 "виконання, виберіть щось одне"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "Переглянути бокову панель сеансів"
+#: source/gx/terminix/cmdparams.d:161
+#, fuzzy
+msgid "You can only use the action parameter within Terminix"
+msgstr "Можете використовувати цей параметр дії тільки у Terminix"
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "Створити новий сеанс"
+#: source/gx/terminix/cmdparams.d:182
+#, fuzzy
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr "Неможливо використовувати обвальний режим геометричними параметрами"
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "Змінити назву сеансу"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "Ввести нову назву для сеансу"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "Відкрити…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "Зберегти"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "Зберегти як…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "Назва…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "Синхронізувати введення"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "Усі файли JSON"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Файл з назвою «%s» не існує"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "Завантажити сеанс"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "Неможливо завантажити сеанс через неочікувану помилку."
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "Помилка завантаження сеансу"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "Зберегти сеанс"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "вимкнено"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "Версія GTK — застара, потрібно щонайменше GTK %d.%d.%d!"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "Трапився неочікувана виняток"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "Помилка:"
 
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "Відкрити в Terminix…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "Відкрити Terminix в %s"
+
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "Відкрити в Terminix…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "Відкрити Terminix в %s"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "Відкрити Terminix тут…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "Відкрити Terminix у цьому каталозі"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "Відкрити Terminix тут…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "Відкрити Terminix у цьому каталозі"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "Програма"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "Програма"
@@ -2628,402 +1660,379 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "Показати бічну панель сеансу"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "Переглянути бокову панель сеансів"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "Перемкнутись на наступний сеанс"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "Перемкнутись на попередній сеанс"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "Перемкнутись на сеанс 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "Перемкнутись на сеанс 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "Перемкнутись на сеанс 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "Перемкнутись на сеанс 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "Перемкнутись на сеанс 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "Перемкнутись на сеанс 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "Перемкнутись на сеанс 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "Перемкнутись на сеанс 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "Перемкнутись на сеанс 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "Перемкнутись на сеанс 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "Сеанс"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "Файл"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "Закрити поточний сеанс"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "Зберегти поточний сеанс"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "Зберегти поточний сеанс з новою назвою файла"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "Відкрити збережений сеанс"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "Додати"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "Додати термінал праворуч"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "Додати термінал додолу"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "Змінити розмір"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "Збільшити розмір догори"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "Збільшити розмір додолу"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "Збільшити розмір вліво"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "Збільшити розмір справа"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr "Перемикання"
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "Перемкнутись на наступний термінал"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "Перемкнутись на попередній термінал"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "Перемкнутись на термінал вище"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "Перемкнутись на термінал нижче"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "Перемкнутись на термінал ліворуч"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "Перемкнутись на термінал праворуч"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "Перемкнутись на термінал 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "Перемкнутись на термінал 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "Перемкнутись на термінал 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "Перемкнутись на термінал 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "Перемкнутись на термінал 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "Перемкнутись на термінал 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "Перемкнутись на термінал 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "Перемкнутись на термінал 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "Перемкнутись на термінал 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "Перемкнутись на термінал 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "Розділити"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "Розділити праворуч"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "Розділити додолу"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "Знайти"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "Знайти наступне"
-
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "Знайти попереднє"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr "Буфер"
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "Скопіювати"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "Вставити"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "Вибрати все"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr "Масштаб"
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr "Наблизити"
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr "Віддалити"
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "Відновити масштаб"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
 #: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
 msgctxt "shortcut window"
 msgid "Other"
 msgstr "Інше"
 
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "Редагувати назву сеансу"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "Синхронізувати введення"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr "Перемикання"
+
+#: data/resources/ui/shortcuts.ui:249
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "Перемкнутись на наступний термінал"
+
+#: data/resources/ui/shortcuts.ui:255
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "Перемкнутись на попередній термінал"
+
+#: data/resources/ui/shortcuts.ui:261
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "Перемкнутись на термінал вище"
+
+#: data/resources/ui/shortcuts.ui:267
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "Перемкнутись на термінал нижче"
+
+#: data/resources/ui/shortcuts.ui:273
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "Перемкнутись на термінал ліворуч"
+
+#: data/resources/ui/shortcuts.ui:279
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "Перемкнутись на термінал праворуч"
+
+#: data/resources/ui/shortcuts.ui:291
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "Перемкнутись на термінал 1"
+
+#: data/resources/ui/shortcuts.ui:297
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "Перемкнутись на термінал 2"
+
+#: data/resources/ui/shortcuts.ui:303
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "Перемкнутись на термінал 3"
+
+#: data/resources/ui/shortcuts.ui:309
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "Перемкнутись на термінал 4"
+
+#: data/resources/ui/shortcuts.ui:315
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "Перемкнутись на термінал 5"
+
+#: data/resources/ui/shortcuts.ui:321
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "Перемкнутись на термінал 6"
+
+#: data/resources/ui/shortcuts.ui:327
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "Перемкнутись на термінал 7"
+
+#: data/resources/ui/shortcuts.ui:333
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "Перемкнутись на термінал 8"
+
+#: data/resources/ui/shortcuts.ui:339
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "Перемкнутись на термінал 9"
+
+#: data/resources/ui/shortcuts.ui:345
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "Перемкнутись на термінал 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "Знайти"
+
+#: data/resources/ui/shortcuts.ui:371
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "Знайти наступне"
+
+#: data/resources/ui/shortcuts.ui:377
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "Знайти попереднє"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr "Буфер"
+
+#: data/resources/ui/shortcuts.ui:389
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "Скопіювати"
+
+#: data/resources/ui/shortcuts.ui:395
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "Вставити"
+
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "Додатково"
+
+#: data/resources/ui/shortcuts.ui:407
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "Вибрати все"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
+msgstr "Масштаб"
+
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
+msgstr "Наблизити"
+
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
+msgstr "Віддалити"
+
+#: data/resources/ui/shortcuts.ui:431
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "Відновити масштаб"
+
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "Зберегти вміст термінала"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "Закрити термінал"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "Розгорнути термінал"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "Поточні параметри термінала"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "Скинути термінал"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "Скинути і очистити термінал"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "Перемкнути тільки для читання"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "Параметри компонування"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "Вставити номер терміналу"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr "Вставити пароль"
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "Стиль заголовку термінала"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "Мозаїчний термінал для Gnome"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "Створити термінал"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "Мозаїчний термінал для Gnome"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix — мозаїчний емулятор термінала."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "Він дозволяє:"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
@@ -3031,19 +2040,16 @@ msgstr ""
 "Компонувати термінали в будь-якому вигляді, розділивши їх горизонтально та "
 "вертикально"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
 "windows"
 msgstr "Термінали можна впорядковувати перетягуванням у вікнах і між ними"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "Термінали можна від'єднати в нове вікно через перетягування"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
@@ -3052,17 +2058,14 @@ msgstr ""
 "Введення можна синхронізувати між терміналами, тож команди, які будуть "
 "вводитись, будуть повторюватись на інших терміналах"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "Групування терміналів можна зберегти і завантажити з диска"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "Термінали підтримують власні заголовки"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
@@ -3071,17 +2074,14 @@ msgstr ""
 "Схеми кольорів збережено у файлах і власні схеми кольорів додаються через "
 "звичайне створення нових файлів"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "Прозоре тло"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "Підтримування сповіщень, коли дії завершується позаочно"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3092,800 +2092,6 @@ msgstr ""
 "побудови інтерфейсу (GNOME HIG). У результаті, використовується оздоблення "
 "на боку клієнта, хоча його можна вимкнути, якщо потрібно."
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix випробувано з GNOME і Unity."
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Вказати розмір вікна, наприклад: 80x24 або 80x24+200+200 (СТОВПЦІxРЯДКИ+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "ГЕОМЕТРІЯ"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "Вікно"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "Редагувати назву сеансу"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "Синхронізувати введення"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "Сеанс"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "Зберегти вивід…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "Відкрити"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "Знайти наступне"
-
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "Знайти попереднє"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Запускати додатковий зразок як новий процес (не бажано)"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "Додати термінал праворуч"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "Додати термінал додолу"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "Знайти текст у терміналі"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "Звук"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "Піктограма"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "Піктограма та звук"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "Автоматичне перемикання профілів"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "Збіги"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "Додати"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "Додати новий збіг"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "Ввести вузол:каталог для збігу"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "Редагувати збіг"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "Редагувати вузол:каталог для збігу"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "Зображення тла"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "Вибрати зображення"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "Усі файли зображення"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "Скинути зображення тла"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "Шкала"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "Черепиця"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "Центр"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "Розтягнення"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "Додати"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "Додати термінал праворуч"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "Додати термінал додолу"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Автоматично копіювати текст у буфер, коли його вибираєте"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "Додати праворуч"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "Додати додолу"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "Вказати заголовок нового термінала"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "ЗАГОЛОВОК"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"Профілі автоматично вибирають на основі значення введених тут.\n"
-"Значення введено через формат <i>вузол:каталог</i>. Або вузол, або каталог "
-"можуть бути порожні, але стовпці мають бути. Записи без вузла і каталогу — "
-"заборонені"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "Увімкнути скорочення"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "Власні посилання"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"перелік користувацьких посилань, на які можна натиснути в терміналі на "
-"основі означень формальних виразів."
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Профілі автоматично вибирають на основі значення введених тут.\n"
-"Значення введено через формат <i>вузол:каталог</i>. Або вузол, або каталог "
-"можуть бути порожні, але стовпці мають бути. Записи без вузла і каталогу — "
-"заборонені."
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "Вираз %s — недійсний"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "Формальний вираз"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "Без урахування регістру"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "Редагувати власні посилання"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "Застосувати"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "Вставити номер терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Бібліотеку %s неможливо завантажити, можливість введення паролю недоступна."
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr "Бібліотеку не завантажено"
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Ідентифікатор"
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Враховувати повернення символу з паролем"
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Вставити пароль"
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Пароль"
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Підтвердити пароль"
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Додати пароль"
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Редагувати пароль"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "Execute the parameter as a command"
-msgstr "Виконати параметр як команду"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr "КОМАНДА"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Відкриває вікно в обвальному режимі або перемикає видимість поточного "
-"обвального режиму"
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr "ОБВАЛ"
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr "Неможливо використовувати обвальний режим геометричними параметрами"
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr "Перемикачі"
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Перемикачі — формальні вирази, які перевіряють текст виводу в терміналі. "
-"Коли виникає збіг, виконується певна налаштована дії."
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Профілі автоматично вибирають на основі значення введених тут.\n"
-"Значення введено через формат <i>користувач@вузол:каталог</i>. Або вузол, "
-"або каталог можуть бути порожні, але стовпці мають бути. Записи без вузла і "
-"каталогу — заборонені."
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr "Ввести користувач@вузол:каталог для збігу"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr "Редагувати користувач@вузол:каталог для збігу"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr "Параметр"
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Edit Triggers"
-msgstr "Редагувати перемикачі"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr "Оновити стан"
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-msgid "ExecuteCommand"
-msgstr "Виконати команду"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr "Надіслати сповіщення"
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-msgid "UpdateTitle"
-msgstr "Оновити заголовок"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr "Дати гудок"
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr "Надіслати повідомлення"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr "Вставити пароль"
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr "Обвал"
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr "Розмістити бокову панель праворуч"
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr "Показувати термінал на всіх робочих просторах"
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr "Показувати термінал на основному екрані"
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr "Показувати на певному екрані"
-
-#: source/gx/terminix/prefwindow.d:720
-msgid "Terminal height"
-msgstr "Висота терміналу"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Закрити термінал натиском на середню кнопку миші на заголовку"
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr "Закрити вікно, коли останній сеанс закрито"
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr "Вставити пароль"
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Додатково"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Розгорнути вікно термінала"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-#, fuzzy
-msgid "You can only use the action parameter within Terminix"
-msgstr "Можете використовувати цей параметр дії тільки у Terminix"
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-#, fuzzy
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr "Неможливо використовувати обвальний режим геометричними параметрами"
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "Редагувати назву сеансу"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "Вказати заголовок нового термінала"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "Переглянути бокову панель сеансів"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "Додатково"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Ще є запущені процеси, однаково закрити?"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Більше не показувати це повідомлення"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "Південноєвропейське"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Вибрати %s колір"
-
-#: source/gx/terminix/prefwindow.d:753
-#, fuzzy
-msgid "Hide window when focus is lost"
-msgstr "Закрити вікно, коли останній сеанс закрито"
-
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "Відкрити в Terminix…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "Відкрити Terminix в %s"
-
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "Відкрити в Terminix…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "Відкрити Terminix тут…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "Відкрити Terminix у цьому каталозі"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "Стиль заголовку термінала"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Схема кольорів"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Показувати термінал на основному екрані"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#~ msgid "You can only use the the action parameter within Terminix"
-#~ msgstr "Можете використовувати цей параметр дії тільки у Terminix"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:12+0100\n"
 "PO-Revision-Date: 2016-08-09 00:53+0000\n"
 "Last-Translator: Mingcong Bai <jeffbai@aosc.xyz>\n"
 "Language-Team: Chinese (China) <https://hosted.weblate.org/projects/terminix/"
@@ -16,960 +16,1149 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:202
+#, fuzzy
+msgid "ExecuteCommand"
+msgstr "命令"
+
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:204
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "标题"
+
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:206
+#, fuzzy
+msgid "SendText"
+msgstr "文字"
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "命令正在请求计算机的管理员权限"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "从互联网复制命令有一定危险性。 "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "你应当确认命令每个部分的作用。"
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "高级选项"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "粘贴"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr "取消"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "名称"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "新建"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "编辑"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "删除"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr "应用"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr "确定"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "搜索选项"
+
+#: source/gx/terminix/terminal/search.d:134
+msgid "Find next"
+msgstr "查找下一个"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:140
+msgid "Find previous"
+msgstr "查找上一个"
+
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "区分大小写"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "全字匹配"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "使用正则表达式匹配"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "换行"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "终端"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
+msgstr "关闭"
+
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr "为此终端关闭输入同步"
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "只读"
+
+#: source/gx/terminix/terminal/terminal.d:437
+#: source/gx/terminix/profilewindow.d:237
+msgid "Terminal bell"
+msgstr "终端响铃"
+
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "编辑配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "仍有正在运行的进程，依然要关闭吗？"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr "为此终端启用输入同步"
+
+#: source/gx/terminix/terminal/terminal.d:692
 #, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "文件 %s 不是兼容的 JSON 颜色主题文件"
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "颜色主题色板需要 16 个颜色"
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
+#: source/gx/terminix/terminal/terminal.d:752
+msgid "Save Output…"
+msgstr "保存输出…"
+
+#: source/gx/terminix/terminal/terminal.d:753
+#: source/gx/terminix/profilewindow.d:202
+msgid "Reset"
+msgstr "重置"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr "重置并清空"
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "编码"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "查找…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr "布局选项…"
+
+#: source/gx/terminix/terminal/terminal.d:775
+msgid "Add Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr "向下分割"
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr "恢复"
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr "打开链接"
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr "复制链接地址"
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "复制"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "全选"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr "剪贴板"
+
+#: source/gx/terminix/terminal/terminal.d:1402
+msgid "Synchronize input"
+msgstr "同步输入"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr "发生未知错误，无其他可用信息"
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "发生未知错误：%s"
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr "保存终端输出"
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "保存"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr "所有文本文件"
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr "所有文件"
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "子进程以 %d 状态正常退出"
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "子进程被 %d 信号中止。"
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr "子进程已被中止。"
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr "重新启动"
+
+#: source/gx/terminix/terminal/terminal.d:2960
+msgid "Don't Paste"
+msgstr "不要粘贴"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr "依然粘贴"
+
+#: source/gx/terminix/terminal/layout.d:28
+msgid "Layout Options"
+msgstr "布局选项"
+
+#: source/gx/terminix/terminal/layout.d:43
+msgid "Active"
+msgstr "会话活动"
+
+#: source/gx/terminix/terminal/layout.d:49
+msgid "Title"
+msgstr "标题"
+
+#: source/gx/terminix/terminal/layout.d:57
+msgid "Session Load"
+msgstr "载入会话"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "命令"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"会话活动选项一直生效且立即应用。\n"
+"会话载入选项仅在载入会话文件时生效。"
+
+#: source/gx/terminix/appwindow.d:317
+msgid "View session sidebar"
+msgstr "显示会话侧边栏"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "创建会话"
+
+#: source/gx/terminix/appwindow.d:360
+msgid "Add terminal right"
+msgstr "右侧新建终端"
+
+#: source/gx/terminix/appwindow.d:364
+msgid "Add terminal down"
+msgstr "下侧新建终端"
+
+#: source/gx/terminix/appwindow.d:369
+msgid "Find text in terminal"
+msgstr "在终端查找文本"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "更改会话名称"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "为会话新建名称"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr "打开…"
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "另存为…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "名称…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "同步输入"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "仍有正在运行的进程，依然要关闭吗？"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "不再显示该信息"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr "所有 JSON 文件"
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "文件名“%s”不存在"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "载入会话"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr "打开"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "发生未知错误，无法载入会话。"
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Error Loading Session"
+msgstr "载入会话出错"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "保存会话"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "新建会话"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "新建窗口"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "首选项"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "快捷键"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "关于"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "退出"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr "感谢名单"
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "设置终端的工作目录"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr "DIRECTORY"
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "设置启动配置文件"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:606
+msgid "Set the title of the new terminal"
+msgstr "设置新终端的标题"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr "标题"
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "打开指定会话"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "向当前 Terminix 实例发送动作"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "执行传入的命令"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+msgid "Maximize the terminal window"
+msgstr "最大化终端窗口"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "最大化终端窗口"
+
+#: source/gx/terminix/application.d:612
+msgid "Full-screen the terminal window"
+msgstr "全屏终端窗口"
+
+#: source/gx/terminix/application.d:613
+msgid "Focus the existing window"
+msgstr "焦点集中到已有窗口"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "将附加实例作为新进程启动（不推荐）"
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "设置窗口大小；例如：80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr "尺寸"
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr "传入终端 UUID 的隐藏参数"
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"终端配置似乎存在问题。这并不是严重问题，但是更正这些问题将改善你的使用体验。"
+"点击如下链接以获取更多信息："
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "检测到配置问题"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "不再显示该信息"
+
+#: source/gx/terminix/profilewindow.d:93
 #, c-format
 msgid "Editing Profile: %s"
 msgstr "正在编辑配置方案：%s"
 
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/profilewindow.d:95
 msgid "New Profile"
 msgstr "新建配置方案"
 
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
+#: source/gx/terminix/profilewindow.d:104
 msgid "General"
 msgstr "常规"
 
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
-msgstr "命令"
-
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:106
 msgid "Color"
 msgstr "颜色"
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
+#: source/gx/terminix/profilewindow.d:107
 msgid "Scrolling"
 msgstr "滚动"
 
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
+#: source/gx/terminix/profilewindow.d:108
 msgid "Compatibility"
 msgstr "兼容性"
 
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr "高级选项"
+
+#: source/gx/terminix/profilewindow.d:165
 msgid "Profile name"
 msgstr "配置方案名称"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
+#: source/gx/terminix/profilewindow.d:174
 #, c-format
 msgid "ID: %s"
 msgstr "ID：%s"
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/profilewindow.d:181
 msgid "Terminal size"
 msgstr "终端大小"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
+#: source/gx/terminix/profilewindow.d:191
 msgid "columns"
 msgstr "列"
 
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
+#: source/gx/terminix/profilewindow.d:197
 msgid "rows"
 msgstr "行"
 
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "重置"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
 msgid "Cursor"
 msgstr "光标"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Block"
 msgstr "方块"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "IBeam"
 msgstr "IBeam"
 
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
+#: source/gx/terminix/profilewindow.d:216
 msgid "Underline"
 msgstr "下划线"
 
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+#: source/gx/terminix/profilewindow.d:226
 msgid "Blink mode"
 msgstr "闪烁模式"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "System"
 msgstr "系统"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "On"
 msgstr "开启"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
+#: source/gx/terminix/profilewindow.d:229
 msgid "Off"
 msgstr "关闭"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
-msgid "Terminal bell"
-msgstr "终端响铃"
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr "无"
 
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr "声音"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr "图标"
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr "图标和声音"
+
+#: source/gx/terminix/profilewindow.d:249
 msgid "Terminal title"
 msgstr "终端标题"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "南欧"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "文本外观"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "允许粗体"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "缩放时重新换行"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 msgid "Custom font"
 msgstr "自定义字体"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "选择终端字体"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "配色方案"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "自定义"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "调色板"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "选项"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "为前景/背景色使用主题颜色"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr "高级选项"
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "透明度"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr "失去焦点时黯淡"
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr "文字"
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "背景"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 msgid "Select Cursor Foreground Color"
 msgstr "选择前景色"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 msgid "Select Cursor Background Color"
 msgstr "选择背景色"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr "高亮"
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 msgid "Select Highlight Foreground Color"
 msgstr "选择高亮前景色"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 msgid "Select Highlight Background Color"
 msgstr "选择高亮背景色"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr "黯淡"
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 msgid "Select Dim Color"
 msgstr "选择黯淡颜色"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "选择 %s 个颜色"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "选择背景色"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "选择前景色"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "前景"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "黑色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "红色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "绿色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "橙色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "蓝色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "紫色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "绿松色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "灰"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "选择 %s 个颜色"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "选择 %s 个淡色"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "配色方案"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "显示滚动条"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "输出时滚动"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "击键时滚动"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "回滚限制："
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "按 Backspace 键产生"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "自动"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "转义序列"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "按 Delete 键产生"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "编码"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "模糊宽度字符"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "窄"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "宽"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "运行作为登录程序的命令"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "运行自定义命令而不是我的命令行外壳"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "命令退出时"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "退出终端"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "重启命令"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "保持终端开启"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+msgid "Custom Links"
+msgstr "自定义链接"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr "可根据正则表达式定义点击终端上一系列的用户定义链接。"
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr "自动切换配置档案"
+
+#: source/gx/terminix/profilewindow.d:1075
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"根据此处输入的值自动选择配置档案。\n"
+"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
+"号。不允许同时忽略主机名和目录。"
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"根据此处输入的值自动选择配置档案。\n"
+"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
+"号。不允许同时忽略主机名和目录。"
+
+#: source/gx/terminix/profilewindow.d:1093
+msgid "Match"
+msgstr "匹配"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr "添加"
+
+#: source/gx/terminix/profilewindow.d:1108
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "输入主机名:目录以匹配"
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr "输入主机名:目录以匹配"
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr "添加新匹配"
+
+#: source/gx/terminix/profilewindow.d:1129
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "编辑主机名:目录以匹配"
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr "编辑主机名:目录以匹配"
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr "编辑匹配"
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr "%s 不是有效的正则表达式"
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr "正则表达式"
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr "不区分大小写"
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr "编辑自定义链接"
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "动作"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "编辑配置方案"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "文件 %s 不是兼容的 JSON 颜色主题文件"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "颜色主题色板需要 16 个颜色"
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "无法定位放置的终端"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "无法定位放置的终端的会话"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "默认"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "配置方案"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr "用于 Linux 的，基于 VTE 的终端模拟器"
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -979,20 +1168,14 @@ msgstr ""
 "此源代码形态由 Mozilla Public License, v. 2.0. 的条款进行许可。如此文件发行时"
 "未包含一份 MPL 副本，该副本可通过 http://mozilla.org/MPL/2.0 获取。"
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr "GTK VTE 部件团队，Terminix 的开发离不开他们的劳动"
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr "GtkD 提供了优秀的 GTK 封装"
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org 提供了优秀的编程语言，D 语言"
@@ -1135,286 +1318,38 @@ msgstr "越南语"
 msgid "Thai"
 msgstr "泰语"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "新建会话"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "新建窗口"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "首选项"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "快捷键"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "关于"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "退出"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr "感谢名单"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "设置终端的工作目录"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr "DIRECTORY"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "设置启动配置文件"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "打开指定会话"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "向当前 Terminix 实例发送动作"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "执行传入的命令"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr "EXECUTE"
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-msgid "Maximize the terminal window"
-msgstr "最大化终端窗口"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-msgid "Full-screen the terminal window"
-msgstr "全屏终端窗口"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-msgid "Focus the existing window"
-msgstr "焦点集中到已有窗口"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr "传入终端 UUID 的隐藏参数"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"终端配置似乎存在问题。这并不是严重问题，但是更正这些问题将改善你的使用体验。"
-"点击如下链接以获取更多信息："
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "检测到配置问题"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "不再显示该信息"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "无法定位放置的终端"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "无法定位放置的终端的会话"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "名称"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "配置方案"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "全局"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 msgid "Appearance"
 msgstr "外观"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "配置方案"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "菜单中显示的编码："
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "已启用"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "动作"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "快捷键"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+msgid "Enable shortcuts"
+msgstr "启用快捷键"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr "覆盖已有快捷键"
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1424,976 +1359,191 @@ msgstr ""
 "快捷键 %s 已指派为 %s。\n"
 "禁用另一动作的快捷键并在此指派？"
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "默认"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "新建"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "编辑"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "删除"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr "开启透明终端，需要重启终端"
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 msgid "Terminal title style"
 msgstr "终端标题样式"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr "一般"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr "较小"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr "无"
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 msgid "Theme variant"
 msgstr "主题变种"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "淡色"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "深色"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+msgid "Background image"
+msgstr "背景图像"
+
+#: source/gx/terminix/prefwindow.d:620
+msgid "Select Image"
+msgstr "选择图像"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr "所有图像文件"
+
+#: source/gx/terminix/prefwindow.d:644
+msgid "Reset background image"
+msgstr "重置背景图像"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr "缩放"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr "平铺"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr "居中"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr "拉伸"
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "编辑会话名称"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr "使用较宽的分割手柄"
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-msgid "Dim unfocused terminals"
-msgstr "黯淡失去焦点的终端"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "设置新终端的标题"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "保存终端内容"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "行为"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "创建新会话时提示"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "在鼠标移入时激活终端"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "打字时自动隐藏鼠标指针"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "进程完成时发送桌面通知"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr "创建新实例时"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "向右分割"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "向下分割"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Focus Window"
 msgstr "聚焦窗口"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "粘贴"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "进行不安全复制时警告"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "如果粘贴内容为注释或变量声明则切除第一个字符"
 
-#: source/gx/terminix/terminal/layout.d:28
-msgid "Layout Options"
-msgstr "布局选项"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "选择时自动将文本复制到剪贴板"
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
-msgstr "确定"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr "取消"
-
-#: source/gx/terminix/terminal/layout.d:43
-msgid "Active"
-msgstr "会话活动"
-
-#: source/gx/terminix/terminal/layout.d:49
-msgid "Title"
-msgstr "标题"
-
-#: source/gx/terminix/terminal/layout.d:57
-msgid "Session Load"
-msgstr "载入会话"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"会话活动选项一直生效且立即应用。\n"
-"会话载入选项仅在载入会话文件时生效。"
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "搜索选项"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "区分大小写"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "全字匹配"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "使用正则表达式匹配"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "换行"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "终端"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "关闭"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr "为此终端关闭输入同步"
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "编辑配置方案"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "仍有正在运行的进程，依然要关闭吗？"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr "为此终端启用输入同步"
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "保存…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "查找…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr "布局选项…"
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "只读"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr "重置并清空"
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-msgid "Split"
-msgstr "分割"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr "恢复"
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr "打开链接"
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr "复制链接地址"
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "复制"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "全选"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr "剪贴板"
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-msgid "Synchronize input"
-msgstr "同步输入"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr "发生未知错误，无其他可用信息"
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "发生未知错误：%s"
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr "保存终端输出"
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr "所有文本文件"
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr "所有文件"
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "子进程以 %d 状态正常退出"
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "子进程被 %d 信号中止。"
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr "子进程已被中止。"
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr "重新启动"
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "命令正在请求计算机的管理员权限"
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "从互联网复制命令有一定危险性。 "
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "你应当确认命令每个部分的作用。"
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-msgid "Don't Paste"
-msgstr "不要粘贴"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr "依然粘贴"
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr "因为“%s”不是目录，因而忽略此项"
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "忽略 session 参数，因为“%s”不存在"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
@@ -2402,193 +1552,78 @@ msgstr ""
 "你不能在载入会话时同时设置配置档案、工作目录及执行的命令行选项，请选择其中一"
 "个操作"
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-msgid "View session sidebar"
-msgstr "显示会话侧边栏"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "创建会话"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
+msgstr ""
 
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "更改会话名称"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "为会话新建名称"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
-msgstr "打开…"
-
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "保存"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "另存为…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "名称…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "同步输入"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr "所有 JSON 文件"
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "文件名“%s”不存在"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "载入会话"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "发生未知错误，无法载入会话。"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Error Loading Session"
-msgstr "载入会话出错"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "保存会话"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 msgid "disabled"
 msgstr "已禁用"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr "你的 GTK 版本太老，需要至少 GTK %d.%d.%d！"
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr "发生未预期错误"
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr "错误： "
 
 # ******************
 # Nautilus extension
 # ******************
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "使用 Terminix 打开…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "在 %s 打开 Terminix"
+
+# ******************
+# Nautilus extension
+# ******************
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "使用 Terminix 打开…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "在 %s 打开 Terminix"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "在此打开 Terminix…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "在此目录打开 Terminix"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "在此打开 Terminix…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "在此目录打开 Terminix"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-msgid "Application"
-msgstr "应用程序"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 msgctxt "shortcut window"
 msgid "Application"
 msgstr "应用程序"
@@ -2628,257 +1663,248 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "显示会话边栏"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
+#: data/resources/ui/shortcuts.ui:61
+#, fuzzy
+msgctxt "shortcut window"
+msgid "View session switcher"
+msgstr "显示会话侧边栏"
+
+#: data/resources/ui/shortcuts.ui:67
 msgctxt "shortcut window"
 msgid "Switch to next session"
 msgstr "切换到下一个会话"
 
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
+#: data/resources/ui/shortcuts.ui:73
 msgctxt "shortcut window"
 msgid "Switch to previous session"
 msgstr "切换到上一个会话"
 
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
+#: data/resources/ui/shortcuts.ui:79
 msgctxt "shortcut window"
 msgid "Switch to session 1"
 msgstr "切换到会话 1"
 
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
+#: data/resources/ui/shortcuts.ui:85
 msgctxt "shortcut window"
 msgid "Switch to session 2"
 msgstr "切换到会话 2"
 
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
+#: data/resources/ui/shortcuts.ui:91
 msgctxt "shortcut window"
 msgid "Switch to session 3"
 msgstr "切换到会话 3"
 
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
+#: data/resources/ui/shortcuts.ui:97
 msgctxt "shortcut window"
 msgid "Switch to session 4"
 msgstr "切换到会话 4"
 
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
+#: data/resources/ui/shortcuts.ui:103
 msgctxt "shortcut window"
 msgid "Switch to session 5"
 msgstr "切换到会话 5"
 
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
+#: data/resources/ui/shortcuts.ui:109
 msgctxt "shortcut window"
 msgid "Switch to session 6"
 msgstr "切换到会话 6"
 
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
+#: data/resources/ui/shortcuts.ui:115
 msgctxt "shortcut window"
 msgid "Switch to session 7"
 msgstr "切换到会话 7"
 
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
+#: data/resources/ui/shortcuts.ui:121
 msgctxt "shortcut window"
 msgid "Switch to session 8"
 msgstr "切换到会话 8"
 
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
+#: data/resources/ui/shortcuts.ui:127
 msgctxt "shortcut window"
 msgid "Switch to session 9"
 msgstr "切换到会话 9"
 
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
+#: data/resources/ui/shortcuts.ui:133
 msgctxt "shortcut window"
 msgid "Switch to session 10"
 msgstr "切换到会话 10"
 
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
+#: data/resources/ui/shortcuts.ui:144
+msgctxt "shortcut window"
 msgid "Session"
 msgstr "会话"
 
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
+#: data/resources/ui/shortcuts.ui:149
 msgctxt "shortcut window"
 msgid "File"
 msgstr "文件"
 
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
+#: data/resources/ui/shortcuts.ui:153
 msgctxt "shortcut window"
 msgid "Close the current session"
 msgstr "关闭当前会话"
 
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
+#: data/resources/ui/shortcuts.ui:159
 msgctxt "shortcut window"
 msgid "Save the current session"
 msgstr "保存当前会话"
 
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
+#: data/resources/ui/shortcuts.ui:165
 msgctxt "shortcut window"
 msgid "Save the current session with new filename"
 msgstr "使用新文件名保存当前会话"
 
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
+#: data/resources/ui/shortcuts.ui:171
 msgctxt "shortcut window"
 msgid "Open a saved session"
 msgstr "打开先前保存的会话"
 
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr "添加"
+
+#: data/resources/ui/shortcuts.ui:183
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "在右侧添加终端"
+
+#: data/resources/ui/shortcuts.ui:189
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "在下侧添加终端"
+
 #: data/resources/ui/shortcuts.ui:197
 msgctxt "shortcut window"
 msgid "Resize"
 msgstr "缩放"
 
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
 #: data/resources/ui/shortcuts.ui:201
 msgctxt "shortcut window"
 msgid "Resize the terminal up"
 msgstr "缩放上侧终端"
 
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
 #: data/resources/ui/shortcuts.ui:207
 msgctxt "shortcut window"
 msgid "Resize the terminal down"
 msgstr "缩放下侧终端"
 
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
 #: data/resources/ui/shortcuts.ui:213
 msgctxt "shortcut window"
 msgid "Resize the terminal left"
 msgstr "缩放左侧终端"
 
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
 #: data/resources/ui/shortcuts.ui:219
 msgctxt "shortcut window"
 msgid "Resize the terminal right"
 msgstr "缩放上侧终端"
 
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr "其他"
+
+#: data/resources/ui/shortcuts.ui:231
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "编辑会话名称"
+
+#: data/resources/ui/shortcuts.ui:237
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "同步输入"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
 msgctxt "shortcut window"
 msgid "Switch"
 msgstr "切换"
 
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
+#: data/resources/ui/shortcuts.ui:249
 msgctxt "shortcut window"
 msgid "Switch to next terminal"
 msgstr "切换到下一个终端"
 
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
+#: data/resources/ui/shortcuts.ui:255
 msgctxt "shortcut window"
 msgid "Switch to previous terminal"
 msgstr "切换到上一个终端"
 
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
+#: data/resources/ui/shortcuts.ui:261
 msgctxt "shortcut window"
 msgid "Switch to the terminal up"
 msgstr "切换到上侧终端"
 
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
+#: data/resources/ui/shortcuts.ui:267
 msgctxt "shortcut window"
 msgid "Switch to the terminal down"
 msgstr "切换到下侧终端"
 
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
+#: data/resources/ui/shortcuts.ui:273
 msgctxt "shortcut window"
 msgid "Switch to the terminal left"
 msgstr "切换到左侧终端"
 
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
+#: data/resources/ui/shortcuts.ui:279
 msgctxt "shortcut window"
 msgid "Switch to the terminal right"
 msgstr "切换到右侧终端"
 
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
+#: data/resources/ui/shortcuts.ui:291
 msgctxt "shortcut window"
 msgid "Switch to terminal 1"
 msgstr "切换到终端 1"
 
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
+#: data/resources/ui/shortcuts.ui:297
 msgctxt "shortcut window"
 msgid "Switch to terminal 2"
 msgstr "切换到终端 2"
 
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
+#: data/resources/ui/shortcuts.ui:303
 msgctxt "shortcut window"
 msgid "Switch to terminal 3"
 msgstr "切换到终端 3"
 
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
+#: data/resources/ui/shortcuts.ui:309
 msgctxt "shortcut window"
 msgid "Switch to terminal 4"
 msgstr "切换到终端 4"
 
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
+#: data/resources/ui/shortcuts.ui:315
 msgctxt "shortcut window"
 msgid "Switch to terminal 5"
 msgstr "切换到终端 5"
 
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
+#: data/resources/ui/shortcuts.ui:321
 msgctxt "shortcut window"
 msgid "Switch to terminal 6"
 msgstr "切换到终端 6"
 
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
+#: data/resources/ui/shortcuts.ui:327
 msgctxt "shortcut window"
 msgid "Switch to terminal 7"
 msgstr "切换到终端 7"
 
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
+#: data/resources/ui/shortcuts.ui:333
 msgctxt "shortcut window"
 msgid "Switch to terminal 8"
 msgstr "切换到终端 8"
 
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
+#: data/resources/ui/shortcuts.ui:339
 msgctxt "shortcut window"
 msgid "Switch to terminal 9"
 msgstr "切换到终端 9"
 
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
+#: data/resources/ui/shortcuts.ui:345
 msgctxt "shortcut window"
 msgid "Switch to terminal 10"
 msgstr "切换到终端 10"
 
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "分割"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "向右分割"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "向下分割"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
 #: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
 msgctxt "shortcut window"
 msgid "Find"
 msgstr "查找"
 
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
+#: data/resources/ui/shortcuts.ui:371
 msgctxt "shortcut window"
 msgid "Find next"
 msgstr "查找下一个"
@@ -2888,199 +1914,176 @@ msgstr "查找下一个"
 # in the Shortcut preferences and in the future
 # the shortcut overview if available in Gnome 3.20
 # ***********************************************
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
+#: data/resources/ui/shortcuts.ui:377
 msgctxt "shortcut window"
 msgid "Find previous"
 msgstr "查找上一个"
 
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
+#: data/resources/ui/shortcuts.ui:385
 msgctxt "shortcut window"
 msgid "Clipboard"
 msgstr "剪贴板"
 
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
+#: data/resources/ui/shortcuts.ui:389
 msgctxt "shortcut window"
 msgid "Copy"
 msgstr "复制"
 
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
+#: data/resources/ui/shortcuts.ui:395
 msgctxt "shortcut window"
 msgid "Paste"
 msgstr "粘贴"
 
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
+#: data/resources/ui/shortcuts.ui:401
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Advanced paste"
+msgstr "高级选项"
+
+#: data/resources/ui/shortcuts.ui:407
 msgctxt "shortcut window"
 msgid "Select all"
 msgstr "全选"
 
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
+#: data/resources/ui/shortcuts.ui:415
 msgctxt "shortcut window"
 msgid "Zoom"
 msgstr "缩放"
 
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
+#: data/resources/ui/shortcuts.ui:419
 msgctxt "shortcut window"
 msgid "Zoom in"
 msgstr "放大"
 
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
+#: data/resources/ui/shortcuts.ui:425
 msgctxt "shortcut window"
 msgid "Zoom out"
 msgstr "缩小"
 
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
+#: data/resources/ui/shortcuts.ui:431
 msgctxt "shortcut window"
 msgid "Zoom normal size"
 msgstr "正常缩放"
 
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr "其他"
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
+#: data/resources/ui/shortcuts.ui:443
 msgctxt "shortcut window"
 msgid "Save terminal contents"
 msgstr "保存终端内容"
 
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
+#: data/resources/ui/shortcuts.ui:449
 msgctxt "shortcut window"
 msgid "Close terminal"
 msgstr "关闭终端"
 
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
+#: data/resources/ui/shortcuts.ui:455
 msgctxt "shortcut window"
 msgid "Maximize terminal"
 msgstr "最大化终端"
 
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
+#: data/resources/ui/shortcuts.ui:461
 msgctxt "shortcut window"
 msgid "Current profile preferences"
 msgstr "当前配置方案首选项"
 
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
+#: data/resources/ui/shortcuts.ui:467
 msgctxt "shortcut window"
 msgid "Reset the terminal"
 msgstr "重置终端"
 
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
+#: data/resources/ui/shortcuts.ui:473
 msgctxt "shortcut window"
 msgid "Reset and clear the terminal"
 msgstr "重置并清空终端"
 
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
+#: data/resources/ui/shortcuts.ui:479
 msgctxt "shortcut window"
 msgid "Toggle read only"
 msgstr "切换只读模式"
 
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
+#: data/resources/ui/shortcuts.ui:485
 msgctxt "shortcut window"
 msgid "Layout options"
 msgstr "布局选项"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/resources/ui/shortcuts.ui:491
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "插入终端序号"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:503
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cycle title style"
+msgstr "终端标题样式"
+
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
 msgid "A tiling terminal for Gnome"
 msgstr "GNOME 的平铺终端模拟器"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
 #: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
 msgid "com.gexperts.Terminix"
 msgstr "com.gexperts.Terminix"
 
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-msgid "New Terminal"
-msgstr "新建终端"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
 msgid "A tiling terminal for GNOME"
 msgstr "GNOME 的平铺终端模拟器"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
 msgid "Terminix is a tiling terminal emulator."
 msgstr "Terminix 是一个平铺终端模拟器。"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 msgid "It lets you:"
 msgstr "它可让你："
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 msgid ""
 "Layout terminals in any fashion by splitting them horizontally or vertically"
 msgstr "通过垂直和水平分割随心所欲地排布终端"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 msgid ""
 "Terminals can be re-arranged using drag and drop both within and between "
 "windows"
 msgstr "可通过在窗口内外拖放重新安排终端"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 msgid "Terminals can be detached into a new window via drag and drop"
 msgstr "可通过拖放将终端脱离为新的窗口"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 msgid ""
 "Input can be synchronized between terminals so commands typed in one "
 "terminal are replicated to the others"
 msgstr "可在终端之间同步输入，可将一个终端的输入复制到另一个终端里"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 msgid "The grouping of terminals can be saved and loaded from disk"
 msgstr "可从磁盘保存和载入终端分组"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 msgid "Terminals support custom titles"
 msgstr "终端支持自定义标题"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 msgid ""
 "Color schemes are stored in files and custom color schemes can be created by "
 "simply creating a new file"
 msgstr "配色方案存储在文件中，可通过创建文件来创建新的配色方案"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 msgid "Transparent background"
 msgstr "透明背景"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 msgid "Supports notifications when processes are completed out of view"
 msgstr "支持进程在视图外完成时发送桌面通知"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
 msgid ""
 "The application was written using GTK 3 and an effort was made to conform to "
@@ -3090,803 +2093,6 @@ msgstr ""
 "该应用程序使用 GTK 3 编写并尝试兼容 GNOME 人机交互指南（HIG）。因此，"
 "Terminix 使用了客户端窗口装饰（CSD），但此功能可随时关闭。"
 
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix 已在 GNOME 和 Unity 上测试。"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "设置窗口大小；例如：80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr "尺寸"
-
-#: source/gx/terminix/prefwindow.d:337
-msgid "Window"
-msgstr "窗口"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "编辑会话名称"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "同步输入"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "会话"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-msgid "Save Output…"
-msgstr "保存输出…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr "打开"
-
-#: source/gx/terminix/terminal/search.d:134
-msgid "Find next"
-msgstr "查找下一个"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:140
-msgid "Find previous"
-msgstr "查找上一个"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "将附加实例作为新进程启动（不推荐）"
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-msgid "Add terminal right"
-msgstr "右侧新建终端"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-msgid "Add terminal down"
-msgstr "下侧新建终端"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-msgid "Find text in terminal"
-msgstr "在终端查找文本"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr "声音"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr "图标"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr "图标和声音"
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr "自动切换配置档案"
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-msgid "Match"
-msgstr "匹配"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr "添加"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr "添加新匹配"
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr "输入主机名:目录以匹配"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr "编辑匹配"
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr "编辑主机名:目录以匹配"
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-msgid "Background image"
-msgstr "背景图像"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-msgid "Select Image"
-msgstr "选择图像"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr "所有图像文件"
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-msgid "Reset background image"
-msgstr "重置背景图像"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr "缩放"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr "平铺"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr "居中"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr "拉伸"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr "添加"
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "在右侧添加终端"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "在下侧添加终端"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "选择时自动将文本复制到剪贴板"
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-msgid "Add Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr "向下分割"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "Set the title of the new terminal"
-msgstr "设置新终端的标题"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr "标题"
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-"根据此处输入的值自动选择配置档案。\n"
-"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
-"号。不允许同时忽略主机名和目录"
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-msgid "Enable shortcuts"
-msgstr "启用快捷键"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-msgid "Custom Links"
-msgstr "自定义链接"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr "可根据正则表达式定义点击终端上一系列的用户定义链接。"
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"根据此处输入的值自动选择配置档案。\n"
-"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
-"号。不允许同时忽略主机名和目录。"
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr "%s 不是有效的正则表达式"
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr "正则表达式"
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr "不区分大小写"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr "编辑自定义链接"
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr "应用"
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "插入终端序号"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "执行传入的命令"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"根据此处输入的值自动选择配置档案。\n"
-"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
-"号。不允许同时忽略主机名和目录。"
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "输入主机名:目录以匹配"
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "编辑主机名:目录以匹配"
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "编辑配置方案"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "命令"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "标题"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-#, fuzzy
-msgid "SendText"
-msgstr "文字"
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "终端标题"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "高级选项"
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "最大化终端窗口"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "编辑会话名称"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "设置新终端的标题"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:61
-#, fuzzy
-msgctxt "shortcut window"
-msgid "View session switcher"
-msgstr "显示会话侧边栏"
-
-#: data/resources/ui/shortcuts.ui:401
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Advanced paste"
-msgstr "高级选项"
-
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "仍有正在运行的进程，依然要关闭吗？"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "不再显示该信息"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "南欧"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "选择 %s 个颜色"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "使用 Terminix 打开…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "在 %s 打开 Terminix"
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "使用 Terminix 打开…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "在此打开 Terminix…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "在此目录打开 Terminix"
-
-#: data/resources/ui/shortcuts.ui:503
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Cycle title style"
-msgstr "终端标题样式"
-
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:728
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "配色方案"
-
-#: source/gx/terminix/prefwindow.d:767
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "保存终端内容"
-
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,11 +5,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-07 11:25+0100\n"
+"POT-Creation-Date: 2016-11-09 08:28+0100\n"
 "PO-Revision-Date: 2016-11-08 15:29+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: Chinese (Taiwan) "
-"<https://hosted.weblate.org/projects/terminix/translations/zh_TW/>\n"
+"Language-Team: Chinese (Taiwan) <https://hosted.weblate.org/projects/"
+"terminix/translations/zh_TW/>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,972 +17,1170 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/gx/terminix/colorschemes.d:167 source/gx/terminix/colorschemes.d:166
-#: source/gx/terminix/colorschemes.d:176 source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
+#: source/gx/terminix/preferences.d:201
+msgid "UpdateState"
 msgstr ""
 
-#: source/gx/terminix/colorschemes.d:224 source/gx/terminix/colorschemes.d:223
-#: source/gx/terminix/colorschemes.d:239 source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:68 source/gx/terminix/profilewindow.d:77
-#: source/gx/terminix/profilewindow.d:85 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:92
-#, c-format
-msgid "Editing Profile: %s"
-msgstr "正在編輯配置方案：%s"
-
-#: source/gx/terminix/profilewindow.d:70 source/gx/terminix/profilewindow.d:79
-#: source/gx/terminix/profilewindow.d:87 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:94
+#: source/gx/terminix/preferences.d:202
 #, fuzzy
-msgid "New Profile"
-msgstr "配置方案"
-
-#: source/gx/terminix/profilewindow.d:78 source/gx/terminix/profilewindow.d:87
-#: source/gx/terminix/profilewindow.d:88 source/gx/terminix/profilewindow.d:96
-#: source/gx/terminix/profilewindow.d:99 source/gx/terminix/profilewindow.d:103
-msgid "General"
-msgstr "常規"
-
-#: source/gx/terminix/profilewindow.d:79 source/gx/terminix/profilewindow.d:774
-#: source/gx/terminix/terminal/layout.d:64
-#: source/gx/terminix/profilewindow.d:779 source/gx/terminix/profilewindow.d:88
-#: source/gx/terminix/profilewindow.d:788 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:789 source/gx/terminix/profilewindow.d:97
-#: source/gx/terminix/profilewindow.d:797
-#: source/gx/terminix/profilewindow.d:1048
-#: source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:1098
-#: source/gx/terminix/profilewindow.d:1100
-#: source/gx/terminix/profilewindow.d:847
-#: source/gx/terminix/profilewindow.d:1147
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:925
-#: source/gx/terminix/profilewindow.d:1225
-msgid "Command"
+msgid "ExecuteCommand"
 msgstr "指令"
 
-#: source/gx/terminix/profilewindow.d:80 source/gx/terminix/profilewindow.d:89
-#: source/gx/terminix/profilewindow.d:90 source/gx/terminix/profilewindow.d:98
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:105
-msgid "Color"
-msgstr "顏色"
+#: source/gx/terminix/preferences.d:203
+msgid "SendNotification"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:81 source/gx/terminix/profilewindow.d:90
-#: source/gx/terminix/profilewindow.d:91 source/gx/terminix/profilewindow.d:99
-#: source/gx/terminix/profilewindow.d:102
-#: source/gx/terminix/profilewindow.d:106
-msgid "Scrolling"
-msgstr "滾動"
-
-#: source/gx/terminix/profilewindow.d:82 source/gx/terminix/profilewindow.d:91
-#: source/gx/terminix/profilewindow.d:92 source/gx/terminix/profilewindow.d:100
-#: source/gx/terminix/profilewindow.d:103
-#: source/gx/terminix/profilewindow.d:107
-msgid "Compatibility"
-msgstr "相容性"
-
-#: source/gx/terminix/profilewindow.d:131
-#: source/gx/terminix/profilewindow.d:141
-#: source/gx/terminix/profilewindow.d:142
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:153
-#: source/gx/terminix/profilewindow.d:157
+#: source/gx/terminix/preferences.d:204
 #, fuzzy
-msgid "Profile name"
-msgstr "配置方案名稱"
+msgid "UpdateTitle"
+msgstr "標題"
 
-#: source/gx/terminix/profilewindow.d:139
-#: source/gx/terminix/profilewindow.d:149
-#: source/gx/terminix/profilewindow.d:150
-#: source/gx/terminix/profilewindow.d:158
-#: source/gx/terminix/profilewindow.d:161
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:166
-#, c-format
-msgid "ID: %s"
-msgstr "ID：%s"
+#: source/gx/terminix/preferences.d:205
+msgid "PlayBell"
+msgstr ""
 
-#: source/gx/terminix/profilewindow.d:146
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:157
-#: source/gx/terminix/profilewindow.d:165
-#: source/gx/terminix/profilewindow.d:168
-#: source/gx/terminix/profilewindow.d:169
-#: source/gx/terminix/profilewindow.d:173
+#: source/gx/terminix/preferences.d:206
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:207
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1369
+#: source/gx/terminix/terminal/terminal.d:1380
+msgid "Paste"
+msgstr "貼上"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/terminal/layout.d:28 source/gx/terminix/appwindow.d:1112
+#: source/gx/terminix/appwindow.d:1146 source/gx/terminix/profilewindow.d:750
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
+msgid "Name"
+msgstr "名稱"
+
+#: source/gx/terminix/terminal/password.d:136
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+#: source/gx/terminix/prefwindow.d:466
+msgid "New"
+msgstr "新建"
+
+#: source/gx/terminix/terminal/password.d:180
+#: source/gx/terminix/profilewindow.d:1023
+#: source/gx/terminix/profilewindow.d:1050
+#: source/gx/terminix/profilewindow.d:1122 source/gx/terminix/prefwindow.d:479
+msgid "Edit"
+msgstr "編輯"
+
+#: source/gx/terminix/terminal/password.d:209
+#: source/gx/terminix/profilewindow.d:1141
+#: source/gx/terminix/profilewindow.d:1289
+#: source/gx/terminix/profilewindow.d:1445 source/gx/terminix/prefwindow.d:482
+msgid "Delete"
+msgstr "刪除"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/profilewindow.d:1310
+#: source/gx/terminix/profilewindow.d:1483
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:28
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:121
+msgid "Search Options"
+msgstr "搜尋選項"
+
+#: source/gx/terminix/terminal/search.d:134
 #, fuzzy
-msgid "Terminal size"
-msgstr "終端大小"
+msgid "Find next"
+msgstr "查詢下一個"
 
-#: source/gx/terminix/profilewindow.d:156
-#: source/gx/terminix/profilewindow.d:166
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/profilewindow.d:175
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:179
-#: source/gx/terminix/profilewindow.d:183
-msgid "columns"
-msgstr "行"
-
-#: source/gx/terminix/profilewindow.d:162
-#: source/gx/terminix/profilewindow.d:172
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:184
-#: source/gx/terminix/profilewindow.d:185
-#: source/gx/terminix/profilewindow.d:189
-msgid "rows"
-msgstr "列"
-
-#: source/gx/terminix/profilewindow.d:167
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/profilewindow.d:177
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/terminal/terminal.d:666
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/terminal/terminal.d:698
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:752
-#: source/gx/terminix/profilewindow.d:190
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/profilewindow.d:194
-msgid "Reset"
-msgstr "重置"
-
-#: source/gx/terminix/profilewindow.d:173
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:178
-#: source/gx/terminix/profilewindow.d:425
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:189
-#: source/gx/terminix/profilewindow.d:435
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:471
-#: source/gx/terminix/profilewindow.d:205
-#: source/gx/terminix/profilewindow.d:491
-msgid "Cursor"
-msgstr "游標"
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Block"
-msgstr "方塊"
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "IBeam"
-msgstr "IBeam"
-
-#: source/gx/terminix/profilewindow.d:176
-#: source/gx/terminix/profilewindow.d:181
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:200
-#: source/gx/terminix/profilewindow.d:203
-#: source/gx/terminix/profilewindow.d:204
-#: source/gx/terminix/profilewindow.d:208
-msgid "Underline"
-msgstr "下劃線"
-
-#: source/gx/terminix/profilewindow.d:183
-#: source/gx/terminix/profilewindow.d:188
-#: source/gx/terminix/profilewindow.d:198
-#: source/gx/terminix/profilewindow.d:199
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:215
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:140
 #, fuzzy
-msgid "Blink mode"
-msgstr "閃爍模式"
+msgid "Find previous"
+msgstr "查詢上一個"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "System"
-msgstr "系統"
+#: source/gx/terminix/terminal/search.d:187
+msgid "Match case"
+msgstr "區分大小寫"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "On"
-msgstr "開啟"
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match entire word only"
+msgstr "只匹配整個單詞"
 
-#: source/gx/terminix/profilewindow.d:186
-#: source/gx/terminix/profilewindow.d:191
-#: source/gx/terminix/profilewindow.d:201
-#: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:213
-#: source/gx/terminix/profilewindow.d:214
-#: source/gx/terminix/profilewindow.d:218
-msgid "Off"
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match as regular expression"
+msgstr "使用正規表示式匹配"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Wrap around"
+msgstr "折列"
+
+#: source/gx/terminix/terminal/terminal.d:369
+#: source/gx/terminix/terminal/terminal.d:2747
+#: data/resources/ui/shortcuts.ui:356
+msgid "Terminal"
+msgstr "終端"
+
+#: source/gx/terminix/terminal/terminal.d:400
+#: source/gx/terminix/terminal/terminal.d:1398 source/gx/terminix/sidebar.d:374
+#: source/gx/terminix/appwindow.d:617
+msgid "Close"
 msgstr "關閉"
 
-#: source/gx/terminix/profilewindow.d:192
-#: source/gx/terminix/profilewindow.d:197
-#: source/gx/terminix/terminal/terminal.d:398
-#: source/gx/terminix/profilewindow.d:207
-#: source/gx/terminix/profilewindow.d:208
-#: source/gx/terminix/terminal/terminal.d:404
-#: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/terminal/terminal.d:414
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:436
-#: source/gx/terminix/profilewindow.d:220
+#: source/gx/terminix/terminal/terminal.d:409
+#: source/gx/terminix/terminal/terminal.d:1105
+#: source/gx/terminix/terminal/terminal.d:1397
+#, fuzzy
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:420
+#: source/gx/terminix/terminal/terminal.d:660
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:430
+#: source/gx/terminix/terminal/terminal.d:765
+msgid "Read-Only"
+msgstr "只讀"
+
 #: source/gx/terminix/terminal/terminal.d:437
-#: source/gx/terminix/profilewindow.d:224
+#: source/gx/terminix/profilewindow.d:237
 #, fuzzy
 msgid "Terminal bell"
 msgstr "終端響鈴"
 
+#: source/gx/terminix/terminal/terminal.d:483
+msgid "Edit Profile"
+msgstr "編輯配置檔"
+
+#: source/gx/terminix/terminal/terminal.d:624
+#: source/gx/terminix/appwindow.d:894
+msgid "There are processes that are still running, close anyway?"
+msgstr "仍有正在執行的程序，依然要關閉嗎？"
+
+#: source/gx/terminix/terminal/terminal.d:662
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:692
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:752
+#, fuzzy
+msgid "Save Output…"
+msgstr "另存為…"
+
+#: source/gx/terminix/terminal/terminal.d:753
 #: source/gx/terminix/profilewindow.d:202
-#: source/gx/terminix/profilewindow.d:207
+msgid "Reset"
+msgstr "重置"
+
+#: source/gx/terminix/terminal/terminal.d:754
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:758
+#: source/gx/terminix/prefwindow.d:101
+msgid "Profiles"
+msgstr "配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:759
+#: source/gx/terminix/profilewindow.d:895 source/gx/terminix/prefwindow.d:104
+#: source/gx/terminix/prefwindow.d:177
+msgid "Encoding"
+msgstr "編碼"
+
+#: source/gx/terminix/terminal/terminal.d:763
+msgid "Find…"
+msgstr "查詢…"
+
+#: source/gx/terminix/terminal/terminal.d:764
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:775
+#, fuzzy
+msgid "Add Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/terminal/terminal.d:779
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1102
+#: source/gx/terminix/terminal/terminal.d:1397
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1357
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1358
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1368
+#: source/gx/terminix/terminal/terminal.d:1375
+msgid "Copy"
+msgstr "複製"
+
+#: source/gx/terminix/terminal/terminal.d:1370
+#: source/gx/terminix/terminal/terminal.d:1385
+msgid "Select All"
+msgstr "全選"
+
+#: source/gx/terminix/terminal/terminal.d:1388
+#: source/gx/terminix/prefwindow.d:869
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1402
+#, fuzzy
+msgid "Synchronize input"
+msgstr "同步輸入"
+
+#: source/gx/terminix/terminal/terminal.d:1991
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1997
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2482
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2485
+#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
+#: source/gx/terminix/profilewindow.d:750
+msgid "Save"
+msgstr "儲存"
+
+#: source/gx/terminix/terminal/terminal.d:2491
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2495
+#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:767
+#: source/gx/terminix/prefwindow.d:630
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2907
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2908
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2909
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2915
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2960
+#, fuzzy
+msgid "Don't Paste"
+msgstr "貼上"
+
+#: source/gx/terminix/terminal/terminal.d:2961
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:28
+#, fuzzy
+msgid "Layout Options"
+msgstr "選項"
+
+#: source/gx/terminix/terminal/layout.d:43
+#, fuzzy
+msgid "Active"
+msgstr "動作"
+
+#: source/gx/terminix/terminal/layout.d:49
+#, fuzzy
+msgid "Title"
+msgstr "標題"
+
+#: source/gx/terminix/terminal/layout.d:57
+#, fuzzy
+msgid "Session Load"
+msgstr "會話"
+
+#: source/gx/terminix/terminal/layout.d:64
+#: source/gx/terminix/profilewindow.d:105
+#: source/gx/terminix/profilewindow.d:955
+#: source/gx/terminix/profilewindow.d:1258
+msgid "Command"
+msgstr "指令"
+
+#: source/gx/terminix/terminal/layout.d:73
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:317
+#, fuzzy
+msgid "View session sidebar"
+msgstr "顯示側邊列"
+
+#: source/gx/terminix/appwindow.d:342
+msgid "Create a new session"
+msgstr "建立會話"
+
+#: source/gx/terminix/appwindow.d:360
+#, fuzzy
+msgid "Add terminal right"
+msgstr "切換到終端 10"
+
+#: source/gx/terminix/appwindow.d:364
+#, fuzzy
+msgid "Add terminal down"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/appwindow.d:369
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "退出此終端"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Change Session Name"
+msgstr "更改會話名稱"
+
+#: source/gx/terminix/appwindow.d:559
+msgid "Enter a new name for the session"
+msgstr "為會話新建名稱"
+
+#: source/gx/terminix/appwindow.d:614
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:616
+msgid "Save As…"
+msgstr "另存為…"
+
+#: source/gx/terminix/appwindow.d:621
+msgid "Name…"
+msgstr "名稱…"
+
+#: source/gx/terminix/appwindow.d:622
+msgid "Synchronize Input"
+msgstr "同步輸入"
+
+#: source/gx/terminix/appwindow.d:627
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:871
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "仍有正在執行的程序，依然要關閉嗎？"
+
+#: source/gx/terminix/appwindow.d:872
+#, fuzzy
+msgid "Do not show this again"
+msgstr "不再顯示該資訊"
+
+#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:763
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1079
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "檔名「%s」不存在"
+
+#: source/gx/terminix/appwindow.d:1109
+msgid "Load Session"
+msgstr "載入會話"
+
+#: source/gx/terminix/appwindow.d:1112
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1127
+msgid "Could not load session due to unexpected error."
+msgstr "發生未知錯誤，無法載入會話。"
+
+#: source/gx/terminix/appwindow.d:1127
+#, fuzzy
+msgid "Error Loading Session"
+msgstr "載入會話"
+
+#: source/gx/terminix/appwindow.d:1143
+msgid "Save Session"
+msgstr "儲存會話"
+
+#: source/gx/terminix/appwindow.d:1225
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:224 source/gx/terminix/session.d:1397
+#: source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
+msgid "New Session"
+msgstr "新建會話"
+
+#: source/gx/terminix/application.d:225 source/gx/terminix/prefwindow.d:863
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
+msgid "New Window"
+msgstr "新建視窗"
+
+#: source/gx/terminix/application.d:229 source/gx/terminix/prefwindow.d:82
+msgid "Preferences"
+msgstr "偏好"
+
+#: source/gx/terminix/application.d:231 source/gx/terminix/prefwindow.d:98
+msgid "Shortcuts"
+msgstr "快捷鍵"
+
+#: source/gx/terminix/application.d:236
+msgid "About"
+msgstr "關於"
+
+#: source/gx/terminix/application.d:237
+msgid "Quit"
+msgstr "退出"
+
+#: source/gx/terminix/application.d:291
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:604
+msgid "Set the working directory of the terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/application.d:604
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:605
+msgid "Set the starting profile"
+msgstr "設定啟動配置檔"
+
+#: source/gx/terminix/application.d:605
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:606
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/application.d:606
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:607
+msgid "Open the specified session"
+msgstr "開啟指定的會話"
+
+#: source/gx/terminix/application.d:607
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:608
+msgid "Send an action to current Terminix instance"
+msgstr "向當前 Terminix 例項傳送動作"
+
+#: source/gx/terminix/application.d:608
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:609
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "執行傳入的指令"
+
+#: source/gx/terminix/application.d:609
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:610
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:611
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:612
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:613
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:614
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:615
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:616
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:617
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:620
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:784
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"終端配置似乎存在問題。這並不是嚴重問題，但是更正這些問題將改善你的使用體驗。"
+"點選如下連結以獲取更多資訊："
+
+#: source/gx/terminix/application.d:785
+msgid "Configuration Issue Detected"
+msgstr "檢測到配置問題"
+
+#: source/gx/terminix/application.d:797
+msgid "Do not show this message again"
+msgstr "不再顯示該資訊"
+
+#: source/gx/terminix/profilewindow.d:93
+#, c-format
+msgid "Editing Profile: %s"
+msgstr "正在編輯配置方案：%s"
+
+#: source/gx/terminix/profilewindow.d:95
+#, fuzzy
+msgid "New Profile"
+msgstr "配置方案"
+
+#: source/gx/terminix/profilewindow.d:104
+msgid "General"
+msgstr "常規"
+
+#: source/gx/terminix/profilewindow.d:106
+msgid "Color"
+msgstr "顏色"
+
+#: source/gx/terminix/profilewindow.d:107
+msgid "Scrolling"
+msgstr "滾動"
+
+#: source/gx/terminix/profilewindow.d:108
+msgid "Compatibility"
+msgstr "相容性"
+
+#: source/gx/terminix/profilewindow.d:109
+#: source/gx/terminix/profilewindow.d:436
+msgid "Advanced"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:165
+#, fuzzy
+msgid "Profile name"
+msgstr "配置方案名稱"
+
+#: source/gx/terminix/profilewindow.d:174
+#, c-format
+msgid "ID: %s"
+msgstr "ID：%s"
+
+#: source/gx/terminix/profilewindow.d:181
+#, fuzzy
+msgid "Terminal size"
+msgstr "終端大小"
+
+#: source/gx/terminix/profilewindow.d:191
+msgid "columns"
+msgstr "行"
+
+#: source/gx/terminix/profilewindow.d:197
+msgid "rows"
+msgstr "列"
+
+#: source/gx/terminix/profilewindow.d:213
+#: source/gx/terminix/profilewindow.d:510
+msgid "Cursor"
+msgstr "游標"
+
 #: source/gx/terminix/profilewindow.d:216
-#: source/gx/terminix/profilewindow.d:217
-#: source/gx/terminix/profilewindow.d:225
-#: source/gx/terminix/profilewindow.d:228
+msgid "Block"
+msgstr "方塊"
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/profilewindow.d:216
+msgid "Underline"
+msgstr "下劃線"
+
+#: source/gx/terminix/profilewindow.d:226
+#, fuzzy
+msgid "Blink mode"
+msgstr "閃爍模式"
+
 #: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:233
+msgid "System"
+msgstr "系統"
+
+#: source/gx/terminix/profilewindow.d:229
+msgid "On"
+msgstr "開啟"
+
+#: source/gx/terminix/profilewindow.d:229
+msgid "Off"
+msgstr "關閉"
+
+#: source/gx/terminix/profilewindow.d:240 source/gx/terminix/prefwindow.d:605
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:240
+msgid "Icon and Sound"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:249
 #, fuzzy
 msgid "Terminal title"
 msgstr "終端標題"
 
-#: source/gx/terminix/profilewindow.d:215
-#: source/gx/terminix/profilewindow.d:220
-#: source/gx/terminix/profilewindow.d:229
-#: source/gx/terminix/profilewindow.d:230
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:268
+#: source/gx/terminix/profilewindow.d:260
+#: source/gx/terminix/profilewindow.d:546
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:269
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:273
+#, fuzzy
+msgid "Southeast"
+msgstr "南歐"
+
+#: source/gx/terminix/profilewindow.d:287
 msgid "Text Appearance"
 msgstr "文字外觀"
 
-#: source/gx/terminix/profilewindow.d:221
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:235
-#: source/gx/terminix/profilewindow.d:236
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:270
-#: source/gx/terminix/profilewindow.d:274
+#: source/gx/terminix/profilewindow.d:293
 msgid "Allow bold text"
 msgstr "允許粗體"
 
-#: source/gx/terminix/profilewindow.d:226
-#: source/gx/terminix/profilewindow.d:231
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:241
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:275
-#: source/gx/terminix/profilewindow.d:279
+#: source/gx/terminix/profilewindow.d:298
 msgid "Rewrap on resize"
 msgstr "縮放時重新換行"
 
-#: source/gx/terminix/profilewindow.d:232
-#: source/gx/terminix/profilewindow.d:237
-#: source/gx/terminix/profilewindow.d:246
-#: source/gx/terminix/profilewindow.d:247
-#: source/gx/terminix/profilewindow.d:255
-#: source/gx/terminix/profilewindow.d:258
-#: source/gx/terminix/profilewindow.d:281
-#: source/gx/terminix/profilewindow.d:285
+#: source/gx/terminix/profilewindow.d:304
 #, fuzzy
 msgid "Custom font"
 msgstr "自訂字型"
 
-#: source/gx/terminix/profilewindow.d:238
-#: source/gx/terminix/profilewindow.d:243
-#: source/gx/terminix/profilewindow.d:252
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:261
-#: source/gx/terminix/profilewindow.d:264
-#: source/gx/terminix/profilewindow.d:287
-#: source/gx/terminix/profilewindow.d:291
+#: source/gx/terminix/profilewindow.d:310
 msgid "Choose A Terminal Font"
 msgstr "選擇終端字型"
 
-#: source/gx/terminix/profilewindow.d:298
-#: source/gx/terminix/profilewindow.d:303
-#: source/gx/terminix/profilewindow.d:312
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:321
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:349
-#: source/gx/terminix/profilewindow.d:355
+#: source/gx/terminix/profilewindow.d:374
 msgid "Color scheme"
 msgstr "配色方案"
 
-#: source/gx/terminix/profilewindow.d:308
-#: source/gx/terminix/profilewindow.d:313
-#: source/gx/terminix/profilewindow.d:322
-#: source/gx/terminix/profilewindow.d:323
-#: source/gx/terminix/profilewindow.d:331
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:365
-#: source/gx/terminix/profilewindow.d:771
+#: source/gx/terminix/profilewindow.d:384
+#: source/gx/terminix/profilewindow.d:790
 msgid "Custom"
 msgstr "自訂"
 
-#: source/gx/terminix/profilewindow.d:319
-#: source/gx/terminix/profilewindow.d:324
-#: source/gx/terminix/profilewindow.d:333
-#: source/gx/terminix/profilewindow.d:334
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:345
-#: source/gx/terminix/profilewindow.d:370
-#: source/gx/terminix/profilewindow.d:390
+#: source/gx/terminix/profilewindow.d:397
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:409
 msgid "Color palette"
 msgstr "調色盤"
 
-#: source/gx/terminix/profilewindow.d:327
-#: source/gx/terminix/profilewindow.d:332
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:342
-#: source/gx/terminix/profilewindow.d:350
-#: source/gx/terminix/profilewindow.d:353 source/gx/terminix/prefwindow.d:735
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:398
+#: source/gx/terminix/profilewindow.d:417 source/gx/terminix/prefwindow.d:746
 msgid "Options"
 msgstr "選項"
 
-#: source/gx/terminix/profilewindow.d:341
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:355
-#: source/gx/terminix/profilewindow.d:356
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:367
-#: source/gx/terminix/profilewindow.d:392
-#: source/gx/terminix/profilewindow.d:412
+#: source/gx/terminix/profilewindow.d:431
 msgid "Use theme colors for foreground/background"
 msgstr "為前景/背景色使用主題顏色"
 
-#: source/gx/terminix/profilewindow.d:346
-#: source/gx/terminix/profilewindow.d:351 source/gx/terminix/profilewindow.d:92
-#: source/gx/terminix/profilewindow.d:360 source/gx/terminix/profilewindow.d:93
-#: source/gx/terminix/profilewindow.d:361
-#: source/gx/terminix/profilewindow.d:101
-#: source/gx/terminix/profilewindow.d:369
-#: source/gx/terminix/profilewindow.d:104
-#: source/gx/terminix/profilewindow.d:372
-#: source/gx/terminix/profilewindow.d:397
-#: source/gx/terminix/profilewindow.d:108
-#: source/gx/terminix/profilewindow.d:417
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:359
-#: source/gx/terminix/profilewindow.d:364
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:374
-#: source/gx/terminix/profilewindow.d:382
-#: source/gx/terminix/profilewindow.d:385
-#: source/gx/terminix/profilewindow.d:410
-#: source/gx/terminix/profilewindow.d:430
+#: source/gx/terminix/profilewindow.d:449
 msgid "Transparency"
 msgstr "透明度"
 
-#: source/gx/terminix/profilewindow.d:373
-#: source/gx/terminix/profilewindow.d:378
-#: source/gx/terminix/profilewindow.d:387
-#: source/gx/terminix/profilewindow.d:388
-#: source/gx/terminix/profilewindow.d:396
-#: source/gx/terminix/profilewindow.d:399
-#: source/gx/terminix/profilewindow.d:424
-#: source/gx/terminix/profilewindow.d:444
+#: source/gx/terminix/profilewindow.d:463
 msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:415
-#: source/gx/terminix/profilewindow.d:420
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:438
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:486
+#: source/gx/terminix/profilewindow.d:505
 msgid "Text"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:416
-#: source/gx/terminix/profilewindow.d:473
-#: source/gx/terminix/profilewindow.d:421
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:430
-#: source/gx/terminix/profilewindow.d:487
-#: source/gx/terminix/profilewindow.d:431
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:499
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:539
-#: source/gx/terminix/profilewindow.d:559
+#: source/gx/terminix/profilewindow.d:506
+#: source/gx/terminix/profilewindow.d:578
 msgid "Background"
 msgstr "背景"
 
-#: source/gx/terminix/profilewindow.d:427
-#: source/gx/terminix/profilewindow.d:432
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:442
-#: source/gx/terminix/profilewindow.d:450
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:498
+#: source/gx/terminix/profilewindow.d:517
 #, fuzzy
 msgid "Select Cursor Foreground Color"
 msgstr "選擇前景色"
 
-#: source/gx/terminix/profilewindow.d:429
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:443
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:452
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:500
+#: source/gx/terminix/profilewindow.d:519
 #, fuzzy
 msgid "Select Cursor Background Color"
 msgstr "選擇背景色"
 
-#: source/gx/terminix/profilewindow.d:434
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:448
-#: source/gx/terminix/profilewindow.d:449
-#: source/gx/terminix/profilewindow.d:457
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:485
-#: source/gx/terminix/profilewindow.d:505
+#: source/gx/terminix/profilewindow.d:524
 msgid "Highlight"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:439
-#: source/gx/terminix/profilewindow.d:444
-#: source/gx/terminix/profilewindow.d:453
-#: source/gx/terminix/profilewindow.d:454
-#: source/gx/terminix/profilewindow.d:462
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:490
-#: source/gx/terminix/profilewindow.d:510
+#: source/gx/terminix/profilewindow.d:529
 #, fuzzy
 msgid "Select Highlight Foreground Color"
 msgstr "選擇前景色"
 
-#: source/gx/terminix/profilewindow.d:441
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:455
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:464
-#: source/gx/terminix/profilewindow.d:467
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:512
+#: source/gx/terminix/profilewindow.d:531
 #, fuzzy
 msgid "Select Highlight Background Color"
 msgstr "選擇背景色"
 
-#: source/gx/terminix/profilewindow.d:446
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:460
-#: source/gx/terminix/profilewindow.d:461
-#: source/gx/terminix/profilewindow.d:469
-#: source/gx/terminix/profilewindow.d:472
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:517
+#: source/gx/terminix/profilewindow.d:536
 msgid "Dim"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:451
-#: source/gx/terminix/profilewindow.d:456
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:466
-#: source/gx/terminix/profilewindow.d:474
-#: source/gx/terminix/profilewindow.d:477
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:522
+#: source/gx/terminix/profilewindow.d:541
 #, fuzzy
 msgid "Select Dim Color"
 msgstr "選擇 %s 個顏色"
 
-#: source/gx/terminix/profilewindow.d:465
-#: source/gx/terminix/profilewindow.d:470
-#: source/gx/terminix/profilewindow.d:479
-#: source/gx/terminix/profilewindow.d:480
-#: source/gx/terminix/profilewindow.d:488
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:531
-#: source/gx/terminix/profilewindow.d:551
+#: source/gx/terminix/profilewindow.d:550
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "選擇 %s 個顏色"
+
+#: source/gx/terminix/profilewindow.d:570
 msgid "Select Background Color"
 msgstr "選擇背景色"
 
-#: source/gx/terminix/profilewindow.d:478
-#: source/gx/terminix/profilewindow.d:492
-#: source/gx/terminix/profilewindow.d:483
-#: source/gx/terminix/profilewindow.d:497
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:493
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:515
-#: source/gx/terminix/profilewindow.d:504
-#: source/gx/terminix/profilewindow.d:518
-#: source/gx/terminix/profilewindow.d:544
-#: source/gx/terminix/profilewindow.d:558
-#: source/gx/terminix/profilewindow.d:564
-#: source/gx/terminix/profilewindow.d:578
+#: source/gx/terminix/profilewindow.d:583
+#: source/gx/terminix/profilewindow.d:597
 msgid "Select Foreground Color"
 msgstr "選擇前景色"
 
-#: source/gx/terminix/profilewindow.d:491
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:505
-#: source/gx/terminix/profilewindow.d:506
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:557
-#: source/gx/terminix/profilewindow.d:577
+#: source/gx/terminix/profilewindow.d:596
 msgid "Foreground"
 msgstr "前景"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Black"
 msgstr "黑"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Red"
 msgstr "紅色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Green"
 msgstr "綠"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Orange"
 msgstr "橙色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Blue"
 msgstr "藍色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Purple"
 msgstr "紫色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Turquoise"
 msgstr "綠鬆色"
 
-#: source/gx/terminix/profilewindow.d:496
-#: source/gx/terminix/profilewindow.d:501
-#: source/gx/terminix/profilewindow.d:510
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:519
-#: source/gx/terminix/profilewindow.d:522
-#: source/gx/terminix/profilewindow.d:562
-#: source/gx/terminix/profilewindow.d:582
+#: source/gx/terminix/profilewindow.d:601
 msgid "Grey"
 msgstr "灰"
 
-#: source/gx/terminix/profilewindow.d:502
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:516
-#: source/gx/terminix/profilewindow.d:517
-#: source/gx/terminix/profilewindow.d:525
-#: source/gx/terminix/profilewindow.d:528
-#: source/gx/terminix/profilewindow.d:568
-#: source/gx/terminix/profilewindow.d:588
+#: source/gx/terminix/profilewindow.d:607
 #, c-format
 msgid "Select %s Color"
 msgstr "選擇 %s 個顏色"
 
-#: source/gx/terminix/profilewindow.d:509
-#: source/gx/terminix/profilewindow.d:514
-#: source/gx/terminix/profilewindow.d:523
-#: source/gx/terminix/profilewindow.d:524
-#: source/gx/terminix/profilewindow.d:532
-#: source/gx/terminix/profilewindow.d:535
-#: source/gx/terminix/profilewindow.d:575
-#: source/gx/terminix/profilewindow.d:595
+#: source/gx/terminix/profilewindow.d:614
 #, c-format
 msgid "Select %s Light Color"
 msgstr "選擇 %s 個淡色"
 
-#: source/gx/terminix/profilewindow.d:651
-#: source/gx/terminix/profilewindow.d:656
-#: source/gx/terminix/profilewindow.d:665
-#: source/gx/terminix/profilewindow.d:666
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:724
-#: source/gx/terminix/profilewindow.d:802
+#: source/gx/terminix/profilewindow.d:747
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "配色方案"
+
+#: source/gx/terminix/profilewindow.d:821
 msgid "Show scrollbar"
 msgstr "顯示滾動條"
 
-#: source/gx/terminix/profilewindow.d:655
-#: source/gx/terminix/profilewindow.d:660
-#: source/gx/terminix/profilewindow.d:669
-#: source/gx/terminix/profilewindow.d:670
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:681
-#: source/gx/terminix/profilewindow.d:728
-#: source/gx/terminix/profilewindow.d:806
+#: source/gx/terminix/profilewindow.d:825
 msgid "Scroll on output"
 msgstr "輸出時滾動"
 
-#: source/gx/terminix/profilewindow.d:659
-#: source/gx/terminix/profilewindow.d:664
-#: source/gx/terminix/profilewindow.d:673
-#: source/gx/terminix/profilewindow.d:674
-#: source/gx/terminix/profilewindow.d:682
-#: source/gx/terminix/profilewindow.d:685
-#: source/gx/terminix/profilewindow.d:732
-#: source/gx/terminix/profilewindow.d:810
+#: source/gx/terminix/profilewindow.d:829
 msgid "Scroll on keystroke"
 msgstr "擊鍵時滾動"
 
-#: source/gx/terminix/profilewindow.d:663
-#: source/gx/terminix/profilewindow.d:668
-#: source/gx/terminix/profilewindow.d:677
-#: source/gx/terminix/profilewindow.d:678
-#: source/gx/terminix/profilewindow.d:686
-#: source/gx/terminix/profilewindow.d:689
-#: source/gx/terminix/profilewindow.d:736
-#: source/gx/terminix/profilewindow.d:814
+#: source/gx/terminix/profilewindow.d:833
 msgid "Limit scrollback to:"
 msgstr "回滾限制："
 
-#: source/gx/terminix/profilewindow.d:704
-#: source/gx/terminix/profilewindow.d:709
-#: source/gx/terminix/profilewindow.d:718
-#: source/gx/terminix/profilewindow.d:719
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:777
-#: source/gx/terminix/profilewindow.d:855
+#: source/gx/terminix/profilewindow.d:874
 msgid "Backspace key generates"
 msgstr "按退格鍵生成"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Automatic"
 msgstr "自動"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Control-H"
 msgstr "Control-H"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "ASCII DEL"
 msgstr "ASCII DEL"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "Escape sequence"
 msgstr "轉義序列"
 
-#: source/gx/terminix/profilewindow.d:707
-#: source/gx/terminix/profilewindow.d:715
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:720
-#: source/gx/terminix/profilewindow.d:721
-#: source/gx/terminix/profilewindow.d:729
-#: source/gx/terminix/profilewindow.d:722
-#: source/gx/terminix/profilewindow.d:730
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:733
-#: source/gx/terminix/profilewindow.d:741
-#: source/gx/terminix/profilewindow.d:780
-#: source/gx/terminix/profilewindow.d:788
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:866
+#: source/gx/terminix/profilewindow.d:877
+#: source/gx/terminix/profilewindow.d:888
 msgid "TTY"
 msgstr "TTY"
 
-#: source/gx/terminix/profilewindow.d:712
-#: source/gx/terminix/profilewindow.d:717
-#: source/gx/terminix/profilewindow.d:726
-#: source/gx/terminix/profilewindow.d:727
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:785
-#: source/gx/terminix/profilewindow.d:863
+#: source/gx/terminix/profilewindow.d:885
 msgid "Delete key generates"
 msgstr "按 Delete 鍵生成"
 
-#: source/gx/terminix/profilewindow.d:720 source/gx/terminix/prefwindow.d:92
-#: source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/profilewindow.d:725 source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/prefwindow.d:167
-#: source/gx/terminix/terminal/terminal.d:662
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:655
-#: source/gx/terminix/profilewindow.d:734 source/gx/terminix/prefwindow.d:97
-#: source/gx/terminix/prefwindow.d:170 source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/terminal/terminal.d:704
-#: source/gx/terminix/profilewindow.d:746 source/gx/terminix/prefwindow.d:102
-#: source/gx/terminix/prefwindow.d:175
-#: source/gx/terminix/terminal/terminal.d:730
-#: source/gx/terminix/prefwindow.d:104 source/gx/terminix/prefwindow.d:177
-#: source/gx/terminix/terminal/terminal.d:758
-#: source/gx/terminix/profilewindow.d:793
-#: source/gx/terminix/terminal/terminal.d:759
-#: source/gx/terminix/profilewindow.d:871
-msgid "Encoding"
-msgstr "編碼"
-
-#: source/gx/terminix/profilewindow.d:735
-#: source/gx/terminix/profilewindow.d:740
-#: source/gx/terminix/profilewindow.d:749
-#: source/gx/terminix/profilewindow.d:750
-#: source/gx/terminix/profilewindow.d:758
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:808
-#: source/gx/terminix/profilewindow.d:886
+#: source/gx/terminix/profilewindow.d:913
 msgid "Ambiguous-width characters"
 msgstr "模糊寬度字元"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Narrow"
 msgstr "窄"
 
-#: source/gx/terminix/profilewindow.d:738
-#: source/gx/terminix/profilewindow.d:743
-#: source/gx/terminix/profilewindow.d:752
-#: source/gx/terminix/profilewindow.d:753
-#: source/gx/terminix/profilewindow.d:761
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:811
-#: source/gx/terminix/profilewindow.d:889
+#: source/gx/terminix/profilewindow.d:916
 msgid "Wide"
 msgstr "寬"
 
-#: source/gx/terminix/profilewindow.d:764
-#: source/gx/terminix/profilewindow.d:769
-#: source/gx/terminix/profilewindow.d:778
-#: source/gx/terminix/profilewindow.d:779
-#: source/gx/terminix/profilewindow.d:787
-#: source/gx/terminix/profilewindow.d:790
-#: source/gx/terminix/profilewindow.d:837
-#: source/gx/terminix/profilewindow.d:915
+#: source/gx/terminix/profilewindow.d:945
 msgid "Run command as a login shell"
 msgstr "作為登入 shell 執行指令"
 
-#: source/gx/terminix/profilewindow.d:768
-#: source/gx/terminix/profilewindow.d:773
-#: source/gx/terminix/profilewindow.d:782
-#: source/gx/terminix/profilewindow.d:783
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:794
-#: source/gx/terminix/profilewindow.d:841
-#: source/gx/terminix/profilewindow.d:919
+#: source/gx/terminix/profilewindow.d:949
 msgid "Run a custom command instead of my shell"
 msgstr "執行自訂指令而不是我的指令列外殼"
 
-#: source/gx/terminix/profilewindow.d:784
-#: source/gx/terminix/profilewindow.d:789
-#: source/gx/terminix/profilewindow.d:798
-#: source/gx/terminix/profilewindow.d:799
-#: source/gx/terminix/profilewindow.d:807
-#: source/gx/terminix/profilewindow.d:810
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:935
+#: source/gx/terminix/profilewindow.d:965
 msgid "When command exits"
 msgstr "指令退出時"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Exit the terminal"
 msgstr "退出此終端"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Restart the command"
 msgstr "重啟該指令"
 
-#: source/gx/terminix/profilewindow.d:786
-#: source/gx/terminix/profilewindow.d:791
-#: source/gx/terminix/profilewindow.d:800
-#: source/gx/terminix/profilewindow.d:801
-#: source/gx/terminix/profilewindow.d:809
-#: source/gx/terminix/profilewindow.d:812
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:937
+#: source/gx/terminix/profilewindow.d:967
 msgid "Hold the terminal open"
 msgstr "保持終端開啟"
 
-#: source/gx/terminix/constants.d:38 source/gx/terminix/constants.d:57
-#: source/gx/terminix/constants.d:53 source/gx/terminix/constants.d:56
+#: source/gx/terminix/profilewindow.d:1015
+#, fuzzy
+msgid "Custom Links"
+msgstr "自訂字型"
+
+#: source/gx/terminix/profilewindow.d:1020
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1041
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1047
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1067
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1075
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1077
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1093
+#, fuzzy
+msgid "Match"
+msgstr "區分大小寫"
+
+#: source/gx/terminix/profilewindow.d:1104
+#: source/gx/terminix/profilewindow.d:1283
+#: source/gx/terminix/profilewindow.d:1439
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1108
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1110
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1112
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1129
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1131
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1133
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1241
+#: source/gx/terminix/profilewindow.d:1382
+#, c-format
+msgid "The expression %s is not a valid regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1246
+#: source/gx/terminix/profilewindow.d:1387
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1270
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1310
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1413 source/gx/terminix/prefwindow.d:229
+msgid "Action"
+msgstr "動作"
+
+#: source/gx/terminix/profilewindow.d:1425
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1461
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/profilewindow.d:1483
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "編輯配置檔"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:548
+msgid "Could not locate dropped terminal"
+msgstr "無法定位放置的終端"
+
+#: source/gx/terminix/session.d:553
+msgid "Could not locate session for dropped terminal"
+msgstr "無法定位放置的終端的會話"
+
+#: source/gx/terminix/session.d:1076 source/gx/terminix/prefwindow.d:450
+#: source/gx/terminix/prefwindow.d:612
+msgid "Default"
+msgstr "預設"
+
+#: source/gx/terminix/session.d:1374 source/gx/terminix/prefwindow.d:452
+msgid "Profile"
+msgstr "配置方案"
+
 #: source/gx/terminix/constants.d:52
 msgid "A VTE based terminal emulator for Linux"
 msgstr ""
 
-#: source/gx/terminix/constants.d:39 source/gx/terminix/constants.d:58
-#: source/gx/terminix/constants.d:54 source/gx/terminix/constants.d:57
 #: source/gx/terminix/constants.d:53
 msgid ""
 "This Source Code Form is subject to the terms of the Mozilla Public License, "
@@ -990,20 +1188,14 @@ msgid ""
 "obtain one at http://mozilla.org/MPL/2.0/."
 msgstr ""
 
-#: source/gx/terminix/constants.d:44 source/gx/terminix/constants.d:63
-#: source/gx/terminix/constants.d:59 source/gx/terminix/constants.d:62
 #: source/gx/terminix/constants.d:58
 msgid "GTK VTE widget team, Terminix would not be possible without their work"
 msgstr ""
 
-#: source/gx/terminix/constants.d:45 source/gx/terminix/constants.d:64
-#: source/gx/terminix/constants.d:60 source/gx/terminix/constants.d:63
 #: source/gx/terminix/constants.d:59
 msgid "GtkD for providing such an excellent GTK wrapper"
 msgstr ""
 
-#: source/gx/terminix/constants.d:46 source/gx/terminix/constants.d:65
-#: source/gx/terminix/constants.d:61 source/gx/terminix/constants.d:64
 #: source/gx/terminix/constants.d:60
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
@@ -1147,290 +1339,40 @@ msgstr "越南語"
 msgid "Thai"
 msgstr "泰語"
 
-#: source/gx/terminix/application.d:183 source/gx/terminix/session.d:1257
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/session.d:1264
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/session.d:1267
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/session.d:1362 source/gx/terminix/application.d:198
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/session.d:1354
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/session.d:1347
-#: source/gx/terminix/application.d:197 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:20
-#: source/gx/terminix/session.d:1391 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/application.d:203 source/gx/terminix/prefwindow.d:852
-#: source/gx/terminix/session.d:1397
-msgid "New Session"
-msgstr "新建會話"
-
-#: source/gx/terminix/application.d:184 source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/prefwindow.d:641 source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/application.d:199
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/application.d:198 source/gx/terminix/prefwindow.d:793
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:852
-msgid "New Window"
-msgstr "新建視窗"
-
-#: source/gx/terminix/application.d:188 source/gx/terminix/prefwindow.d:73
-#: source/gx/terminix/prefwindow.d:75 source/gx/terminix/application.d:203
-#: source/gx/terminix/prefwindow.d:78 source/gx/terminix/application.d:202
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/application.d:208
-msgid "Preferences"
-msgstr "偏好"
-
-#: source/gx/terminix/application.d:190 source/gx/terminix/prefwindow.d:86
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/application.d:205
-#: source/gx/terminix/prefwindow.d:91 source/gx/terminix/application.d:204
-#: source/gx/terminix/prefwindow.d:96 source/gx/terminix/prefwindow.d:98
-#: source/gx/terminix/application.d:210
-msgid "Shortcuts"
-msgstr "快捷鍵"
-
-#: source/gx/terminix/application.d:195 source/gx/terminix/application.d:210
-#: source/gx/terminix/application.d:209 source/gx/terminix/application.d:215
-msgid "About"
-msgstr "關於"
-
-#: source/gx/terminix/application.d:196 source/gx/terminix/application.d:211
-#: source/gx/terminix/application.d:210 source/gx/terminix/application.d:216
-msgid "Quit"
-msgstr "退出"
-
-#: source/gx/terminix/application.d:247 source/gx/terminix/application.d:262
-#: source/gx/terminix/application.d:264 source/gx/terminix/application.d:270
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "Set the working directory of the terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/application.d:466 source/gx/terminix/application.d:479
-#: source/gx/terminix/application.d:542 source/gx/terminix/application.d:552
-#: source/gx/terminix/application.d:583 source/gx/terminix/application.d:600
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "Set the starting profile"
-msgstr "設定啟動配置檔"
-
-#: source/gx/terminix/application.d:467 source/gx/terminix/application.d:480
-#: source/gx/terminix/application.d:543 source/gx/terminix/application.d:553
-#: source/gx/terminix/application.d:584 source/gx/terminix/application.d:601
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "Open the specified session"
-msgstr "開啟指定的會話"
-
-#: source/gx/terminix/application.d:468 source/gx/terminix/application.d:481
-#: source/gx/terminix/application.d:544 source/gx/terminix/application.d:555
-#: source/gx/terminix/application.d:586 source/gx/terminix/application.d:603
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "Send an action to current Terminix instance"
-msgstr "向當前 Terminix 例項傳送動作"
-
-#: source/gx/terminix/application.d:469 source/gx/terminix/application.d:482
-#: source/gx/terminix/application.d:545 source/gx/terminix/application.d:556
-#: source/gx/terminix/application.d:587 source/gx/terminix/application.d:604
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "Execute the passed command"
-msgstr "執行傳入的指令"
-
-#: source/gx/terminix/application.d:470 source/gx/terminix/application.d:483
-#: source/gx/terminix/application.d:546 source/gx/terminix/application.d:557
-msgid "EXECUTE"
-msgstr ""
-
-#: source/gx/terminix/application.d:471 source/gx/terminix/application.d:484
-#: source/gx/terminix/application.d:547 source/gx/terminix/application.d:558
-#: source/gx/terminix/application.d:589 source/gx/terminix/application.d:606
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:472 source/gx/terminix/application.d:485
-#: source/gx/terminix/application.d:548 source/gx/terminix/application.d:559
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:591
-#: source/gx/terminix/application.d:608
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:473 source/gx/terminix/application.d:486
-#: source/gx/terminix/application.d:549 source/gx/terminix/application.d:560
-#: source/gx/terminix/application.d:591 source/gx/terminix/application.d:592
-#: source/gx/terminix/application.d:609
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:476 source/gx/terminix/application.d:477
-#: source/gx/terminix/application.d:490 source/gx/terminix/application.d:554
-#: source/gx/terminix/application.d:565 source/gx/terminix/application.d:597
-#: source/gx/terminix/application.d:598 source/gx/terminix/application.d:616
-#: source/gx/terminix/application.d:599
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:616 source/gx/terminix/application.d:617
-#: source/gx/terminix/application.d:624 source/gx/terminix/application.d:637
-#: source/gx/terminix/application.d:707 source/gx/terminix/application.d:718
-#: source/gx/terminix/application.d:750 source/gx/terminix/application.d:751
-#: source/gx/terminix/application.d:780 source/gx/terminix/application.d:763
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"終端配置似乎存在問題。這並不是嚴重問題，但是更正這些問題將改善你的使用體驗。"
-"點選如下連結以獲取更多資訊："
-
-#: source/gx/terminix/application.d:617 source/gx/terminix/application.d:618
-#: source/gx/terminix/application.d:625 source/gx/terminix/application.d:638
-#: source/gx/terminix/application.d:708 source/gx/terminix/application.d:719
-#: source/gx/terminix/application.d:751 source/gx/terminix/application.d:752
-#: source/gx/terminix/application.d:781 source/gx/terminix/application.d:764
-msgid "Configuration Issue Detected"
-msgstr "檢測到配置問題"
-
-#: source/gx/terminix/application.d:629 source/gx/terminix/application.d:630
-#: source/gx/terminix/application.d:637 source/gx/terminix/application.d:650
-#: source/gx/terminix/application.d:720 source/gx/terminix/application.d:731
-#: source/gx/terminix/application.d:763 source/gx/terminix/application.d:764
-#: source/gx/terminix/application.d:793 source/gx/terminix/application.d:776
-msgid "Do not show this message again"
-msgstr "不再顯示該資訊"
-
-#: source/gx/terminix/session.d:507 source/gx/terminix/session.d:514
-#: source/gx/terminix/session.d:537 source/gx/terminix/session.d:549
-#: source/gx/terminix/session.d:548
-msgid "Could not locate dropped terminal"
-msgstr "無法定位放置的終端"
-
-#: source/gx/terminix/session.d:512 source/gx/terminix/session.d:519
-#: source/gx/terminix/session.d:542 source/gx/terminix/session.d:554
-#: source/gx/terminix/session.d:553
-msgid "Could not locate session for dropped terminal"
-msgstr "無法定位放置的終端的會話"
-
-#: source/gx/terminix/session.d:1223 source/gx/terminix/session.d:1230
-#: source/gx/terminix/session.d:1233 source/gx/terminix/session.d:1328
-#: source/gx/terminix/session.d:1320 source/gx/terminix/session.d:1313
-#: source/gx/terminix/terminal/password.d:135
-#: source/gx/terminix/terminal/password.d:424 source/gx/terminix/session.d:1357
-#: source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1363
-msgid "Name"
-msgstr "名稱"
-
-#: source/gx/terminix/session.d:1234 source/gx/terminix/prefwindow.d:378
-#: source/gx/terminix/session.d:1241 source/gx/terminix/prefwindow.d:424
-#: source/gx/terminix/session.d:1244 source/gx/terminix/prefwindow.d:433
-#: source/gx/terminix/session.d:1339 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/session.d:1331 source/gx/terminix/prefwindow.d:445
-#: source/gx/terminix/session.d:1324 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/session.d:1368 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/session.d:1374
-msgid "Profile"
-msgstr "配置方案"
-
-#: source/gx/terminix/prefwindow.d:80 source/gx/terminix/prefwindow.d:82
-#: source/gx/terminix/prefwindow.d:85 source/gx/terminix/prefwindow.d:87
 #: source/gx/terminix/prefwindow.d:89
 msgid "Global"
 msgstr "全局"
 
-#: source/gx/terminix/prefwindow.d:83 source/gx/terminix/prefwindow.d:85
-#: source/gx/terminix/prefwindow.d:88 source/gx/terminix/prefwindow.d:90
 #: source/gx/terminix/prefwindow.d:92
 #, fuzzy
 msgid "Appearance"
 msgstr "外觀"
 
-#: source/gx/terminix/prefwindow.d:89
-#: source/gx/terminix/terminal/terminal.d:657
-#: source/gx/terminix/prefwindow.d:91
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:658
-#: source/gx/terminix/terminal/terminal.d:654
-#: source/gx/terminix/prefwindow.d:94
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:703
-#: source/gx/terminix/prefwindow.d:99
-#: source/gx/terminix/terminal/terminal.d:729
-#: source/gx/terminix/prefwindow.d:101
-#: source/gx/terminix/terminal/terminal.d:757
-#: source/gx/terminix/terminal/terminal.d:758
-msgid "Profiles"
-msgstr "配置方案"
+#: source/gx/terminix/prefwindow.d:95
+msgid "Quake"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:127 source/gx/terminix/prefwindow.d:129
-#: source/gx/terminix/prefwindow.d:132 source/gx/terminix/prefwindow.d:137
 #: source/gx/terminix/prefwindow.d:139
 msgid "Encodings showing in menu:"
 msgstr "選單中顯示的編碼："
 
-#: source/gx/terminix/prefwindow.d:163 source/gx/terminix/prefwindow.d:165
-#: source/gx/terminix/prefwindow.d:168 source/gx/terminix/prefwindow.d:173
 #: source/gx/terminix/prefwindow.d:175
 msgid "Enabled"
 msgstr "已啟用"
 
-#: source/gx/terminix/prefwindow.d:214 source/gx/terminix/prefwindow.d:217
-#: source/gx/terminix/prefwindow.d:218 source/gx/terminix/prefwindow.d:221
-#: source/gx/terminix/prefwindow.d:222 source/gx/terminix/profilewindow.d:1253
-#: source/gx/terminix/prefwindow.d:227 source/gx/terminix/profilewindow.d:1255
-#: source/gx/terminix/prefwindow.d:229 source/gx/terminix/profilewindow.d:1302
-#: source/gx/terminix/profilewindow.d:1380
-msgid "Action"
-msgstr "動作"
-
-#: source/gx/terminix/prefwindow.d:243 source/gx/terminix/prefwindow.d:246
-#: source/gx/terminix/prefwindow.d:247 source/gx/terminix/prefwindow.d:250
-#: source/gx/terminix/prefwindow.d:251 source/gx/terminix/prefwindow.d:256
 #: source/gx/terminix/prefwindow.d:258
 msgid "Shortcut Key"
 msgstr "快捷鍵"
 
-#: source/gx/terminix/prefwindow.d:274 source/gx/terminix/prefwindow.d:277
-#: source/gx/terminix/prefwindow.d:278 source/gx/terminix/prefwindow.d:281
-#: source/gx/terminix/prefwindow.d:287 source/gx/terminix/prefwindow.d:292
+#: source/gx/terminix/prefwindow.d:270
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "快捷鍵"
+
 #: source/gx/terminix/prefwindow.d:294
 msgid "Overwrite Existing Shortcut"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:275 source/gx/terminix/prefwindow.d:278
-#: source/gx/terminix/prefwindow.d:279 source/gx/terminix/prefwindow.d:282
-#: source/gx/terminix/prefwindow.d:288 source/gx/terminix/prefwindow.d:293
 #: source/gx/terminix/prefwindow.d:295
 #, c-format
 msgid ""
@@ -1438,1183 +1380,276 @@ msgid ""
 "Disable the shortcut for the other action and assign here instead?"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:376 source/gx/terminix/prefwindow.d:525
-#: source/gx/terminix/appwindow.d:91 source/gx/terminix/prefwindow.d:422
-#: source/gx/terminix/prefwindow.d:571 source/gx/terminix/prefwindow.d:431
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/appwindow.d:98
-#: source/gx/terminix/prefwindow.d:436 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/appwindow.d:99 source/gx/terminix/prefwindow.d:443
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/appwindow.d:100
-#: source/gx/terminix/prefwindow.d:448 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/session.d:1070 source/gx/terminix/prefwindow.d:450
-#: source/gx/terminix/prefwindow.d:601 source/gx/terminix/session.d:1076
-msgid "Default"
-msgstr "預設"
+#: source/gx/terminix/prefwindow.d:475
+msgid "Clone"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:392 source/gx/terminix/prefwindow.d:438
-#: source/gx/terminix/prefwindow.d:447 source/gx/terminix/prefwindow.d:452
-#: source/gx/terminix/prefwindow.d:459
-#: source/gx/terminix/terminal/password.d:159
-#: source/gx/terminix/prefwindow.d:464 source/gx/terminix/prefwindow.d:466
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "新建"
-
-#: source/gx/terminix/prefwindow.d:405 source/gx/terminix/prefwindow.d:451
-#: source/gx/terminix/prefwindow.d:460 source/gx/terminix/profilewindow.d:884
-#: source/gx/terminix/prefwindow.d:465 source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/prefwindow.d:472 source/gx/terminix/profilewindow.d:861
-#: source/gx/terminix/profilewindow.d:921
-#: source/gx/terminix/terminal/password.d:182
-#: source/gx/terminix/profilewindow.d:865
-#: source/gx/terminix/profilewindow.d:891
-#: source/gx/terminix/profilewindow.d:962 source/gx/terminix/prefwindow.d:477
-#: source/gx/terminix/profilewindow.d:892
-#: source/gx/terminix/profilewindow.d:964 source/gx/terminix/prefwindow.d:479
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/profilewindow.d:912
-#: source/gx/terminix/profilewindow.d:939
-#: source/gx/terminix/profilewindow.d:1011
-#: source/gx/terminix/profilewindow.d:990
-#: source/gx/terminix/profilewindow.d:1017
-#: source/gx/terminix/profilewindow.d:1089
-msgid "Edit"
-msgstr "編輯"
-
-#: source/gx/terminix/prefwindow.d:408 source/gx/terminix/prefwindow.d:454
-#: source/gx/terminix/prefwindow.d:463 source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/prefwindow.d:468 source/gx/terminix/profilewindow.d:896
-#: source/gx/terminix/prefwindow.d:475 source/gx/terminix/profilewindow.d:934
-#: source/gx/terminix/profilewindow.d:1079
-#: source/gx/terminix/terminal/password.d:211
-#: source/gx/terminix/profilewindow.d:981
-#: source/gx/terminix/profilewindow.d:1129
-#: source/gx/terminix/profilewindow.d:1285 source/gx/terminix/prefwindow.d:480
-#: source/gx/terminix/profilewindow.d:983
-#: source/gx/terminix/profilewindow.d:1131
-#: source/gx/terminix/profilewindow.d:1287 source/gx/terminix/prefwindow.d:482
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/profilewindow.d:1030
-#: source/gx/terminix/profilewindow.d:1178
-#: source/gx/terminix/profilewindow.d:1334
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1256
-#: source/gx/terminix/profilewindow.d:1412
-msgid "Delete"
-msgstr "刪除"
-
-#: source/gx/terminix/prefwindow.d:508 source/gx/terminix/prefwindow.d:554
-#: source/gx/terminix/prefwindow.d:563 source/gx/terminix/prefwindow.d:568
-#: source/gx/terminix/prefwindow.d:575 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:582
+#: source/gx/terminix/prefwindow.d:593
 msgid "Enable transparency, requires re-start"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:518 source/gx/terminix/prefwindow.d:564
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:579
-#: source/gx/terminix/prefwindow.d:586 source/gx/terminix/prefwindow.d:591
-#: source/gx/terminix/prefwindow.d:593
+#: source/gx/terminix/prefwindow.d:604
 #, fuzzy
 msgid "Terminal title style"
 msgstr "終端標題"
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Normal"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/prefwindow.d:580
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594
+#: source/gx/terminix/prefwindow.d:605
 msgid "Small"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:519 source/gx/terminix/prefwindow.d:565
-#: source/gx/terminix/prefwindow.d:574 source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222 source/gx/terminix/prefwindow.d:592
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:524 source/gx/terminix/prefwindow.d:570
-#: source/gx/terminix/prefwindow.d:579 source/gx/terminix/prefwindow.d:586
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:598
-#: source/gx/terminix/prefwindow.d:600
+#: source/gx/terminix/prefwindow.d:611
 #, fuzzy
 msgid "Theme variant"
 msgstr "主題變種"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Light"
 msgstr "淡色"
 
-#: source/gx/terminix/prefwindow.d:525 source/gx/terminix/prefwindow.d:571
-#: source/gx/terminix/prefwindow.d:580 source/gx/terminix/prefwindow.d:587
-#: source/gx/terminix/prefwindow.d:594 source/gx/terminix/prefwindow.d:599
-#: source/gx/terminix/prefwindow.d:601
+#: source/gx/terminix/prefwindow.d:612
 msgid "Dark"
 msgstr "深色"
 
-#: source/gx/terminix/prefwindow.d:532 source/gx/terminix/prefwindow.d:578
-#: source/gx/terminix/prefwindow.d:587 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:653 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:671
+#: source/gx/terminix/prefwindow.d:618
+#, fuzzy
+msgid "Background image"
+msgstr "背景"
+
+#: source/gx/terminix/prefwindow.d:620
+#, fuzzy
+msgid "Select Image"
+msgstr "全選"
+
+#: source/gx/terminix/prefwindow.d:623
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:644
+#, fuzzy
+msgid "Reset background image"
+msgstr "透明度"
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:650
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:669
+#, fuzzy
+msgid "Default session name"
+msgstr "切換到會話 1"
+
+#: source/gx/terminix/prefwindow.d:682
 msgid "Use a wide handle for splitters"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:537 source/gx/terminix/prefwindow.d:583
-#: source/gx/terminix/prefwindow.d:592
-#, fuzzy
-msgid "Dim unfocused terminals"
-msgstr "終端"
+#: source/gx/terminix/prefwindow.d:687
+msgid "Place the sidebar on the right"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:562 source/gx/terminix/prefwindow.d:608
-#: source/gx/terminix/prefwindow.d:617 source/gx/terminix/prefwindow.d:613
-#: source/gx/terminix/prefwindow.d:674 source/gx/terminix/prefwindow.d:681
-#: source/gx/terminix/prefwindow.d:750 source/gx/terminix/prefwindow.d:797
-#: source/gx/terminix/prefwindow.d:809
+#: source/gx/terminix/prefwindow.d:691
+#, fuzzy
+msgid "Show the terminal title even if its the only terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/prefwindow.d:712
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:723
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:734
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:754
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:759
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:764
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:778
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/prefwindow.d:785
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:820
 msgid "Behavior"
 msgstr "行為"
 
-#: source/gx/terminix/prefwindow.d:568 source/gx/terminix/prefwindow.d:614
-#: source/gx/terminix/prefwindow.d:623 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:680 source/gx/terminix/prefwindow.d:687
-#: source/gx/terminix/prefwindow.d:756 source/gx/terminix/prefwindow.d:803
-#: source/gx/terminix/prefwindow.d:815
+#: source/gx/terminix/prefwindow.d:826
 msgid "Prompt when creating a new session"
 msgstr "建立新會話時提示"
 
-#: source/gx/terminix/prefwindow.d:573 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/prefwindow.d:628 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:685 source/gx/terminix/prefwindow.d:692
-#: source/gx/terminix/prefwindow.d:761 source/gx/terminix/prefwindow.d:808
-#: source/gx/terminix/prefwindow.d:820
+#: source/gx/terminix/prefwindow.d:831
 msgid "Focus a terminal when the mouse moves over it"
 msgstr "在滑鼠移入時啟用終端"
 
-#: source/gx/terminix/prefwindow.d:578 source/gx/terminix/prefwindow.d:624
-#: source/gx/terminix/prefwindow.d:633 source/gx/terminix/prefwindow.d:629
-#: source/gx/terminix/prefwindow.d:690 source/gx/terminix/prefwindow.d:697
-#: source/gx/terminix/prefwindow.d:766 source/gx/terminix/prefwindow.d:813
-#: source/gx/terminix/prefwindow.d:825
+#: source/gx/terminix/prefwindow.d:836
 msgid "Autohide the mouse pointer when typing"
 msgstr "打字時自動隱藏滑鼠指針"
 
-#: source/gx/terminix/prefwindow.d:584 source/gx/terminix/prefwindow.d:630
-#: source/gx/terminix/prefwindow.d:639 source/gx/terminix/prefwindow.d:635
-#: source/gx/terminix/prefwindow.d:696 source/gx/terminix/prefwindow.d:703
-#: source/gx/terminix/prefwindow.d:782 source/gx/terminix/prefwindow.d:829
 #: source/gx/terminix/prefwindow.d:841
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:846
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefwindow.d:852
 msgid "Send desktop notification on process complete"
 msgstr "程序完成時傳送桌面通知"
 
-#: source/gx/terminix/prefwindow.d:592 source/gx/terminix/prefwindow.d:638
-#: source/gx/terminix/prefwindow.d:647 source/gx/terminix/prefwindow.d:643
-#: source/gx/terminix/prefwindow.d:704 source/gx/terminix/prefwindow.d:711
-#: source/gx/terminix/prefwindow.d:790 source/gx/terminix/prefwindow.d:837
-#: source/gx/terminix/prefwindow.d:849
+#: source/gx/terminix/prefwindow.d:860
 msgid "On new instance"
 msgstr ""
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:668
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:669
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Right"
 msgstr "向右分割"
 
-#: source/gx/terminix/prefwindow.d:595
-#: source/gx/terminix/terminal/terminal.d:672
-#: source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/prefwindow.d:650
-#: source/gx/terminix/terminal/terminal.d:673
-#: source/gx/terminix/prefwindow.d:646 source/gx/terminix/prefwindow.d:707
-#: source/gx/terminix/prefwindow.d:714 source/gx/terminix/prefwindow.d:793
-#: source/gx/terminix/prefwindow.d:840 source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 msgid "Split Down"
 msgstr "向下分割"
 
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:641
-#: source/gx/terminix/prefwindow.d:650 source/gx/terminix/prefwindow.d:646
-#: source/gx/terminix/prefwindow.d:707 source/gx/terminix/prefwindow.d:714
-#: source/gx/terminix/prefwindow.d:793 source/gx/terminix/prefwindow.d:840
-#: source/gx/terminix/prefwindow.d:852
+#: source/gx/terminix/prefwindow.d:863
 #, fuzzy
 msgid "Focus Window"
 msgstr "新建視窗"
 
-#: source/gx/terminix/prefwindow.d:601
-#: source/gx/terminix/terminal/terminal.d:940
-#: source/gx/terminix/terminal/terminal.d:951
-#: source/gx/terminix/prefwindow.d:647
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:970
-#: source/gx/terminix/prefwindow.d:656
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/prefwindow.d:652
-#: source/gx/terminix/terminal/terminal.d:961
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:1002
-#: source/gx/terminix/terminal/terminal.d:1013
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1059
-#: source/gx/terminix/terminal/terminal.d:1113
-#: source/gx/terminix/terminal/terminal.d:1124
-#: source/gx/terminix/terminal/terminal.d:1268
-#: source/gx/terminix/terminal/terminal.d:1279
-#: source/gx/terminix/terminal/terminal.d:1329
-#: source/gx/terminix/terminal/terminal.d:1340
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1378
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1379
-msgid "Paste"
-msgstr "貼上"
+#: source/gx/terminix/prefwindow.d:875
+msgid "Always use advanced paste dialog"
+msgstr ""
 
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:653
-#: source/gx/terminix/prefwindow.d:662 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:719 source/gx/terminix/prefwindow.d:726
-#: source/gx/terminix/prefwindow.d:805 source/gx/terminix/prefwindow.d:857
-#: source/gx/terminix/prefwindow.d:869
+#: source/gx/terminix/prefwindow.d:880
 msgid "Warn when attempting unsafe paste"
 msgstr "進行不安全複製時警告"
 
-#: source/gx/terminix/prefwindow.d:612 source/gx/terminix/prefwindow.d:658
-#: source/gx/terminix/prefwindow.d:667 source/gx/terminix/prefwindow.d:663
-#: source/gx/terminix/prefwindow.d:724 source/gx/terminix/prefwindow.d:731
-#: source/gx/terminix/prefwindow.d:810 source/gx/terminix/prefwindow.d:862
-#: source/gx/terminix/prefwindow.d:874
+#: source/gx/terminix/prefwindow.d:885
 msgid "Strip first character of paste if comment or variable declaration"
 msgstr "如果貼上內容為註釋或變數聲明則切除第一個字元"
 
-#: source/gx/terminix/terminal/layout.d:28
-#, fuzzy
-msgid "Layout Options"
-msgstr "選項"
-
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/terminal/password.d:481
-msgid "OK"
+#: source/gx/terminix/prefwindow.d:890
+msgid "Automatically copy text to clipboard when selecting"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:28
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:855 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:480
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/appwindow.d:1006 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:1112 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:43
-#, fuzzy
-msgid "Active"
-msgstr "動作"
-
-#: source/gx/terminix/terminal/layout.d:49
-#, fuzzy
-msgid "Title"
-msgstr "標題"
-
-#: source/gx/terminix/terminal/layout.d:57
-#, fuzzy
-msgid "Session Load"
-msgstr "會話"
-
-#: source/gx/terminix/terminal/layout.d:73
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:120
-#: source/gx/terminix/terminal/search.d:121
-msgid "Search Options"
-msgstr "搜尋選項"
-
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:185
-#: source/gx/terminix/terminal/search.d:187
-msgid "Match case"
-msgstr "區分大小寫"
-
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:186
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match entire word only"
-msgstr "只匹配整個單詞"
-
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:187
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match as regular expression"
-msgstr "使用正規表示式匹配"
-
-#: source/gx/terminix/terminal/search.d:189
-#: source/gx/terminix/terminal/search.d:188
-#: source/gx/terminix/terminal/search.d:190
-msgid "Wrap around"
-msgstr "折列"
-
-#: source/gx/terminix/terminal/terminal.d:326
-#: source/gx/terminix/terminal/terminal.d:652
-#: source/gx/terminix/terminal/terminal.d:800
-#: data/resources/ui/shortcuts.ui:308
-#: source/gx/terminix/terminal/terminal.d:325
-#: source/gx/terminix/terminal/terminal.d:656
-#: source/gx/terminix/terminal/terminal.d:819
-#: source/gx/terminix/prefwindow.d:339 data/resources/ui/shortcuts.ui:326
-#: source/gx/terminix/terminal/terminal.d:322
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:816
-#: source/gx/terminix/terminal/terminal.d:821
-#: source/gx/terminix/terminal/terminal.d:330
-#: source/gx/terminix/terminal/terminal.d:876
-#: data/resources/ui/shortcuts.ui:332 data/resources/ui/shortcuts.ui:350
-#: source/gx/terminix/terminal/terminal.d:882
-#: source/gx/terminix/terminal/terminal.d:917
-#: source/gx/terminix/terminal/terminal.d:336
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:2513
-#: data/resources/ui/shortcuts.ui:356
-#: source/gx/terminix/terminal/terminal.d:368
-#: source/gx/terminix/terminal/terminal.d:2709
-#: source/gx/terminix/terminal/terminal.d:369
-#: source/gx/terminix/terminal/terminal.d:2740
-msgid "Terminal"
-msgstr "終端"
-
-#: source/gx/terminix/terminal/terminal.d:357
-#: source/gx/terminix/terminal/terminal.d:969 source/gx/terminix/sidebar.d:308
-#: source/gx/terminix/appwindow.d:407
-#: source/gx/terminix/terminal/terminal.d:356
-#: source/gx/terminix/terminal/terminal.d:988
-#: source/gx/terminix/terminal/terminal.d:353
-#: source/gx/terminix/terminal/terminal.d:985
-#: source/gx/terminix/terminal/terminal.d:990
-#: source/gx/terminix/terminal/terminal.d:361
-#: source/gx/terminix/terminal/terminal.d:1031
-#: source/gx/terminix/appwindow.d:503
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1077
-#: source/gx/terminix/appwindow.d:504
-#: source/gx/terminix/terminal/terminal.d:367
-#: source/gx/terminix/terminal/terminal.d:1142
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:1297
-#: source/gx/terminix/appwindow.d:502 source/gx/terminix/sidebar.d:372
-#: source/gx/terminix/terminal/terminal.d:392
-#: source/gx/terminix/terminal/terminal.d:1358
-#: source/gx/terminix/appwindow.d:561 source/gx/terminix/sidebar.d:374
-#: source/gx/terminix/terminal/terminal.d:399
-#: source/gx/terminix/terminal/terminal.d:1396
-#: source/gx/terminix/appwindow.d:565
-#: source/gx/terminix/terminal/terminal.d:400
-#: source/gx/terminix/terminal/terminal.d:1397
-#: source/gx/terminix/appwindow.d:617
-msgid "Close"
-msgstr "關閉"
-
-#: source/gx/terminix/terminal/terminal.d:366
-#: source/gx/terminix/terminal/terminal.d:831
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:365
-#: source/gx/terminix/terminal/terminal.d:850
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:362
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:852
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:370
-#: source/gx/terminix/terminal/terminal.d:904
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:910
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:945
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:971
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:386
-#: source/gx/terminix/terminal/terminal.d:1019
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:401
-#: source/gx/terminix/terminal/terminal.d:1051
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:408
-#: source/gx/terminix/terminal/terminal.d:1104
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:409
-#: source/gx/terminix/terminal/terminal.d:1105
-#: source/gx/terminix/terminal/terminal.d:1396
-#, fuzzy
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:377
-#: source/gx/terminix/terminal/terminal.d:569
-#: source/gx/terminix/terminal/terminal.d:376
-#: source/gx/terminix/terminal/terminal.d:573
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:570
-#: source/gx/terminix/terminal/terminal.d:381
-#: source/gx/terminix/terminal/terminal.d:586
-#: source/gx/terminix/terminal/terminal.d:387
-#: source/gx/terminix/terminal/terminal.d:592
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:607
-#: source/gx/terminix/terminal/terminal.d:412
-#: source/gx/terminix/terminal/terminal.d:632
-#: source/gx/terminix/terminal/terminal.d:419
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:660
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:416
-#: source/gx/terminix/terminal/terminal.d:420
-#: source/gx/terminix/terminal/terminal.d:417
-#: source/gx/terminix/terminal/terminal.d:439
-#: source/gx/terminix/terminal/terminal.d:445
-#: source/gx/terminix/terminal/terminal.d:460
-#: source/gx/terminix/terminal/terminal.d:475
-#: source/gx/terminix/terminal/terminal.d:482
-#: source/gx/terminix/terminal/terminal.d:483
-msgid "Edit Profile"
-msgstr "編輯配置檔"
-
-#: source/gx/terminix/terminal/terminal.d:535
-#: source/gx/terminix/appwindow.d:642
-#: source/gx/terminix/terminal/terminal.d:539
-#: source/gx/terminix/terminal/terminal.d:536
-#: source/gx/terminix/terminal/terminal.d:550
-#: source/gx/terminix/appwindow.d:747
-#: source/gx/terminix/terminal/terminal.d:556
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/appwindow.d:755
-#: source/gx/terminix/terminal/terminal.d:596
-#: source/gx/terminix/appwindow.d:816
-#: source/gx/terminix/terminal/terminal.d:623
-#: source/gx/terminix/appwindow.d:841
-#: source/gx/terminix/terminal/terminal.d:624
-#: source/gx/terminix/appwindow.d:894
-msgid "There are processes that are still running, close anyway?"
-msgstr "仍有正在執行的程序，依然要關閉嗎？"
-
-#: source/gx/terminix/terminal/terminal.d:571
-#: source/gx/terminix/terminal/terminal.d:575
-#: source/gx/terminix/terminal/terminal.d:572
-#: source/gx/terminix/terminal/terminal.d:588
-#: source/gx/terminix/terminal/terminal.d:594
-#: source/gx/terminix/terminal/terminal.d:609
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:662
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:634
-#: source/gx/terminix/terminal/terminal.d:638
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Save…"
-msgstr "儲存…"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:639
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:676
-#: source/gx/terminix/terminal/terminal.d:708
-#: source/gx/terminix/terminal/terminal.d:734
-#: source/gx/terminix/terminal/terminal.d:762
-#: source/gx/terminix/terminal/terminal.d:763
-msgid "Find…"
-msgstr "查詢…"
-
-#: source/gx/terminix/terminal/terminal.d:636
-#: source/gx/terminix/terminal/terminal.d:640
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:659
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:677
-#: source/gx/terminix/terminal/terminal.d:709
-#: source/gx/terminix/terminal/terminal.d:735
-#: source/gx/terminix/terminal/terminal.d:763
-#: source/gx/terminix/terminal/terminal.d:764
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:644
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:645
-#: source/gx/terminix/terminal/terminal.d:391
-#: source/gx/terminix/terminal/terminal.d:660
-#: source/gx/terminix/terminal/terminal.d:661
-#: source/gx/terminix/terminal/terminal.d:397
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:407
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/terminal/terminal.d:422
-#: source/gx/terminix/terminal/terminal.d:736
-#: source/gx/terminix/terminal/terminal.d:429
-#: source/gx/terminix/terminal/terminal.d:764
-#: source/gx/terminix/terminal/terminal.d:430
-#: source/gx/terminix/terminal/terminal.d:765
-msgid "Read-Only"
-msgstr "只讀"
-
-#: source/gx/terminix/terminal/terminal.d:649
-#: source/gx/terminix/terminal/terminal.d:653
-#: source/gx/terminix/terminal/terminal.d:650
-#: source/gx/terminix/terminal/terminal.d:667
-#: source/gx/terminix/terminal/terminal.d:699
-#: source/gx/terminix/terminal/terminal.d:725
-#: source/gx/terminix/terminal/terminal.d:753
-#: source/gx/terminix/terminal/terminal.d:754
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:678
-#: source/gx/terminix/terminal/terminal.d:682
-#: source/gx/terminix/terminal/terminal.d:679
-#, fuzzy
-msgid "Split"
-msgstr "向下分割"
-
-#: source/gx/terminix/terminal/terminal.d:828
-#: source/gx/terminix/terminal/terminal.d:968
-#: source/gx/terminix/terminal/terminal.d:847
-#: source/gx/terminix/terminal/terminal.d:987
-#: source/gx/terminix/terminal/terminal.d:844
-#: source/gx/terminix/terminal/terminal.d:984
-#: source/gx/terminix/terminal/terminal.d:849
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:901
-#: source/gx/terminix/terminal/terminal.d:1030
-#: source/gx/terminix/terminal/terminal.d:907
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:942
-#: source/gx/terminix/terminal/terminal.d:1076
-#: source/gx/terminix/terminal/terminal.d:1141
-#: source/gx/terminix/terminal/terminal.d:1016
-#: source/gx/terminix/terminal/terminal.d:1296
-#: source/gx/terminix/terminal/terminal.d:1048
-#: source/gx/terminix/terminal/terminal.d:1357
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1395
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1396
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:927
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:943
-#: source/gx/terminix/terminal/terminal.d:948
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1000
-#: source/gx/terminix/terminal/terminal.d:1036
-#: source/gx/terminix/terminal/terminal.d:1101
-#: source/gx/terminix/terminal/terminal.d:1256
-#: source/gx/terminix/terminal/terminal.d:1317
-#: source/gx/terminix/terminal/terminal.d:1355
-#: source/gx/terminix/terminal/terminal.d:1356
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:928
-#: source/gx/terminix/terminal/terminal.d:947
-#: source/gx/terminix/terminal/terminal.d:944
-#: source/gx/terminix/terminal/terminal.d:949
-#: source/gx/terminix/terminal/terminal.d:995
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1037
-#: source/gx/terminix/terminal/terminal.d:1102
-#: source/gx/terminix/terminal/terminal.d:1257
-#: source/gx/terminix/terminal/terminal.d:1318
-#: source/gx/terminix/terminal/terminal.d:1356
-#: source/gx/terminix/terminal/terminal.d:1357
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:939
-#: source/gx/terminix/terminal/terminal.d:946
-#: source/gx/terminix/terminal/terminal.d:958
-#: source/gx/terminix/terminal/terminal.d:965
-#: source/gx/terminix/terminal/terminal.d:955
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:967
-#: source/gx/terminix/terminal/terminal.d:1001
-#: source/gx/terminix/terminal/terminal.d:1008
-#: source/gx/terminix/terminal/terminal.d:1007
-#: source/gx/terminix/terminal/terminal.d:1014
-#: source/gx/terminix/terminal/terminal.d:1047
-#: source/gx/terminix/terminal/terminal.d:1054
-#: source/gx/terminix/terminal/terminal.d:1112
-#: source/gx/terminix/terminal/terminal.d:1119
-#: source/gx/terminix/terminal/terminal.d:1267
-#: source/gx/terminix/terminal/terminal.d:1274
-#: source/gx/terminix/terminal/terminal.d:1328
-#: source/gx/terminix/terminal/terminal.d:1335
-#: source/gx/terminix/terminal/terminal.d:1366
-#: source/gx/terminix/terminal/terminal.d:1373
-#: source/gx/terminix/terminal/terminal.d:1367
-#: source/gx/terminix/terminal/terminal.d:1374
-msgid "Copy"
-msgstr "複製"
-
-#: source/gx/terminix/terminal/terminal.d:941
-#: source/gx/terminix/terminal/terminal.d:956
-#: source/gx/terminix/terminal/terminal.d:960
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:957
-#: source/gx/terminix/terminal/terminal.d:972
-#: source/gx/terminix/terminal/terminal.d:962
-#: source/gx/terminix/terminal/terminal.d:977
-#: source/gx/terminix/terminal/terminal.d:1003
-#: source/gx/terminix/terminal/terminal.d:1018
-#: source/gx/terminix/terminal/terminal.d:1009
-#: source/gx/terminix/terminal/terminal.d:1024
-#: source/gx/terminix/terminal/terminal.d:1049
-#: source/gx/terminix/terminal/terminal.d:1064
-#: source/gx/terminix/terminal/terminal.d:1114
-#: source/gx/terminix/terminal/terminal.d:1129
-#: source/gx/terminix/terminal/terminal.d:1269
-#: source/gx/terminix/terminal/terminal.d:1284
-#: source/gx/terminix/terminal/terminal.d:1330
-#: source/gx/terminix/terminal/terminal.d:1345
-#: source/gx/terminix/terminal/terminal.d:1368
-#: source/gx/terminix/terminal/terminal.d:1383
-#: source/gx/terminix/terminal/terminal.d:1369
-#: source/gx/terminix/terminal/terminal.d:1384
-msgid "Select All"
-msgstr "全選"
-
-#: source/gx/terminix/terminal/terminal.d:959
-#: source/gx/terminix/terminal/terminal.d:978
-#: source/gx/terminix/terminal/terminal.d:975
-#: source/gx/terminix/terminal/terminal.d:980
-#: source/gx/terminix/terminal/terminal.d:1021
-#: source/gx/terminix/terminal/terminal.d:1027
-#: source/gx/terminix/prefwindow.d:713
-#: source/gx/terminix/terminal/terminal.d:1067
-#: source/gx/terminix/prefwindow.d:720
-#: source/gx/terminix/terminal/terminal.d:1132
-#: source/gx/terminix/terminal/terminal.d:1287
-#: source/gx/terminix/prefwindow.d:799
-#: source/gx/terminix/terminal/terminal.d:1348
-#: source/gx/terminix/prefwindow.d:846
-#: source/gx/terminix/terminal/terminal.d:1386
-#: source/gx/terminix/prefwindow.d:858
-#: source/gx/terminix/terminal/terminal.d:1387
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:973
-#: source/gx/terminix/terminal/terminal.d:992
-#: source/gx/terminix/terminal/terminal.d:989
-#: source/gx/terminix/terminal/terminal.d:994
-#: source/gx/terminix/terminal/terminal.d:1035
-#: source/gx/terminix/terminal/terminal.d:1041
-#: source/gx/terminix/terminal/terminal.d:1081
-#: source/gx/terminix/terminal/terminal.d:1146
-#: source/gx/terminix/terminal/terminal.d:1301
-#: source/gx/terminix/terminal/terminal.d:1362
-#: source/gx/terminix/terminal/terminal.d:1400
-#: source/gx/terminix/terminal/terminal.d:1401
-#, fuzzy
-msgid "Synchronize input"
-msgstr "同步輸入"
-
-#: source/gx/terminix/terminal/terminal.d:1410
-#: source/gx/terminix/terminal/terminal.d:1429
-#: source/gx/terminix/terminal/terminal.d:1425
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1486
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1534
-#: source/gx/terminix/terminal/terminal.d:1669
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/terminal/terminal.d:1891
-#: source/gx/terminix/terminal/terminal.d:1958
-#: source/gx/terminix/terminal/terminal.d:1984
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1416
-#: source/gx/terminix/terminal/terminal.d:1435
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1437
-#: source/gx/terminix/terminal/terminal.d:1492
-#: source/gx/terminix/terminal/terminal.d:1498
-#: source/gx/terminix/terminal/terminal.d:1540
-#: source/gx/terminix/terminal/terminal.d:1675
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1897
-#: source/gx/terminix/terminal/terminal.d:1964
-#: source/gx/terminix/terminal/terminal.d:1990
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1730
-#: source/gx/terminix/terminal/terminal.d:1749
-#: source/gx/terminix/terminal/terminal.d:1747
-#: source/gx/terminix/terminal/terminal.d:1754
-#: source/gx/terminix/terminal/terminal.d:1826
-#: source/gx/terminix/terminal/terminal.d:1832
-#: source/gx/terminix/terminal/terminal.d:1869
-#: source/gx/terminix/terminal/terminal.d:2004
-#: source/gx/terminix/terminal/terminal.d:2186
-#: source/gx/terminix/terminal/terminal.d:2238
-#: source/gx/terminix/terminal/terminal.d:2444
-#: source/gx/terminix/terminal/terminal.d:2475
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1736
-#: source/gx/terminix/terminal/terminal.d:1755
-#: source/gx/terminix/terminal/terminal.d:1753
-#: source/gx/terminix/terminal/terminal.d:1763
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1841
-#: source/gx/terminix/terminal/terminal.d:1878
-#: source/gx/terminix/terminal/terminal.d:2013
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2247
-#: source/gx/terminix/terminal/terminal.d:2453
-#: source/gx/terminix/terminal/terminal.d:2484
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1740
-#: source/gx/terminix/appwindow.d:710
-#: source/gx/terminix/terminal/terminal.d:1759
-#: source/gx/terminix/appwindow.d:725
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/terminal/terminal.d:1767
-#: source/gx/terminix/terminal/terminal.d:1839
-#: source/gx/terminix/appwindow.d:815 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/terminal/terminal.d:1845
-#: source/gx/terminix/terminal/terminal.d:1882
-#: source/gx/terminix/prefwindow.d:611
-#: source/gx/terminix/terminal/terminal.d:2017
-#: source/gx/terminix/terminal/terminal.d:2199
-#: source/gx/terminix/appwindow.d:882 source/gx/terminix/prefwindow.d:616
-#: source/gx/terminix/terminal/terminal.d:2251
-#: source/gx/terminix/appwindow.d:965 source/gx/terminix/prefwindow.d:619
-#: source/gx/terminix/terminal/terminal.d:2457
-#: source/gx/terminix/appwindow.d:1004
-#: source/gx/terminix/terminal/terminal.d:2488
-#: source/gx/terminix/appwindow.d:1070 source/gx/terminix/profilewindow.d:748
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2055
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2076
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2181
-#: source/gx/terminix/terminal/terminal.d:2187
-#: source/gx/terminix/terminal/terminal.d:2221
-#: source/gx/terminix/terminal/terminal.d:2362
-#: source/gx/terminix/terminal/terminal.d:2570
-#: source/gx/terminix/terminal/terminal.d:2673
-#: source/gx/terminix/terminal/terminal.d:2869
-#: source/gx/terminix/terminal/terminal.d:2900
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2056
-#: source/gx/terminix/terminal/terminal.d:2079
-#: source/gx/terminix/terminal/terminal.d:2077
-#: source/gx/terminix/terminal/terminal.d:2087
-#: source/gx/terminix/terminal/terminal.d:2182
-#: source/gx/terminix/terminal/terminal.d:2188
-#: source/gx/terminix/terminal/terminal.d:2222
-#: source/gx/terminix/terminal/terminal.d:2363
-#: source/gx/terminix/terminal/terminal.d:2571
-#: source/gx/terminix/terminal/terminal.d:2674
-#: source/gx/terminix/terminal/terminal.d:2870
-#: source/gx/terminix/terminal/terminal.d:2901
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2057
-#: source/gx/terminix/terminal/terminal.d:2080
-#: source/gx/terminix/terminal/terminal.d:2078
-#: source/gx/terminix/terminal/terminal.d:2088
-#: source/gx/terminix/terminal/terminal.d:2183
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2223
-#: source/gx/terminix/terminal/terminal.d:2364
-#: source/gx/terminix/terminal/terminal.d:2572
-#: source/gx/terminix/terminal/terminal.d:2675
-#: source/gx/terminix/terminal/terminal.d:2871
-#: source/gx/terminix/terminal/terminal.d:2902
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2063
-#: source/gx/terminix/terminal/terminal.d:2086
-#: source/gx/terminix/terminal/terminal.d:2084
-#: source/gx/terminix/terminal/terminal.d:2094
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/terminal/terminal.d:2195
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2370
-#: source/gx/terminix/terminal/terminal.d:2578
-#: source/gx/terminix/terminal/terminal.d:2681
-#: source/gx/terminix/terminal/terminal.d:2877
-#: source/gx/terminix/terminal/terminal.d:2908
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2103
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2124
-#: source/gx/terminix/terminal/terminal.d:2134
-#: source/gx/terminix/terminal/terminal.d:2229
-#: source/gx/terminix/terminal/terminal.d:2235
-#: source/gx/terminix/terminal/terminal.d:2269
-#: source/gx/terminix/terminal/terminal.d:2410
-#: source/gx/terminix/terminal/terminal.d:2618
-#: source/gx/terminix/terminal/advpaste.d:29
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2104
-#: source/gx/terminix/terminal/terminal.d:2127
-#: source/gx/terminix/terminal/terminal.d:2125
-#: source/gx/terminix/terminal/terminal.d:2135
-#: source/gx/terminix/terminal/terminal.d:2230
-#: source/gx/terminix/terminal/terminal.d:2236
-#: source/gx/terminix/terminal/terminal.d:2270
-#: source/gx/terminix/terminal/terminal.d:2411
-#: source/gx/terminix/terminal/terminal.d:2619
-#: source/gx/terminix/terminal/advpaste.d:30
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2105
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2126
-#: source/gx/terminix/terminal/terminal.d:2136
-#: source/gx/terminix/terminal/terminal.d:2231
-#: source/gx/terminix/terminal/terminal.d:2237
-#: source/gx/terminix/terminal/terminal.d:2271
-#: source/gx/terminix/terminal/terminal.d:2412
-#: source/gx/terminix/terminal/terminal.d:2620
-#: source/gx/terminix/terminal/advpaste.d:31
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2107
-#: source/gx/terminix/terminal/terminal.d:2130
-#: source/gx/terminix/terminal/terminal.d:2128
-#: source/gx/terminix/terminal/terminal.d:2138
-#: source/gx/terminix/terminal/terminal.d:2233
-#: source/gx/terminix/terminal/terminal.d:2239
-#: source/gx/terminix/terminal/terminal.d:2273
-#: source/gx/terminix/terminal/terminal.d:2414
-#: source/gx/terminix/terminal/terminal.d:2622
-#: source/gx/terminix/terminal/terminal.d:2726
-#: source/gx/terminix/terminal/terminal.d:2922
-#: source/gx/terminix/terminal/terminal.d:2953
-#, fuzzy
-msgid "Don't Paste"
-msgstr "貼上"
-
-#: source/gx/terminix/terminal/terminal.d:2108
-#: source/gx/terminix/terminal/terminal.d:2131
-#: source/gx/terminix/terminal/terminal.d:2129
-#: source/gx/terminix/terminal/terminal.d:2139
-#: source/gx/terminix/terminal/terminal.d:2234
-#: source/gx/terminix/terminal/terminal.d:2240
-#: source/gx/terminix/terminal/terminal.d:2274
-#: source/gx/terminix/terminal/terminal.d:2415
-#: source/gx/terminix/terminal/terminal.d:2623
-#: source/gx/terminix/terminal/terminal.d:2727
-#: source/gx/terminix/terminal/terminal.d:2923
-#: source/gx/terminix/terminal/terminal.d:2954
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:75 source/gx/terminix/cmdparams.d:83
-#: source/gx/terminix/cmdparams.d:85 source/gx/terminix/cmdparams.d:87
-#: source/gx/terminix/cmdparams.d:92 source/gx/terminix/cmdparams.d:94
 #: source/gx/terminix/cmdparams.d:96
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
 msgstr ""
 
-#: source/gx/terminix/cmdparams.d:102 source/gx/terminix/cmdparams.d:131
-#: source/gx/terminix/cmdparams.d:133 source/gx/terminix/cmdparams.d:135
-#: source/gx/terminix/cmdparams.d:140 source/gx/terminix/cmdparams.d:142
 #: source/gx/terminix/cmdparams.d:144
 #, fuzzy, c-format
 msgid "Ignoring parameter session as '%s' does not exist"
 msgstr "檔名「%s」不存在"
 
-#: source/gx/terminix/cmdparams.d:111 source/gx/terminix/cmdparams.d:140
-#: source/gx/terminix/cmdparams.d:142 source/gx/terminix/cmdparams.d:145
-#: source/gx/terminix/cmdparams.d:150 source/gx/terminix/cmdparams.d:152
 #: source/gx/terminix/cmdparams.d:154
 msgid ""
 "You cannot load a session and set a profile/working directory/execute "
 "command option, please choose one or the other"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:185 source/gx/terminix/appwindow.d:212
-#: source/gx/terminix/appwindow.d:213 source/gx/terminix/appwindow.d:220
-#: source/gx/terminix/appwindow.d:261 source/gx/terminix/appwindow.d:265
-#: source/gx/terminix/appwindow.d:317
-#, fuzzy
-msgid "View session sidebar"
-msgstr "顯示側邊列"
-
-#: source/gx/terminix/appwindow.d:199 source/gx/terminix/appwindow.d:224
-#: source/gx/terminix/appwindow.d:225 source/gx/terminix/appwindow.d:245
-#: source/gx/terminix/appwindow.d:286 source/gx/terminix/appwindow.d:290
-#: source/gx/terminix/appwindow.d:342
-msgid "Create a new session"
-msgstr "建立會話"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Change Session Name"
-msgstr "更改會話名稱"
-
-#: source/gx/terminix/appwindow.d:378 source/gx/terminix/appwindow.d:445
-#: source/gx/terminix/appwindow.d:446 source/gx/terminix/appwindow.d:444
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:559
-msgid "Enter a new name for the session"
-msgstr "為會話新建名稱"
-
-#: source/gx/terminix/appwindow.d:404 source/gx/terminix/appwindow.d:500
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:499
-#: source/gx/terminix/appwindow.d:558 source/gx/terminix/appwindow.d:562
-#: source/gx/terminix/appwindow.d:614
-msgid "Open…"
+#: source/gx/terminix/cmdparams.d:161
+msgid "You can only use the action parameter within Terminix"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:405
-#: source/gx/terminix/terminal/terminal.d:1757
-#: source/gx/terminix/appwindow.d:797
-#: source/gx/terminix/terminal/terminal.d:1829
-#: source/gx/terminix/appwindow.d:501 source/gx/terminix/appwindow.d:887
-#: source/gx/terminix/terminal/terminal.d:1835
-#: source/gx/terminix/terminal/terminal.d:1872
-#: source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/terminal/terminal.d:2007
-#: source/gx/terminix/terminal/terminal.d:2189
-#: source/gx/terminix/appwindow.d:500 source/gx/terminix/appwindow.d:954
-#: source/gx/terminix/terminal/terminal.d:2241
-#: source/gx/terminix/appwindow.d:559 source/gx/terminix/appwindow.d:1040
-#: source/gx/terminix/terminal/terminal.d:2447
-#: source/gx/terminix/appwindow.d:563 source/gx/terminix/appwindow.d:1079
-#: source/gx/terminix/terminal/terminal.d:2478
-#: source/gx/terminix/appwindow.d:615 source/gx/terminix/appwindow.d:1146
-#: source/gx/terminix/profilewindow.d:731
-msgid "Save"
-msgstr "儲存"
-
-#: source/gx/terminix/appwindow.d:406 source/gx/terminix/appwindow.d:502
-#: source/gx/terminix/appwindow.d:503 source/gx/terminix/appwindow.d:501
-#: source/gx/terminix/appwindow.d:560 source/gx/terminix/appwindow.d:564
-#: source/gx/terminix/appwindow.d:616
-msgid "Save As…"
-msgstr "另存為…"
-
-#: source/gx/terminix/appwindow.d:411 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:508 source/gx/terminix/appwindow.d:506
-#: source/gx/terminix/appwindow.d:565 source/gx/terminix/appwindow.d:569
-#: source/gx/terminix/appwindow.d:621
-msgid "Name…"
-msgstr "名稱…"
-
-#: source/gx/terminix/appwindow.d:412 source/gx/terminix/appwindow.d:508
-#: source/gx/terminix/appwindow.d:509 source/gx/terminix/appwindow.d:507
-#: source/gx/terminix/appwindow.d:566 source/gx/terminix/appwindow.d:570
-#: source/gx/terminix/appwindow.d:622
-msgid "Synchronize Input"
-msgstr "同步輸入"
-
-#: source/gx/terminix/appwindow.d:417 source/gx/terminix/appwindow.d:513
-#: source/gx/terminix/appwindow.d:514 source/gx/terminix/appwindow.d:512
-#: source/gx/terminix/appwindow.d:571 source/gx/terminix/appwindow.d:575
-#: source/gx/terminix/appwindow.d:627
-msgid "GC"
+#: source/gx/terminix/cmdparams.d:182
+msgid ""
+"You cannot use the quake mode with maximize, minimize, fullscreen or "
+"geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:706 source/gx/terminix/appwindow.d:721
-#: source/gx/terminix/appwindow.d:811 source/gx/terminix/appwindow.d:878
-#: source/gx/terminix/appwindow.d:961 source/gx/terminix/appwindow.d:1000
-#: source/gx/terminix/appwindow.d:1066 source/gx/terminix/profilewindow.d:744
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:719 source/gx/terminix/appwindow.d:734
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:891
-#: source/gx/terminix/appwindow.d:974 source/gx/terminix/appwindow.d:1013
-#: source/gx/terminix/appwindow.d:1079
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "檔名「%s」不存在"
-
-#: source/gx/terminix/appwindow.d:746 source/gx/terminix/appwindow.d:761
-#: source/gx/terminix/appwindow.d:762 source/gx/terminix/appwindow.d:852
-#: source/gx/terminix/appwindow.d:919 source/gx/terminix/appwindow.d:1003
-#: source/gx/terminix/appwindow.d:1042 source/gx/terminix/appwindow.d:1109
-msgid "Load Session"
-msgstr "載入會話"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-msgid "Could not load session due to unexpected error."
-msgstr "發生未知錯誤，無法載入會話。"
-
-#: source/gx/terminix/appwindow.d:759 source/gx/terminix/appwindow.d:774
-#: source/gx/terminix/appwindow.d:778 source/gx/terminix/appwindow.d:868
-#: source/gx/terminix/appwindow.d:935 source/gx/terminix/appwindow.d:1021
-#: source/gx/terminix/appwindow.d:1060 source/gx/terminix/appwindow.d:1127
-#, fuzzy
-msgid "Error Loading Session"
-msgstr "載入會話"
-
-#: source/gx/terminix/appwindow.d:774 source/gx/terminix/appwindow.d:789
-#: source/gx/terminix/appwindow.d:794 source/gx/terminix/appwindow.d:884
-#: source/gx/terminix/appwindow.d:951 source/gx/terminix/appwindow.d:1037
-#: source/gx/terminix/appwindow.d:1076 source/gx/terminix/appwindow.d:1143
-msgid "Save Session"
-msgstr "儲存會話"
-
-#: source/gx/terminix/appwindow.d:809
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:3
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:7
-#: source/gx/terminix/appwindow.d:824 source/gx/terminix/appwindow.d:832
-#: source/gx/terminix/appwindow.d:922
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: source/gx/terminix/appwindow.d:992 source/gx/terminix/appwindow.d:1119
-#: source/gx/terminix/appwindow.d:1158 source/gx/terminix/appwindow.d:1225
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/gtk/actions.d:26 source/gx/gtk/actions.d:25
+#: source/gx/gtk/actions.d:25
 #, fuzzy
 msgid "disabled"
 msgstr "已啟用"
 
-#: source/app.d:46 source/app.d:72 source/app.d:76 source/app.d:82
-#: source/app.d:96 source/app.d:106
+#: source/app.d:106
 #, c-format
 msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
 msgstr ""
 
-#: source/app.d:66 source/app.d:92 source/app.d:96 source/app.d:93
-#: source/app.d:99 source/app.d:113 source/app.d:123
+#: source/app.d:123
 msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/app.d:67 source/app.d:93 source/app.d:97 source/app.d:94
-#: source/app.d:100 source/app.d:114 source/app.d:124
+#: source/app.d:124
 msgid "Error: "
 msgstr ""
 
 # ******************
 # Nautilus extension
 # ******************
-#: data/nautilus/open-terminix.py:43 data/nautilus/open-terminix.py:48
-msgid "Open in Terminix…"
+#: data/nautilus/open-terminix.py:65
+#, fuzzy
+msgid "Open Remote Terminix…"
 msgstr "使用 Terminix 開啟…"
 
-#: data/nautilus/open-terminix.py:44 data/nautilus/open-terminix.py:49
+#: data/nautilus/open-terminix.py:66
+#, fuzzy, python-format
+msgid "Open Remote Terminix In %s"
+msgstr "在 %s 開啟 Terminix"
+
+# ******************
+# Nautilus extension
+# ******************
+#: data/nautilus/open-terminix.py:76
+#, fuzzy
+msgid "Open In Terminix…"
+msgstr "使用 Terminix 開啟…"
+
 #: data/nautilus/open-terminix.py:77
 #, python-format
 msgid "Open Terminix In %s"
 msgstr "在 %s 開啟 Terminix"
 
-#: data/nautilus/open-terminix.py:50 data/nautilus/open-terminix.py:55
+#: data/nautilus/open-terminix.py:87
+#, fuzzy
+msgid "Open Remote Terminix Here…"
+msgstr "在此開啟 Terminix…"
+
+#: data/nautilus/open-terminix.py:88
+#, fuzzy
+msgid "Open Remote Terminix In This Directory"
+msgstr "在此目錄開啟 Terminix"
+
 #: data/nautilus/open-terminix.py:93
 msgid "Open Terminix Here…"
 msgstr "在此開啟 Terminix…"
 
-#: data/nautilus/open-terminix.py:51 data/nautilus/open-terminix.py:56
 #: data/nautilus/open-terminix.py:94
 msgid "Open Terminix In This Directory"
 msgstr "在此目錄開啟 Terminix"
 
-#: data/resources/ui/shortcuts.ui:10 source/gx/terminix/prefwindow.d:338
-#, fuzzy
-msgid "Application"
-msgstr "動作"
-
-#: data/resources/ui/shortcuts.ui:15 data/resources/ui/shortcuts.ui:10
+#: data/resources/ui/shortcuts.ui:10 data/resources/ui/shortcuts.ui:15
 #, fuzzy
 msgctxt "shortcut window"
 msgid "Application"
@@ -2661,1297 +1696,412 @@ msgctxt "shortcut window"
 msgid "View session sidebar"
 msgstr "顯示側邊列"
 
-#: data/resources/ui/shortcuts.ui:61 data/resources/ui/shortcuts.ui:67
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to next session"
-msgstr "切換到會話 10"
-
-#: data/resources/ui/shortcuts.ui:67 data/resources/ui/shortcuts.ui:73
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to previous session"
-msgstr "切換到上一個終端"
-
-#: data/resources/ui/shortcuts.ui:73 data/resources/ui/shortcuts.ui:79
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 1"
-msgstr "切換到會話 1"
-
-#: data/resources/ui/shortcuts.ui:79 data/resources/ui/shortcuts.ui:85
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 2"
-msgstr "切換到會話 2"
-
-#: data/resources/ui/shortcuts.ui:85 data/resources/ui/shortcuts.ui:91
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 3"
-msgstr "切換到會話 3"
-
-#: data/resources/ui/shortcuts.ui:91 data/resources/ui/shortcuts.ui:97
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 4"
-msgstr "切換到會話 4"
-
-#: data/resources/ui/shortcuts.ui:97 data/resources/ui/shortcuts.ui:103
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 5"
-msgstr "切換到會話 5"
-
-#: data/resources/ui/shortcuts.ui:103 data/resources/ui/shortcuts.ui:109
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 6"
-msgstr "切換到會話 6"
-
-#: data/resources/ui/shortcuts.ui:109 data/resources/ui/shortcuts.ui:115
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 7"
-msgstr "切換到會話 7"
-
-#: data/resources/ui/shortcuts.ui:115 data/resources/ui/shortcuts.ui:121
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 8"
-msgstr "切換到會話 8"
-
-#: data/resources/ui/shortcuts.ui:121 data/resources/ui/shortcuts.ui:127
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 9"
-msgstr "切換到會話 9"
-
-#: data/resources/ui/shortcuts.ui:127 data/resources/ui/shortcuts.ui:133
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to session 10"
-msgstr "切換到會話 10"
-
-#: data/resources/ui/shortcuts.ui:138 source/gx/terminix/prefwindow.d:340
-#, fuzzy
-msgid "Session"
-msgstr "會話"
-
-#: data/resources/ui/shortcuts.ui:143 data/resources/ui/shortcuts.ui:149
-msgctxt "shortcut window"
-msgid "File"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:147 data/resources/ui/shortcuts.ui:153
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Close the current session"
-msgstr "開啟指定的會話"
-
-#: data/resources/ui/shortcuts.ui:153 data/resources/ui/shortcuts.ui:159
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Save the current session"
-msgstr "開啟指定的會話"
-
-#: data/resources/ui/shortcuts.ui:159 data/resources/ui/shortcuts.ui:165
-msgctxt "shortcut window"
-msgid "Save the current session with new filename"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:165 data/resources/ui/shortcuts.ui:171
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Open a saved session"
-msgstr "建立會話"
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:191
-#: data/resources/ui/shortcuts.ui:197
-msgctxt "shortcut window"
-msgid "Resize"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:195
-#: data/resources/ui/shortcuts.ui:201
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal up"
-msgstr "退出此終端"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:201
-#: data/resources/ui/shortcuts.ui:207
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal down"
-msgstr "保持終端開啟"
-
-#: data/resources/ui/shortcuts.ui:189 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:213
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal left"
-msgstr "退出此終端"
-
-#: data/resources/ui/shortcuts.ui:195 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:219
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Resize the terminal right"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:203 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:263 data/resources/ui/shortcuts.ui:239
-#: data/resources/ui/shortcuts.ui:281 data/resources/ui/shortcuts.ui:245
-#: data/resources/ui/shortcuts.ui:287
-msgctxt "shortcut window"
-msgid "Switch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:207 data/resources/ui/shortcuts.ui:225
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:249
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to next terminal"
-msgstr "切換到下一個終端"
-
-#: data/resources/ui/shortcuts.ui:213 data/resources/ui/shortcuts.ui:231
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:255
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to previous terminal"
-msgstr "切換到上一個終端"
-
-#: data/resources/ui/shortcuts.ui:219 data/resources/ui/shortcuts.ui:237
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:261
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal up"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:243
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:267
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal down"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:249
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:273
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal left"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:237 data/resources/ui/shortcuts.ui:255
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:279
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to the terminal right"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:243 data/resources/ui/shortcuts.ui:267
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:291
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 1"
-msgstr "切換到終端 1"
-
-#: data/resources/ui/shortcuts.ui:249 data/resources/ui/shortcuts.ui:273
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:297
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 2"
-msgstr "切換到終端 2"
-
-#: data/resources/ui/shortcuts.ui:255 data/resources/ui/shortcuts.ui:279
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:303
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 3"
-msgstr "切換到終端 3"
-
-#: data/resources/ui/shortcuts.ui:261 data/resources/ui/shortcuts.ui:285
-#: data/resources/ui/shortcuts.ui:303 data/resources/ui/shortcuts.ui:309
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 4"
-msgstr "切換到終端 4"
-
-#: data/resources/ui/shortcuts.ui:267 data/resources/ui/shortcuts.ui:291
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:315
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 5"
-msgstr "切換到終端 5"
-
-#: data/resources/ui/shortcuts.ui:273 data/resources/ui/shortcuts.ui:297
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:321
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 6"
-msgstr "切換到終端 6"
-
-#: data/resources/ui/shortcuts.ui:279 data/resources/ui/shortcuts.ui:303
-#: data/resources/ui/shortcuts.ui:321 data/resources/ui/shortcuts.ui:327
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 7"
-msgstr "切換到終端 7"
-
-#: data/resources/ui/shortcuts.ui:285 data/resources/ui/shortcuts.ui:309
-#: data/resources/ui/shortcuts.ui:327 data/resources/ui/shortcuts.ui:333
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 8"
-msgstr "切換到終端 8"
-
-#: data/resources/ui/shortcuts.ui:291 data/resources/ui/shortcuts.ui:315
-#: data/resources/ui/shortcuts.ui:333 data/resources/ui/shortcuts.ui:339
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 9"
-msgstr "切換到終端 9"
-
-#: data/resources/ui/shortcuts.ui:297 data/resources/ui/shortcuts.ui:321
-#: data/resources/ui/shortcuts.ui:339 data/resources/ui/shortcuts.ui:345
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Switch to terminal 10"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:313 data/resources/ui/shortcuts.ui:331
-#: data/resources/ui/shortcuts.ui:337
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split"
-msgstr "向下分割"
-
-#: data/resources/ui/shortcuts.ui:317 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:341
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split right"
-msgstr "向右分割"
-
-#: data/resources/ui/shortcuts.ui:323 data/resources/ui/shortcuts.ui:341
-#: data/resources/ui/shortcuts.ui:347
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Split down"
-msgstr "向下分割"
-
-#: data/resources/ui/shortcuts.ui:331 data/resources/ui/shortcuts.ui:335
-#: data/resources/ui/shortcuts.ui:349 data/resources/ui/shortcuts.ui:353
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find"
-msgstr "查詢…"
-
-#: data/resources/ui/shortcuts.ui:341 data/resources/ui/shortcuts.ui:359
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:371
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find next"
-msgstr "查詢下一個"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: data/resources/ui/shortcuts.ui:347 data/resources/ui/shortcuts.ui:365
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:377
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Find previous"
-msgstr "查詢上一個"
-
-#: data/resources/ui/shortcuts.ui:355 data/resources/ui/shortcuts.ui:373
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:385
-msgctxt "shortcut window"
-msgid "Clipboard"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:359 data/resources/ui/shortcuts.ui:377
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:389
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Copy"
-msgstr "複製"
-
-#: data/resources/ui/shortcuts.ui:365 data/resources/ui/shortcuts.ui:383
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:395
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Paste"
-msgstr "貼上"
-
-#: data/resources/ui/shortcuts.ui:371 data/resources/ui/shortcuts.ui:389
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:407
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Select all"
-msgstr "全選"
-
-#: data/resources/ui/shortcuts.ui:379 data/resources/ui/shortcuts.ui:397
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:415
-msgctxt "shortcut window"
-msgid "Zoom"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:383 data/resources/ui/shortcuts.ui:401
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:419
-msgctxt "shortcut window"
-msgid "Zoom in"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:389 data/resources/ui/shortcuts.ui:407
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:425
-msgctxt "shortcut window"
-msgid "Zoom out"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:395 data/resources/ui/shortcuts.ui:413
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:431
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Zoom normal size"
-msgstr "正常縮放"
-
-#: data/resources/ui/shortcuts.ui:403 data/resources/ui/shortcuts.ui:305
-#: data/resources/ui/shortcuts.ui:421 data/resources/ui/shortcuts.ui:203
-#: data/resources/ui/shortcuts.ui:427 data/resources/ui/shortcuts.ui:221
-#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
-msgctxt "shortcut window"
-msgid "Other"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:407 data/resources/ui/shortcuts.ui:425
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:443
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Save terminal contents"
-msgstr "保持終端開啟"
-
-#: data/resources/ui/shortcuts.ui:413 data/resources/ui/shortcuts.ui:431
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:449
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Close terminal"
-msgstr "終端"
-
-#: data/resources/ui/shortcuts.ui:419 data/resources/ui/shortcuts.ui:437
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:455
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Maximize terminal"
-msgstr "退出此終端"
-
-#: data/resources/ui/shortcuts.ui:425 data/resources/ui/shortcuts.ui:443
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:461
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Current profile preferences"
-msgstr "配置方案偏好設定"
-
-#: data/resources/ui/shortcuts.ui:431 data/resources/ui/shortcuts.ui:449
-#: data/resources/ui/shortcuts.ui:455 data/resources/ui/shortcuts.ui:467
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Reset the terminal"
-msgstr "退出此終端"
-
-#: data/resources/ui/shortcuts.ui:437 data/resources/ui/shortcuts.ui:455
-#: data/resources/ui/shortcuts.ui:461 data/resources/ui/shortcuts.ui:473
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Reset and clear the terminal"
-msgstr "退出此終端"
-
-#: data/resources/ui/shortcuts.ui:443 data/resources/ui/shortcuts.ui:461
-#: data/resources/ui/shortcuts.ui:467 data/resources/ui/shortcuts.ui:479
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Toggle read only"
-msgstr "只讀"
-
-#: data/resources/ui/shortcuts.ui:449 data/resources/ui/shortcuts.ui:467
-#: data/resources/ui/shortcuts.ui:473 data/resources/ui/shortcuts.ui:485
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Layout options"
-msgstr "選項"
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
-msgid "A tiling terminal for Gnome"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:10
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
-msgid "com.gexperts.Terminix"
-msgstr ""
-
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:15
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:16
-#, fuzzy
-msgid "New Terminal"
-msgstr "終端"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
-msgid "A tiling terminal for GNOME"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:10
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
-msgid "Terminix is a tiling terminal emulator."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:13
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-msgid "It lets you:"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-msgid ""
-"Layout terminals in any fashion by splitting them horizontally or vertically"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:16
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-msgid ""
-"Terminals can be re-arranged using drag and drop both within and between "
-"windows"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-msgid "Terminals can be detached into a new window via drag and drop"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-msgid ""
-"Input can be synchronized between terminals so commands typed in one "
-"terminal are replicated to the others"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-msgid "The grouping of terminals can be saved and loaded from disk"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-msgid "Terminals support custom titles"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-msgid ""
-"Color schemes are stored in files and custom color schemes can be created by "
-"simply creating a new file"
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
-#, fuzzy
-msgid "Transparent background"
-msgstr "透明度"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#, fuzzy
-msgid "Supports notifications when processes are completed out of view"
-msgstr "程序完成時傳送桌面通知"
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
-msgid ""
-"The application was written using GTK 3 and an effort was made to conform to "
-"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
-"decorations, though it can be disabled if necessary."
-msgstr ""
-
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:29
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
-msgid "Terminix has been tested with GNOME and with Unity."
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:474 source/gx/terminix/application.d:487
-#: source/gx/terminix/application.d:551 source/gx/terminix/application.d:562
-#: source/gx/terminix/application.d:593 source/gx/terminix/application.d:594
-#: source/gx/terminix/application.d:611
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:337
-#, fuzzy
-msgid "Window"
-msgstr "新建視窗"
-
-#: data/resources/ui/shortcuts.ui:309 data/resources/ui/shortcuts.ui:207
-#: data/resources/ui/shortcuts.ui:225 data/resources/ui/shortcuts.ui:231
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Edit the session name"
-msgstr "切換到會話 1"
-
-#: data/resources/ui/shortcuts.ui:315 data/resources/ui/shortcuts.ui:213
-#: data/resources/ui/shortcuts.ui:231 data/resources/ui/shortcuts.ui:237
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Synchronize the input"
-msgstr "同步輸入"
-
-#: data/resources/ui/shortcuts.ui:138 data/resources/ui/shortcuts.ui:144
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Session"
-msgstr "會話"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#: source/gx/terminix/terminal/terminal.d:648
-#: source/gx/terminix/terminal/terminal.d:665
-#: source/gx/terminix/terminal/terminal.d:697
-#: source/gx/terminix/terminal/terminal.d:723
-#: source/gx/terminix/terminal/terminal.d:751
-#: source/gx/terminix/terminal/terminal.d:752
-#, fuzzy
-msgid "Save Output…"
-msgstr "另存為…"
-
-#: source/gx/terminix/appwindow.d:765 source/gx/terminix/appwindow.d:855
-#: source/gx/terminix/appwindow.d:922 source/gx/terminix/appwindow.d:1006
-#: source/gx/terminix/appwindow.d:1045 source/gx/terminix/appwindow.d:1112
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:134
-#, fuzzy
-msgid "Find next"
-msgstr "查詢下一個"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:140
-#, fuzzy
-msgid "Find previous"
-msgstr "查詢上一個"
-
-#: source/gx/terminix/application.d:550 source/gx/terminix/application.d:561
-#: source/gx/terminix/application.d:592 source/gx/terminix/application.d:593
-#: source/gx/terminix/application.d:610
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:242 source/gx/terminix/appwindow.d:243
-#: source/gx/terminix/appwindow.d:263 source/gx/terminix/appwindow.d:304
-#: source/gx/terminix/appwindow.d:308 source/gx/terminix/appwindow.d:360
-#, fuzzy
-msgid "Add terminal right"
-msgstr "切換到終端 10"
-
-#: source/gx/terminix/appwindow.d:246 source/gx/terminix/appwindow.d:247
-#: source/gx/terminix/appwindow.d:267 source/gx/terminix/appwindow.d:308
-#: source/gx/terminix/appwindow.d:312 source/gx/terminix/appwindow.d:364
-#, fuzzy
-msgid "Add terminal down"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/appwindow.d:251 source/gx/terminix/appwindow.d:252
-#: source/gx/terminix/appwindow.d:272 source/gx/terminix/appwindow.d:313
-#: source/gx/terminix/appwindow.d:317 source/gx/terminix/appwindow.d:369
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "退出此終端"
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:210
-#: source/gx/terminix/profilewindow.d:211
-#: source/gx/terminix/profilewindow.d:219
-#: source/gx/terminix/profilewindow.d:222
-#: source/gx/terminix/profilewindow.d:223
-#: source/gx/terminix/profilewindow.d:227
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:832
-#: source/gx/terminix/profilewindow.d:833
-#: source/gx/terminix/profilewindow.d:877
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:956
-#: source/gx/terminix/profilewindow.d:1034
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:860
-#: source/gx/terminix/profilewindow.d:859
-#: source/gx/terminix/profilewindow.d:897
-#: source/gx/terminix/profilewindow.d:933
-#: source/gx/terminix/profilewindow.d:935
-#: source/gx/terminix/profilewindow.d:982
-#: source/gx/terminix/profilewindow.d:1060
-#, fuzzy
-msgid "Match"
-msgstr "區分大小寫"
-
-#: source/gx/terminix/profilewindow.d:871
-#: source/gx/terminix/profilewindow.d:870
-#: source/gx/terminix/profilewindow.d:908
-#: source/gx/terminix/profilewindow.d:1073
-#: source/gx/terminix/profilewindow.d:944
-#: source/gx/terminix/profilewindow.d:1123
-#: source/gx/terminix/profilewindow.d:1279
-#: source/gx/terminix/profilewindow.d:946
-#: source/gx/terminix/profilewindow.d:1125
-#: source/gx/terminix/profilewindow.d:1281
-#: source/gx/terminix/profilewindow.d:993
-#: source/gx/terminix/profilewindow.d:1172
-#: source/gx/terminix/profilewindow.d:1328
-#: source/gx/terminix/profilewindow.d:1071
-#: source/gx/terminix/profilewindow.d:1250
-#: source/gx/terminix/profilewindow.d:1406
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:954
-#: source/gx/terminix/profilewindow.d:1001
-#: source/gx/terminix/profilewindow.d:1079
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:874
-#: source/gx/terminix/profilewindow.d:873
-#: source/gx/terminix/profilewindow.d:911
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:952
-#: source/gx/terminix/profilewindow.d:999
-#: source/gx/terminix/profilewindow.d:1077
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:975
-#: source/gx/terminix/profilewindow.d:1022
-#: source/gx/terminix/profilewindow.d:1100
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:926
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:973
-#: source/gx/terminix/profilewindow.d:1020
-#: source/gx/terminix/profilewindow.d:1098
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:593 source/gx/terminix/prefwindow.d:600
-#: source/gx/terminix/prefwindow.d:605 source/gx/terminix/prefwindow.d:607
-#, fuzzy
-msgid "Background image"
-msgstr "背景"
-
-#: source/gx/terminix/prefwindow.d:595 source/gx/terminix/prefwindow.d:602
-#: source/gx/terminix/prefwindow.d:607 source/gx/terminix/prefwindow.d:609
-#, fuzzy
-msgid "Select Image"
-msgstr "全選"
-
-#: source/gx/terminix/prefwindow.d:597 source/gx/terminix/prefwindow.d:604
-#: source/gx/terminix/prefwindow.d:609 source/gx/terminix/prefwindow.d:612
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:618 source/gx/terminix/prefwindow.d:625
-#: source/gx/terminix/prefwindow.d:630 source/gx/terminix/prefwindow.d:633
-#, fuzzy
-msgid "Reset background image"
-msgstr "透明度"
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:624 source/gx/terminix/prefwindow.d:631
-#: source/gx/terminix/prefwindow.d:636 source/gx/terminix/prefwindow.d:639
-msgid "Stretch"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:173 data/resources/ui/shortcuts.ui:179
-msgctxt "shortcut window"
-msgid "Add"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:177 data/resources/ui/shortcuts.ui:183
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal right"
-msgstr "切換到終端 10"
-
-#: data/resources/ui/shortcuts.ui:183 data/resources/ui/shortcuts.ui:189
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Add terminal down"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/prefwindow.d:729 source/gx/terminix/prefwindow.d:736
-#: source/gx/terminix/prefwindow.d:815 source/gx/terminix/prefwindow.d:867
-#: source/gx/terminix/prefwindow.d:879
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:671
-#: source/gx/terminix/terminal/terminal.d:688
-#: source/gx/terminix/terminal/terminal.d:720
-#: source/gx/terminix/terminal/terminal.d:746
-#: source/gx/terminix/terminal/terminal.d:774
-#: source/gx/terminix/terminal/terminal.d:775
-#, fuzzy
-msgid "Add Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/terminal/terminal.d:675
-#: source/gx/terminix/terminal/terminal.d:692
-#: source/gx/terminix/terminal/terminal.d:724
-#: source/gx/terminix/terminal/terminal.d:750
-#: source/gx/terminix/terminal/terminal.d:778
-#: source/gx/terminix/terminal/terminal.d:779
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/application.d:554 source/gx/terminix/application.d:585
-#: source/gx/terminix/application.d:602
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:838
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:263 source/gx/terminix/prefwindow.d:268
-#: source/gx/terminix/prefwindow.d:270
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "快捷鍵"
-
-#: source/gx/terminix/profilewindow.d:853
-#: source/gx/terminix/profilewindow.d:857
-#: source/gx/terminix/profilewindow.d:904
-#: source/gx/terminix/profilewindow.d:982
-#, fuzzy
-msgid "Custom Links"
-msgstr "自訂字型"
-
-#: source/gx/terminix/profilewindow.d:858
-#: source/gx/terminix/profilewindow.d:862
-#: source/gx/terminix/profilewindow.d:909
-#: source/gx/terminix/profilewindow.d:987
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:882
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:919
-#: source/gx/terminix/profilewindow.d:966
-#: source/gx/terminix/profilewindow.d:1044
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1033
-#: source/gx/terminix/profilewindow.d:1081
-#: source/gx/terminix/profilewindow.d:1222
-#: source/gx/terminix/profilewindow.d:1083
-#: source/gx/terminix/profilewindow.d:1224
-#: source/gx/terminix/profilewindow.d:1130
-#: source/gx/terminix/profilewindow.d:1271
-#: source/gx/terminix/profilewindow.d:1208
-#: source/gx/terminix/profilewindow.d:1349
-#, c-format
-msgid "The expression %s is not a valid regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1036
-#: source/gx/terminix/profilewindow.d:1086
-#: source/gx/terminix/profilewindow.d:1227
-#: source/gx/terminix/profilewindow.d:1088
-#: source/gx/terminix/profilewindow.d:1229
-#: source/gx/terminix/profilewindow.d:1135
-#: source/gx/terminix/profilewindow.d:1276
-#: source/gx/terminix/profilewindow.d:1213
-#: source/gx/terminix/profilewindow.d:1354
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1060
-#: source/gx/terminix/profilewindow.d:1110
-#: source/gx/terminix/profilewindow.d:1112
-#: source/gx/terminix/profilewindow.d:1159
-#: source/gx/terminix/profilewindow.d:1237
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1277
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1108
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/profilewindow.d:1150
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1152
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/profilewindow.d:1199
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1277
-#: source/gx/terminix/profilewindow.d:1450
-msgid "Apply"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:479 data/resources/ui/shortcuts.ui:491
-#, fuzzy
-msgctxt "shortcut window"
-msgid "Insert terminal number"
-msgstr "退出此終端"
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:637
-#: source/gx/terminix/terminal/terminal.d:663
-#: source/gx/terminix/terminal/terminal.d:691
-#: source/gx/terminix/terminal/terminal.d:692
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:138
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:233
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:368
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:432
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:440
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:486
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:491
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "執行傳入的指令"
-
-#: source/gx/terminix/application.d:588 source/gx/terminix/application.d:605
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-#: source/gx/terminix/application.d:612
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:594 source/gx/terminix/application.d:595
-msgid "QUAKE"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:175
-msgid ""
-"You cannot use the quake mode with maximize, fullscreen or geometry "
-"parameters"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:883
-#: source/gx/terminix/profilewindow.d:930
-#: source/gx/terminix/profilewindow.d:1008
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:888
-#: source/gx/terminix/profilewindow.d:889
-#: source/gx/terminix/profilewindow.d:936
-#: source/gx/terminix/profilewindow.d:1014
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:915
-#: source/gx/terminix/profilewindow.d:917
-#: source/gx/terminix/profilewindow.d:964
-#: source/gx/terminix/profilewindow.d:1042
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:948
-#: source/gx/terminix/profilewindow.d:950
-#: source/gx/terminix/profilewindow.d:997
-#: source/gx/terminix/profilewindow.d:1075
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:969
-#: source/gx/terminix/profilewindow.d:971
-#: source/gx/terminix/profilewindow.d:1018
-#: source/gx/terminix/profilewindow.d:1096
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1265
-#: source/gx/terminix/profilewindow.d:1267
-#: source/gx/terminix/profilewindow.d:1314
-#: source/gx/terminix/profilewindow.d:1392
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:1323
-#: source/gx/terminix/profilewindow.d:1325
-#: source/gx/terminix/profilewindow.d:1372
-#: source/gx/terminix/profilewindow.d:1450
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "編輯配置檔"
-
-#: source/gx/terminix/preferences.d:176 source/gx/terminix/preferences.d:189
-#: source/gx/terminix/preferences.d:199
-msgid "UpdateState"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:177 source/gx/terminix/preferences.d:190
-#: source/gx/terminix/preferences.d:200
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "指令"
-
-#: source/gx/terminix/preferences.d:178 source/gx/terminix/preferences.d:191
-#: source/gx/terminix/preferences.d:201
-msgid "SendNotification"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:179 source/gx/terminix/preferences.d:192
-#: source/gx/terminix/preferences.d:202
-#, fuzzy
-msgid "UpdateTitle"
-msgstr "標題"
-
-#: source/gx/terminix/preferences.d:180 source/gx/terminix/preferences.d:193
-#: source/gx/terminix/preferences.d:203
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:181 source/gx/terminix/preferences.d:194
-#: source/gx/terminix/preferences.d:204
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:182 source/gx/terminix/preferences.d:195
-#: source/gx/terminix/preferences.d:205
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:93 source/gx/terminix/prefwindow.d:95
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:663 source/gx/terminix/prefwindow.d:676
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:687 source/gx/terminix/prefwindow.d:743
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:694 source/gx/terminix/prefwindow.d:755
-#: source/gx/terminix/prefwindow.d:767
-msgid "Display terminal on primary monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:701 source/gx/terminix/prefwindow.d:762
-#: source/gx/terminix/prefwindow.d:774
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:720
-#, fuzzy
-msgid "Terminal height"
-msgstr "終端標題"
-
-#: source/gx/terminix/prefwindow.d:771 source/gx/terminix/prefwindow.d:818
-#: source/gx/terminix/prefwindow.d:830
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:776 source/gx/terminix/prefwindow.d:823
-#: source/gx/terminix/prefwindow.d:835
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: data/resources/ui/shortcuts.ui:485 data/resources/ui/shortcuts.ui:497
-msgctxt "shortcut window"
-msgid "Insert password"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:83
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:124
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/application.d:590 source/gx/terminix/application.d:607
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/cmdparams.d:159 source/gx/terminix/cmdparams.d:161
-msgid "You can only use the action parameter within Terminix"
-msgstr ""
-
-#: source/gx/terminix/cmdparams.d:178 source/gx/terminix/cmdparams.d:182
-msgid ""
-"You cannot use the quake mode with maximize, minimize, fullscreen or "
-"geometry parameters"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:658
-#, fuzzy
-msgid "Default session name"
-msgstr "切換到會話 1"
-
-#: source/gx/terminix/prefwindow.d:680
-#, fuzzy
-msgid "Show the terminal title even if its the only terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/prefwindow.d:701
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:712
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:723
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:748
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefwindow.d:852 source/gx/terminix/prefwindow.d:864
-msgid "Always use advanced paste dialog"
-msgstr ""
-
 #: data/resources/ui/shortcuts.ui:61
 #, fuzzy
 msgctxt "shortcut window"
 msgid "View session switcher"
 msgstr "顯示側邊列"
 
+#: data/resources/ui/shortcuts.ui:67
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to next session"
+msgstr "切換到會話 10"
+
+#: data/resources/ui/shortcuts.ui:73
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to previous session"
+msgstr "切換到上一個終端"
+
+#: data/resources/ui/shortcuts.ui:79
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 1"
+msgstr "切換到會話 1"
+
+#: data/resources/ui/shortcuts.ui:85
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 2"
+msgstr "切換到會話 2"
+
+#: data/resources/ui/shortcuts.ui:91
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 3"
+msgstr "切換到會話 3"
+
+#: data/resources/ui/shortcuts.ui:97
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 4"
+msgstr "切換到會話 4"
+
+#: data/resources/ui/shortcuts.ui:103
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 5"
+msgstr "切換到會話 5"
+
+#: data/resources/ui/shortcuts.ui:109
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 6"
+msgstr "切換到會話 6"
+
+#: data/resources/ui/shortcuts.ui:115
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 7"
+msgstr "切換到會話 7"
+
+#: data/resources/ui/shortcuts.ui:121
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 8"
+msgstr "切換到會話 8"
+
+#: data/resources/ui/shortcuts.ui:127
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 9"
+msgstr "切換到會話 9"
+
+#: data/resources/ui/shortcuts.ui:133
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to session 10"
+msgstr "切換到會話 10"
+
+#: data/resources/ui/shortcuts.ui:144
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Session"
+msgstr "會話"
+
+#: data/resources/ui/shortcuts.ui:149
+msgctxt "shortcut window"
+msgid "File"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:153
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Close the current session"
+msgstr "開啟指定的會話"
+
+#: data/resources/ui/shortcuts.ui:159
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Save the current session"
+msgstr "開啟指定的會話"
+
+#: data/resources/ui/shortcuts.ui:165
+msgctxt "shortcut window"
+msgid "Save the current session with new filename"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:171
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Open a saved session"
+msgstr "建立會話"
+
+#: data/resources/ui/shortcuts.ui:179
+msgctxt "shortcut window"
+msgid "Add"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:183
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal right"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:189
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Add terminal down"
+msgstr "保持終端開啟"
+
+#: data/resources/ui/shortcuts.ui:197
+msgctxt "shortcut window"
+msgid "Resize"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:201
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal up"
+msgstr "退出此終端"
+
+#: data/resources/ui/shortcuts.ui:207
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal down"
+msgstr "保持終端開啟"
+
+#: data/resources/ui/shortcuts.ui:213
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal left"
+msgstr "退出此終端"
+
+#: data/resources/ui/shortcuts.ui:219
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Resize the terminal right"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:227 data/resources/ui/shortcuts.ui:439
+msgctxt "shortcut window"
+msgid "Other"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:231
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Edit the session name"
+msgstr "切換到會話 1"
+
+#: data/resources/ui/shortcuts.ui:237
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Synchronize the input"
+msgstr "同步輸入"
+
+#: data/resources/ui/shortcuts.ui:245 data/resources/ui/shortcuts.ui:287
+msgctxt "shortcut window"
+msgid "Switch"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:249
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to next terminal"
+msgstr "切換到下一個終端"
+
+#: data/resources/ui/shortcuts.ui:255
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to previous terminal"
+msgstr "切換到上一個終端"
+
+#: data/resources/ui/shortcuts.ui:261
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal up"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:267
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal down"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:273
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal left"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:279
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to the terminal right"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:291
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 1"
+msgstr "切換到終端 1"
+
+#: data/resources/ui/shortcuts.ui:297
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 2"
+msgstr "切換到終端 2"
+
+#: data/resources/ui/shortcuts.ui:303
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 3"
+msgstr "切換到終端 3"
+
+#: data/resources/ui/shortcuts.ui:309
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 4"
+msgstr "切換到終端 4"
+
+#: data/resources/ui/shortcuts.ui:315
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 5"
+msgstr "切換到終端 5"
+
+#: data/resources/ui/shortcuts.ui:321
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 6"
+msgstr "切換到終端 6"
+
+#: data/resources/ui/shortcuts.ui:327
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 7"
+msgstr "切換到終端 7"
+
+#: data/resources/ui/shortcuts.ui:333
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 8"
+msgstr "切換到終端 8"
+
+#: data/resources/ui/shortcuts.ui:339
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 9"
+msgstr "切換到終端 9"
+
+#: data/resources/ui/shortcuts.ui:345
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Switch to terminal 10"
+msgstr "切換到終端 10"
+
+#: data/resources/ui/shortcuts.ui:361 data/resources/ui/shortcuts.ui:365
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find"
+msgstr "查詢…"
+
+#: data/resources/ui/shortcuts.ui:371
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find next"
+msgstr "查詢下一個"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: data/resources/ui/shortcuts.ui:377
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Find previous"
+msgstr "查詢上一個"
+
+#: data/resources/ui/shortcuts.ui:385
+msgctxt "shortcut window"
+msgid "Clipboard"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:389
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Copy"
+msgstr "複製"
+
+#: data/resources/ui/shortcuts.ui:395
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Paste"
+msgstr "貼上"
+
 #: data/resources/ui/shortcuts.ui:401
 msgctxt "shortcut window"
 msgid "Advanced paste"
 msgstr ""
 
-#: source/gx/terminix/application.d:613 source/gx/terminix/application.d:596
-msgid "Show the Terminix and dependant component versions"
+#: data/resources/ui/shortcuts.ui:407
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Select all"
+msgstr "全選"
+
+#: data/resources/ui/shortcuts.ui:415
+msgctxt "shortcut window"
+msgid "Zoom"
 msgstr ""
 
-#: source/gx/terminix/appwindow.d:818 source/gx/terminix/appwindow.d:871
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "仍有正在執行的程序，依然要關閉嗎？"
-
-#: source/gx/terminix/appwindow.d:819 source/gx/terminix/appwindow.d:872
-#, fuzzy
-msgid "Do not show this again"
-msgstr "不再顯示該資訊"
-
-#: source/gx/terminix/profilewindow.d:240
-#: source/gx/terminix/profilewindow.d:507
-#: source/gx/terminix/profilewindow.d:244
-#: source/gx/terminix/profilewindow.d:527
-msgid "Badge"
+#: data/resources/ui/shortcuts.ui:419
+msgctxt "shortcut window"
+msgid "Zoom in"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:249
-#: source/gx/terminix/profilewindow.d:253
-msgid "Badge position"
+#: data/resources/ui/shortcuts.ui:425
+msgctxt "shortcut window"
+msgid "Zoom out"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northwest"
+#: data/resources/ui/shortcuts.ui:431
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Zoom normal size"
+msgstr "正常縮放"
+
+#: data/resources/ui/shortcuts.ui:443
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Save terminal contents"
+msgstr "保持終端開啟"
+
+#: data/resources/ui/shortcuts.ui:449
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Close terminal"
+msgstr "終端"
+
+#: data/resources/ui/shortcuts.ui:455
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Maximize terminal"
+msgstr "退出此終端"
+
+#: data/resources/ui/shortcuts.ui:461
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Current profile preferences"
+msgstr "配置方案偏好設定"
+
+#: data/resources/ui/shortcuts.ui:467
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Reset the terminal"
+msgstr "退出此終端"
+
+#: data/resources/ui/shortcuts.ui:473
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Reset and clear the terminal"
+msgstr "退出此終端"
+
+#: data/resources/ui/shortcuts.ui:479
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Toggle read only"
+msgstr "只讀"
+
+#: data/resources/ui/shortcuts.ui:485
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Layout options"
+msgstr "選項"
+
+#: data/resources/ui/shortcuts.ui:491
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Insert terminal number"
+msgstr "退出此終端"
+
+#: data/resources/ui/shortcuts.ui:497
+msgctxt "shortcut window"
+msgid "Insert password"
 msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/profilewindow.d:253
-#: source/gx/terminix/profilewindow.d:257
-#, fuzzy
-msgid "Southeast"
-msgstr "南歐"
-
-#: source/gx/terminix/profilewindow.d:511
-#: source/gx/terminix/profilewindow.d:531
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/prefwindow.d:753
-msgid "Hide window when focus is lost"
-msgstr ""
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:65
-#, fuzzy
-msgid "Open Remote Terminix…"
-msgstr "使用 Terminix 開啟…"
-
-#: data/nautilus/open-terminix.py:66
-#, fuzzy, python-format
-msgid "Open Remote Terminix In %s"
-msgstr "在 %s 開啟 Terminix"
-
-# ******************
-# Nautilus extension
-# ******************
-#: data/nautilus/open-terminix.py:76
-#, fuzzy
-msgid "Open In Terminix…"
-msgstr "使用 Terminix 開啟…"
-
-#: data/nautilus/open-terminix.py:87
-#, fuzzy
-msgid "Open Remote Terminix Here…"
-msgstr "在此開啟 Terminix…"
-
-#: data/nautilus/open-terminix.py:88
-#, fuzzy
-msgid "Open Remote Terminix In This Directory"
-msgstr "在此目錄開啟 Terminix"
 
 #: data/resources/ui/shortcuts.ui:503
 #, fuzzy
@@ -3959,28 +2109,78 @@ msgctxt "shortcut window"
 msgid "Cycle title style"
 msgstr "終端標題"
 
-#: source/gx/terminix/profilewindow.d:378
-msgid "Export"
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:5
+msgid "A tiling terminal for Gnome"
 msgstr ""
 
-#: source/gx/terminix/profilewindow.d:728
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:11
+msgid "com.gexperts.Terminix"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:9
+msgid "A tiling terminal for GNOME"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:12
+msgid "Terminix is a tiling terminal emulator."
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:15
+msgid "It lets you:"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:17
+msgid ""
+"Layout terminals in any fashion by splitting them horizontally or vertically"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:18
+msgid ""
+"Terminals can be re-arranged using drag and drop both within and between "
+"windows"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:19
+msgid "Terminals can be detached into a new window via drag and drop"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:20
+msgid ""
+"Input can be synchronized between terminals so commands typed in one "
+"terminal are replicated to the others"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:21
+msgid "The grouping of terminals can be saved and loaded from disk"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:22
+msgid "Terminals support custom titles"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:23
+msgid ""
+"Color schemes are stored in files and custom color schemes can be created by "
+"simply creating a new file"
+msgstr ""
+
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:24
 #, fuzzy
-msgid "Export Color Scheme"
-msgstr "配色方案"
+msgid "Transparent background"
+msgstr "透明度"
 
-#: source/gx/terminix/prefwindow.d:767
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:25
 #, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "保持終端開啟"
+msgid "Supports notifications when processes are completed out of view"
+msgstr "程序完成時傳送桌面通知"
 
-#: source/gx/terminix/profilewindow.d:1428
-msgid "Limit number of lines for trigger processing to:"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:27
+msgid ""
+"The application was written using GTK 3 and an effort was made to conform to "
+"GNOME Human Interface Guidelines (HIG). As a result, it does use client-side-"
+"decorations, though it can be disabled if necessary."
 msgstr ""
 
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
+msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""


### PR DESCRIPTION
Now extract-strings.sh updates the pot file so it will contain only existing strings.