### PR TITLE
rpmlint warning for missing shebang

### DIFF
--- a/data/scripts/terminix_int.sh
+++ b/data/scripts/terminix_int.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Adapted from vte.sh script, copyright notice from that ensues:
 
 # Copyright © 2006 Shaun McCance <shaunm@gnome.org>


### PR DESCRIPTION
This bash script is missing a shebang and is getting a warning from rpmlint report when build terminix as rpm package on OBS (http://build.opensuse.org).