### PR TITLE
Fix build errors

### DIFF
--- a/source/gx/terminix/terminal/exvte.d
+++ b/source/gx/terminix/terminal/exvte.d
@@ -77,7 +77,7 @@ public:
 	 *     summary = The summary
 	 *     bod = Extra optional text
 	 */
-	gulong addOnNotificationReceived(void delegate(string, string, Terminal) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	ulong addOnNotificationReceived(void delegate(string, string, Terminal) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
 		onNotificationReceivedListeners ~= new OnNotificationReceivedDelegateWrapper(dlg, 0, connectFlags);
 		onNotificationReceivedListeners[onNotificationReceivedListeners.length - 1].handlerId = Signals.connectData(
@@ -128,7 +128,7 @@ public:
 	protected OnTerminalScreenChangedDelegateWrapper[] onTerminalScreenChangedListeners;
 
 	/** */
-	gulong addOnTerminalScreenChanged(void delegate(int, Terminal) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	ulong addOnTerminalScreenChanged(void delegate(int, Terminal) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
 		onTerminalScreenChangedListeners ~= new OnTerminalScreenChangedDelegateWrapper(dlg, 0, connectFlags);
 		onTerminalScreenChangedListeners[onTerminalScreenChangedListeners.length - 1].handlerId = Signals.connectData(


### PR DESCRIPTION
```
source/gx/terminix/terminal/exvte.d(90): Error: cannot implicitly convert expression (this.onNotificationReceivedListeners[this.onNotificationReceivedListeners.length - 1u].handlerId) of type ulong to uint
source/gx/terminix/terminal/exvte.d(141): Error: cannot implicitly convert expression (this.onTerminalScreenChangedListeners[this.onTerminalScreenChangedListeners.length - 1u].handlerId) of type ulong to uint
```