### PR TITLE
ldmd2 is another name for ldmd on Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_SUBST([DCFLAGS])
 AC_PROG_INSTALL
 # Look for D compiler. Use dmd-compatible wrapper for ldc and gdc.
 # NOTE: Terminix cannot be compiled with gdc currently.
-AC_PATH_PROGS([DC], [ldmd dmd gdmd], NOT_FOUND)
+AC_PATH_PROGS([DC], [ldmd ldmd2 dmd gdmd], NOT_FOUND)
 AC_PATH_PROG([GLIB_COMPILE_RES], [glib-compile-resources])
 PKG_PROG_PKG_CONFIG
 AM_GNU_GETTEXT([external])
@@ -29,7 +29,7 @@ AM_GNU_GETTEXT_VERSION([0.19.7])
 DC_SUFFIX=
 case $(basename $DC) in
 	dmd) DC_SUFFIX=-dmd ;;
-	ldmd) DC_SUFFIX=-ldc ;;
+	ldmd,ldmd2) DC_SUFFIX=-ldc ;;
 	gdmd) DC_SUFFIX=-gdc ;;
 	NOT_FOUND) AC_MSG_ERROR(Could not find any compatible D compiler, 1)
 esac


### PR DESCRIPTION
When downloading dmd for Debian from [here](https://dlang.org/download.html#dmd), the .deb install a binary called `/usr/bin/ldmd2` (instead of the expected `ldmd`).