### PR TITLE
Add missing context field

### DIFF
--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -353,7 +353,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>
         <property name="section-name">terminal</property>
-        <property name="title" translatable="yes">Terminal</property>
+        <property name="title" translatable="yes" context="shortcut window">Terminal</property>
         <property name="max-height">12</property>
         <child>
           <object class="GtkShortcutsGroup">


### PR DESCRIPTION
I guess this could be the reason why "Terminal" is not translated under Preferences -> Shortcuts.