### PR TITLE
Add Nautilus shortcut, fixes #672

### DIFF
--- a/data/gsettings/com.gexperts.Terminix.gschema.xml
+++ b/data/gsettings/com.gexperts.Terminix.gschema.xml
@@ -1046,5 +1046,10 @@
       <default>'disabled'</default>
       <summary>Keyboard shortcut to cycle the terminal title styles</summary>
     </key>
+    <!-- Nautilus Shortcut for Open in Terminix -->
+    <key name="nautilus-open" type="s">
+      <default>'&lt;Ctrl&gt;z'</default>
+      <summary>Keyboard shortcut used in Nautilus for Open Here extension</summary>
+    </key>
   </schema>
 </schemalist>

--- a/data/gsettings/com.gexperts.Terminix.gschema.xml
+++ b/data/gsettings/com.gexperts.Terminix.gschema.xml
@@ -1048,7 +1048,7 @@
     </key>
     <!-- Nautilus Shortcut for Open in Terminix -->
     <key name="nautilus-open" type="s">
-      <default>'&lt;Ctrl&gt;z'</default>
+      <default>'&lt;Ctrl&gt;&lt;Shift&gt;t'</default>
       <summary>Keyboard shortcut used in Nautilus for Open Here extension</summary>
     </key>
   </schema>

--- a/data/nautilus/open-terminix.py
+++ b/data/nautilus/open-terminix.py
@@ -2,90 +2,120 @@
 
 # This example is contributed by Martin Enlund
 # Example modified for Terminix
-import os
-import urllib
-from urlparse import urlparse
-
+# Shortcuts Provider was inspired by captain nemo extension
 import gettext
+from urllib import unquote
+
+from subprocess import PIPE, call
+from urlparse import urlparse
 gettext.textdomain("terminix")
 _ = gettext.gettext
 
-import gi
+from gi import require_version
 
-gi.require_version('Nautilus', '3.0')
+require_version('Gtk', '3.0')
+require_version('Nautilus', '3.0')
 
-from gi.repository import Nautilus, GObject, Gio
+from gi.repository import GObject, Gdk, Gio, Gtk, Nautilus
+
+TERMINAL = "terminix"
+IS_INSTALLED = bool(call(['which', TERMINAL], stdout=PIPE, stderr=PIPE) == 0)
+
+
+def open_terminl_in_file(filename):
+    if filename:
+        call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
+    else:
+        call("{0} &".format(TERMINAL), shell=True)
+
+
+class OpenTerminixShortcutProvider(GObject.GObject, Nautilus.LocationWidgetProvider):
+    def __init__(self):
+        self.accel_group = Gtk.AccelGroup()
+        if IS_INSTALLED:
+            self.accel_group.connect(ord('z'), Gdk.ModifierType.CONTROL_MASK,
+                Gtk.AccelFlags.VISIBLE, self._open_terminal)
+        self.window = None
+        self.uri = None
+
+    def _open_terminal(self, *args):
+        filename = unquote(self.uri[7:])
+        open_terminl_in_file(filename)
+
+    def get_widget(self, uri, window):
+        self.uri = uri
+        if self.window:
+            self.window.remove_accel_group(self.accel_group)
+        window.add_accel_group(self.accel_group)
+        self.window = window
+        return None
 
 class OpenTerminixExtension(GObject.GObject, Nautilus.MenuProvider):
 
-    def __init__(self):
-        self.terminal = 'terminix'
-
     def _open_terminal(self, file):
-        if file.get_uri_scheme() in ['ftp','sftp']:
+        if file.get_uri_scheme() in ['ftp', 'sftp']:
             result = urlparse(file.get_uri())
             if result.username:
-                value = 'ssh -t %s@%s' % (result.username, result.hostname)
+                value = 'ssh -t {0}@{1}'.format(result.username, result.hostname)
             else:
-                value = 'ssh -t %s' % (result.hostname)
+                value = 'ssh -t {0}'.format(result.hostname)
             if result.port:
-                value = value + " -p " + result.port
+                value = "{0} -p {1}".format(value, result.port)
             if file.is_directory():
-                value = value + " cd \"%s\" ; $SHELL" % (result.path)
+                value = '{0} cd "{1}" ; $SHELL'.format(value, result.path)
 
-            os.system('%s -e "%s" &' % (self.terminal, value))
-        else:            
+            call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
+        else:
             gfile = Gio.File.new_for_uri(file.get_uri())
             filename = gfile.get_path()
-            if filename is None:
-                os.system('%s &' % (self.terminal))
-            else:
-                os.system('%s -w "%s" &' % (self.terminal, filename))
-    
+            open_terminl_in_file(filename)
+
     def menu_activate_cb(self, menu, file):
         self._open_terminal(file)
 
     def menu_background_activate_cb(self, menu, file):
-
         self._open_terminal(file)
 
     def get_file_items(self, window, files):
         if len(files) != 1:
-            print "Number of files is %d" % len(files) 
+            print("Number of files is %d" % len(files))
             return
         items = []
         file = files[0]
-        print "Handling file: ", file.get_uri()
-        print "file scheme: ", file.get_uri_scheme()
+        print("Handling file: ", file.get_uri())
+        print("file scheme: ", file.get_uri_scheme())
 
-        if file.is_directory(): #and file.get_uri_scheme() == 'file':
+        if file.is_directory():  # and file.get_uri_scheme() == 'file':
 
-            if file.get_uri_scheme() in ['ftp','sftp']:
+            if file.get_uri_scheme() in ['ftp', 'sftp']:
                 item = Nautilus.MenuItem(name='NautilusPython::openterminal_remote_item',
-                                        label=_(u'Open Remote Terminix'),
-                                        tip=_(u'Open Remote Terminix In %s') % file.get_uri())
+                                         label=_(u'Open Remote Terminix'),
+                                         tip=_(u'Open Remote Terminix In %s') % file.get_uri())
                 item.connect('activate', self.menu_activate_cb, file)
                 items.append(item)
 
             gfile = Gio.File.new_for_uri(file.get_uri())
-            info = gfile.query_info("standard::*", Gio.FileQueryInfoFlags.NONE, None)
+            info = gfile.query_info(
+                "standard::*", Gio.FileQueryInfoFlags.NONE, None)
             # Get UTF-8 version of basename
             filename = info.get_attribute_as_string("standard::name")
 
             item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                    label=_(u'Open In Terminix'),
-                                    tip=_(u'Open Terminix In %s') % filename)
+                                     label=_(u'Open In Terminix'),
+                                     tip=_(u'Open Terminix In %s') % filename)
             item.connect('activate', self.menu_activate_cb, file)
             items.append(item)
 
+        if not IS_INSTALLED:
+            items = []
         return items
 
     def get_background_items(self, window, file):
         items = []
-        if file.get_uri_scheme() in ['ftp','sftp']:
+        if file.get_uri_scheme() in ['ftp', 'sftp']:
             item = Nautilus.MenuItem(name='NautilusPython::openterminal_bg_remote_item',
-                                    label=_(u'Open Remote Terminix Here'),
-                                    tip=_(u'Open Remote Terminix In This Directory'))
+                                     label=_(u'Open Remote Terminix Here'),
+                                     tip=_(u'Open Remote Terminix In This Directory'))
             item.connect('activate', self.menu_activate_cb, file)
             items.append(item)
 
@@ -94,4 +124,7 @@ class OpenTerminixExtension(GObject.GObject, Nautilus.MenuProvider):
                                  tip=_(u'Open Terminix In This Directory'))
         item.connect('activate', self.menu_background_activate_cb, file)
         items.append(item)
+
+        if not IS_INSTALLED:
+            items = []
         return items

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -507,5 +507,25 @@
         </child>
       </object>
     </child>
+    <child>
+      <object class="GtkShortcutsSection">
+        <property name="visible">1</property>
+        <property name="section-name">nautilus</property>
+        <property name="title" translatable="yes" context="shortcut window">Nautilus</property>
+        <property name="max-height">12</property>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">1</property>
+            <property name="title" translatable="yes" context="shortcut window">Open</property>
+            <child>
+              <object class="GtkShortcutsShortcut" id ="nautilus-open">
+                <property name="visible">1</property>
+                <property name="title" translatable="yes" context="shortcut window">Open in Terminix</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
   </object>
 </interface>

--- a/source/gx/terminix/prefeditor/prefdialog.d
+++ b/source/gx/terminix/prefeditor/prefdialog.d
@@ -719,6 +719,7 @@ private:
             TreeIterRange shortcutRange = TreeIterRange(tsShortcuts, categoryIter);
             foreach(TreeIter iter; shortcutRange) {
                 string currentActionName = tsShortcuts.getValueString(iter, COLUMN_ACTION_NAME);
+                if (currentActionName.startsWith("nautilus")) continue;
                 if (currentActionName.length > 0 && currentActionName != actionName) {
                     if (tsShortcuts.getValueString(iter, COLUMN_SHORTCUT) == accelLabel) {
                         MessageDialog dlg = new MessageDialog(cast(Window) this.getToplevel(), DialogFlags.MODAL, MessageType.QUESTION, ButtonsType.OK_CANCEL, null, null);

--- a/source/gx/terminix/prefeditor/prefdialog.d
+++ b/source/gx/terminix/prefeditor/prefdialog.d
@@ -709,6 +709,9 @@ private:
      * Check if shortcut is already assigned and if so disable it
      */
     bool checkAndPromptChangeShortcut(string actionName, string accelName, string accelLabel) {
+        // Do not check if accel is already used for nautilus shortcuts
+        if (actionName.startsWith("nautilus")) return true;
+
         //Get first level, shortcut categories (i.e. Application, Window, Session or Terminal)
         TreeIterRange categoryRange = TreeIterRange(tsShortcuts);
         foreach(TreeIter categoryIter; categoryRange) {
@@ -787,6 +790,7 @@ private:
             prefixes["app"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Application");
             prefixes["terminal"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Terminal");
             prefixes["session"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Session");
+            prefixes["nautilus"] = C_(SHORTCUT_LOCALIZATION_CONTEXT, "Nautilus");
         } catch (XMLException e) {
             error("Failed to parse shortcuts.ui", e);
         }


### PR DESCRIPTION
Some code of the extension was still using Python2, modified that. Fixed some stuff and imported only needed libraries/functions.
The current shortcut is CTRL + Z
I opened this PR in order to see if it's possible to add a new configuration for that in Terminix itself, so I can change that to use the configured shortcut from DConf directly.  Or just if anyone has a better proposal 

Here's a small video that shows how it works
https://youtu.be/Sxi_8UggqGY

PS: works only with directories. FTP and SFTP are not supported (maybe it's possible) i will try to investigate more and push a fix in the future! 
