### PR TITLE
Allow localizing manpages

### DIFF
--- a/data/man/po/de.man.po
+++ b/data/man/po/de.man.po
@@ -1,0 +1,375 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2017-01-31 23:37+0100\n"
+"PO-Revision-Date: 2017-01-31 23:23+0100\n"
+"Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.11\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: TH
+#: data/man/terminix:3
+#, no-wrap
+msgid "TERMINIX"
+msgstr "TERMINIX"
+
+#. type: TH
+#: data/man/terminix:3
+#, no-wrap
+msgid "26 December 2016"
+msgstr "26. Dezember 2016"
+
+#. type: TH
+#: data/man/terminix:3
+#, no-wrap
+msgid "1.4.0"
+msgstr "1.4.0"
+
+#. type: TH
+#: data/man/terminix:3
+#, no-wrap
+msgid "Terminix Commands"
+msgstr "Terminix Befehle"
+
+#. type: SH
+#: data/man/terminix:4
+#, no-wrap
+msgid "NAME"
+msgstr "NAME"
+
+#. type: Plain text
+#: data/man/terminix:6
+msgid "B<terminix> - Tiling GTK3 terminal emulator for GNOME"
+msgstr "B<terminix> - GTK3-Terminal-Emulator mit Kacheldarstellung für GNOME"
+
+#. type: SH
+#: data/man/terminix:6
+#, no-wrap
+msgid "SYNOPSIS"
+msgstr "ÜBERSICHT"
+
+#. type: Plain text
+#: data/man/terminix:9
+msgid "B<terminix> [I<options>]"
+msgstr "B<terminix> [I<Optionen>]"
+
+#. type: SH
+#: data/man/terminix:9
+#, no-wrap
+msgid "DESCRIPTION"
+msgstr "BESCHREIBUNG"
+
+#. type: Plain text
+#: data/man/terminix:11
+msgid ""
+"B<terminix> is an advanced GTK3 tiling terminal emulator designed to adhere "
+"to Gnome Human Interface Guidelines."
+msgstr ""
+"B<terminix> ist ein moderner GTK3-Terminal-Emulator, der sich an die Gnome "
+"Human Interface-Richtlinien hält."
+
+#. type: SH
+#: data/man/terminix:11
+#, no-wrap
+msgid "OPTIONS"
+msgstr "OPTIONEN"
+
+#. type: Plain text
+#: data/man/terminix:13
+msgid ""
+"The B<terminix> application accepts the following command line parameters:"
+msgstr ""
+"Die B<terminix>-Anwendung akzeptiert die folgenden Kommandozeilenparameter:"
+
+#. type: TP
+#: data/man/terminix:13
+#, no-wrap
+msgid "B<-h --help>"
+msgstr "B<-h --help>"
+
+#. type: Plain text
+#: data/man/terminix:16
+msgid "Show help options."
+msgstr "Hilfeoptionen anzeigen."
+
+#. type: TP
+#: data/man/terminix:16
+#, no-wrap
+msgid "B<-v --version>"
+msgstr "B<-v --version>"
+
+#. type: Plain text
+#: data/man/terminix:19
+msgid ""
+"Show the version of Terminix as well as the versions of dependent components."
+msgstr "Versionsnummern von Terminix und abhängigen Komponenten anzeigen."
+
+#. type: TP
+#: data/man/terminix:19
+#, no-wrap
+msgid "B<-w --working-directory=DIRECTORY>"
+msgstr "B<-w --working-directory=ORDNER>"
+
+#. type: Plain text
+#: data/man/terminix:22
+msgid "Set the working directory of the terminal."
+msgstr "Arbeitsordner des Terminals wählen."
+
+#. type: TP
+#: data/man/terminix:22
+#, no-wrap
+msgid "B<-p --profile=PROFILE_NAME>"
+msgstr "B<-p --profile=PROFIL_NAME>"
+
+#. type: Plain text
+#: data/man/terminix:25
+msgid ""
+"Set the starting profile using the name of one of the existing profiles. If "
+"a name is passed that does not correspond to an existing profile, the "
+"default profile will be used."
+msgstr ""
+"Setzt das Startprofil durch Angabe des Namens eines vorhandenen Profils. "
+"Wenn ein Name angegeben wird, für den kein passendes Profil existiert, wird "
+"das Standardprofil verwendet."
+
+#. type: TP
+#: data/man/terminix:25
+#, no-wrap
+msgid "B<-t --title=TITLE>"
+msgstr "B<-t --title=TITEL>"
+
+#. type: Plain text
+#: data/man/terminix:28
+msgid "Set the title of the new terminal."
+msgstr "Titel des neuen Terminals setzen."
+
+#. type: TP
+#: data/man/terminix:28
+#, no-wrap
+msgid "B<-s --session=SESSION_NAME>"
+msgstr "B<-s --session=SESSION_NAME>"
+
+#. type: Plain text
+#: data/man/terminix:31
+msgid ""
+"Open the specified session file which has been previously saved. Session "
+"files are saved from within Terminix, they store the complete layout of the "
+"session enabling the user to re-load it when required. Note that only the "
+"layout and layout options are saved, this will not restore the terminal to "
+"where it was left off, rather new terminals are created."
+msgstr ""
+"Öffnet die angegebene Sitzungs-Datei, welche zuvor gespeichert wurde. "
+"Sitzungs-Dateien werden aus Terminix heraus gespeichert. Sie speichern das "
+"gesamte Layout der Sitzung und ermöglichen dem Anwender dadurch die Sitzung "
+"bei Bedarf wieder zu laden. Beachten Sie, dass nur das Layout und die Layout-"
+"Optionen gespeichert werden. Diese Option stellt die Terminals nicht wieder "
+"in dem Zustand her, in dem sie verlassen wurden, stattdessen werden neue "
+"Terminals geöffnet."
+
+#. type: TP
+#: data/man/terminix:31
+#, no-wrap
+msgid "B<-a --action=ACTION_NAME>"
+msgstr "B<-a --action=AKTIONS_NAME>"
+
+#. type: Plain text
+#: data/man/terminix:34
+msgid ""
+"Perform an action in the current Terminix instance, the following actions "
+"are supported:"
+msgstr ""
+"Eine Aktion in der aktuellen Terminix-Instanz ausführen. Die folgenden "
+"Aktionen werden unterstützt:"
+
+#. type: Plain text
+#: data/man/terminix:37
+msgid ""
+"B<session-add-right> Adds a new terminal to the right of the current "
+"terminal."
+msgstr ""
+"B<session-add-right> Fügt ein neues Terminal rechts vom aktuellen Terminal "
+"ein."
+
+#. type: Plain text
+#: data/man/terminix:40
+msgid "B<session-add-down> Adds a new terminal down from the current terminal."
+msgstr ""
+"B<session-add-down> Fügt ein neues Terminal unterhalb des aktuellen "
+"Terminals ein."
+
+#. type: Plain text
+#: data/man/terminix:43
+msgid ""
+"B<app-new-session> Creates a new Terminix session within the current window."
+msgstr ""
+"B<app-new-session> Eine neue Terminix-Sitzung im aktuellen Fenster öffnen."
+
+#. type: Plain text
+#: data/man/terminix:46
+msgid "B<app-new-window> Creates a new Terminix window."
+msgstr "B<app-new-window> Ein neues Terminix-Fenster öffnen"
+
+#. type: TP
+#: data/man/terminix:46
+#, no-wrap
+msgid "B<-e --command=COMMAND>"
+msgstr "B<-e --command=BEFEHL>"
+
+#. type: Plain text
+#: data/man/terminix:49
+msgid ""
+"Execute all text after this parameter as a command, thus this parameter must "
+"be the last parameter."
+msgstr ""
+"Führe allen Text nach diesem Parameter als Kommando aus. Dieser Parameter "
+"muss daher als letzter Parameter angegeben werden."
+
+#. type: TP
+#: data/man/terminix:49
+#, no-wrap
+msgid "B<--maximize>"
+msgstr "B<--maximize>"
+
+#. type: Plain text
+#: data/man/terminix:52
+msgid "Maximize the terminal window."
+msgstr "Terminalfenster maximieren."
+
+#. type: TP
+#: data/man/terminix:52
+#, no-wrap
+msgid "B<--minimize>"
+msgstr "B<--minimize>"
+
+#. type: Plain text
+#: data/man/terminix:55
+msgid "Minimize the terminal window."
+msgstr "Terminalfenster minimieren."
+
+#. type: TP
+#: data/man/terminix:55
+#, no-wrap
+msgid "B<--full-screen>"
+msgstr "B<--full-screen>"
+
+#. type: Plain text
+#: data/man/terminix:58
+msgid "Full-screen the terminal window."
+msgstr "Terminalfenster im Vollbildmodus anzeigen."
+
+#. type: TP
+#: data/man/terminix:58
+#, no-wrap
+msgid "B<--focus-window>"
+msgstr "B<--focus-window>"
+
+#. type: Plain text
+#: data/man/terminix:61
+msgid "Focus the existing window."
+msgstr "Vorhandenes Fenster fokussieren."
+
+#. type: TP
+#: data/man/terminix:61
+#, no-wrap
+msgid "B<--new-process>"
+msgstr "B<--new-process>"
+
+#. type: Plain text
+#: data/man/terminix:64
+msgid ""
+"Start an additional Terminix instance as a new process. By default and as "
+"per GTK+ 3 guidelines, Terminix maintains a single process that all windows "
+"belong to. This option forces Terminix to start as a separate process. This "
+"is not recommended and is intended for debugging purposes only, using this "
+"option will prevent different Terminix windows from communicating with each "
+"other."
+msgstr ""
+"Starte eine zusätzliche Terminix-Instanz in einem neuen Prozess. "
+"Standardmäßig folgt Terminix den GTK+ 3-Richtlinien und läuft in einem "
+"einzelnen Prozess, zu dem alle Fenster gehören. Diese Option zwingt Terminix "
+"dazu einen separaten Prozess zu starten. Das wird nicht empfohlen und ist "
+"lediglich für die Fehlersuche gedacht. Die Verwendung dieser Option "
+"verhindert, dass verschiedene Terminix-Fenster untereinander kommunizieren "
+"können."
+
+#. type: TP
+#: data/man/terminix:64
+#, no-wrap
+msgid "B<--geometry=GEOMETRY>"
+msgstr "B<--geometry=GEOMETRIE>"
+
+#. type: Plain text
+#: data/man/terminix:67
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)."
+msgstr ""
+"Fenstergröße festlegen; Beispiel: 80x24, oder 80x24+200+200 (SPALTENxZEILEN+X"
+"+Y)."
+
+#. type: TP
+#: data/man/terminix:67
+#, no-wrap
+msgid "B<-q --quake>"
+msgstr "B<-q --quake>"
+
+#. type: Plain text
+#: data/man/terminix:70
+msgid ""
+"Open a window in quake mode or toggle existing quake mode window visibility."
+msgstr ""
+"Öffnet ein Fenster im Quake-Modus oder schaltet die Sichtbarkeit eines "
+"vorhandenen Fensters im Quake-Modus um."
+
+#. type: TP
+#: data/man/terminix:70
+#, no-wrap
+msgid "B<--preferences>"
+msgstr "B<--preferences>"
+
+#. type: Plain text
+#: data/man/terminix:73
+msgid "Show the Terminix preferences dialog directly."
+msgstr "Terminix-Einstellungsdialog direkt anzeigen."
+
+#. type: SH
+#: data/man/terminix:73
+#, no-wrap
+msgid "SEE ALSO"
+msgstr "SIEHE AUCH"
+
+#. type: Plain text
+#: data/man/terminix:75
+msgid "None"
+msgstr "Keine"
+
+#. type: SH
+#: data/man/terminix:75
+#, no-wrap
+msgid "BUGS"
+msgstr "FEHLER"
+
+#. type: Plain text
+#: data/man/terminix:77
+msgid "See bugs at https://github.com/gnunn1/terminix/issues"
+msgstr "Siehe Fehler auf https://github.com/gnunn1/terminix/issues"
+
+#. type: SH
+#: data/man/terminix:77
+#, no-wrap
+msgid "AUTHOR"
+msgstr "AUTOR"
+
+#. type: Plain text
+#: data/man/terminix:78
+msgid "Gerald Nunn and other contributors."
+msgstr "Gerald Nunn und weitere Mitwirkende."

--- a/data/man/po/terminix.man.pot
+++ b/data/man/po/terminix.man.pot
@@ -1,0 +1,338 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2017-01-31 23:37+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: TH
+#: ./data/man/terminix:3
+#, no-wrap
+msgid "TERMINIX"
+msgstr ""
+
+#. type: TH
+#: ./data/man/terminix:3
+#, no-wrap
+msgid "26 December 2016"
+msgstr ""
+
+#. type: TH
+#: ./data/man/terminix:3
+#, no-wrap
+msgid "1.4.0"
+msgstr ""
+
+#. type: TH
+#: ./data/man/terminix:3
+#, no-wrap
+msgid "Terminix Commands"
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:4
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:6
+msgid "B<terminix> - Tiling GTK3 terminal emulator for GNOME"
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:6
+#, no-wrap
+msgid "SYNOPSIS"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:9
+msgid "B<terminix> [I<options>]"
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:9
+#, no-wrap
+msgid "DESCRIPTION"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:11
+msgid ""
+"B<terminix> is an advanced GTK3 tiling terminal emulator designed to adhere "
+"to Gnome Human Interface Guidelines."
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:11
+#, no-wrap
+msgid "OPTIONS"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:13
+msgid "The B<terminix> application accepts the following command line parameters:"
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:13
+#, no-wrap
+msgid "B<-h --help>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:16
+msgid "Show help options."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:16
+#, no-wrap
+msgid "B<-v --version>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:19
+msgid ""
+"Show the version of Terminix as well as the versions of dependent "
+"components."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:19
+#, no-wrap
+msgid "B<-w --working-directory=DIRECTORY>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:22
+msgid "Set the working directory of the terminal."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:22
+#, no-wrap
+msgid "B<-p --profile=PROFILE_NAME>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:25
+msgid ""
+"Set the starting profile using the name of one of the existing profiles. If "
+"a name is passed that does not correspond to an existing profile, the "
+"default profile will be used."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:25
+#, no-wrap
+msgid "B<-t --title=TITLE>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:28
+msgid "Set the title of the new terminal."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:28
+#, no-wrap
+msgid "B<-s --session=SESSION_NAME>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:31
+msgid ""
+"Open the specified session file which has been previously saved. Session "
+"files are saved from within Terminix, they store the complete layout of the "
+"session enabling the user to re-load it when required. Note that only the "
+"layout and layout options are saved, this will not restore the terminal to "
+"where it was left off, rather new terminals are created."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:31
+#, no-wrap
+msgid "B<-a --action=ACTION_NAME>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:34
+msgid ""
+"Perform an action in the current Terminix instance, the following actions "
+"are supported:"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:37
+msgid ""
+"B<session-add-right> Adds a new terminal to the right of the current "
+"terminal."
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:40
+msgid "B<session-add-down> Adds a new terminal down from the current terminal."
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:43
+msgid "B<app-new-session> Creates a new Terminix session within the current window."
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:46
+msgid "B<app-new-window> Creates a new Terminix window."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:46
+#, no-wrap
+msgid "B<-e --command=COMMAND>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:49
+msgid ""
+"Execute all text after this parameter as a command, thus this parameter must "
+"be the last parameter."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:49
+#, no-wrap
+msgid "B<--maximize>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:52
+msgid "Maximize the terminal window."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:52
+#, no-wrap
+msgid "B<--minimize>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:55
+msgid "Minimize the terminal window."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:55
+#, no-wrap
+msgid "B<--full-screen>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:58
+msgid "Full-screen the terminal window."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:58
+#, no-wrap
+msgid "B<--focus-window>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:61
+msgid "Focus the existing window."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:61
+#, no-wrap
+msgid "B<--new-process>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:64
+msgid ""
+"Start an additional Terminix instance as a new process. By default and as "
+"per GTK+ 3 guidelines, Terminix maintains a single process that all windows "
+"belong to. This option forces Terminix to start as a separate process. This "
+"is not recommended and is intended for debugging purposes only, using this "
+"option will prevent different Terminix windows from communicating with each "
+"other."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:64
+#, no-wrap
+msgid "B<--geometry=GEOMETRY>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:67
+msgid "Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:67
+#, no-wrap
+msgid "B<-q --quake>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:70
+msgid "Open a window in quake mode or toggle existing quake mode window visibility."
+msgstr ""
+
+#. type: TP
+#: ./data/man/terminix:70
+#, no-wrap
+msgid "B<--preferences>"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:73
+msgid "Show the Terminix preferences dialog directly."
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:73
+#, no-wrap
+msgid "SEE ALSO"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:75
+msgid "None"
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:75
+#, no-wrap
+msgid "BUGS"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:77
+msgid "See bugs at https://github.com/gnunn1/terminix/issues"
+msgstr ""
+
+#. type: SH
+#: ./data/man/terminix:77
+#, no-wrap
+msgid "AUTHOR"
+msgstr ""
+
+#. type: Plain text
+#: ./data/man/terminix:78
+msgid "Gerald Nunn and other contributors."
+msgstr ""

--- a/extract-strings.sh
+++ b/extract-strings.sh
@@ -57,3 +57,10 @@ do
   echo -n $file
   msgmerge --update $file $OUTPUT_FILE
 done
+
+# Update manpage translations
+if type po4a-updatepo >/dev/null 2>&1; then
+  MANDIR=${BASEDIR}/data/man
+  po4a-gettextize -f man -m ${MANDIR}/terminix -p ${MANDIR}/po/terminix.man.pot
+  po4a-updatepo -f man -m ${MANDIR}/terminix -p ${MANDIR}/po/*.man.po
+fi

--- a/install.sh
+++ b/install.sh
@@ -105,9 +105,20 @@ install -d ${PREFIX}/share/dbus-1/services
 install -m 644 data/dbus/com.gexperts.Terminix.service ${PREFIX}/share/dbus-1/services/
 
 # Copy man page
+echo "Installing man pages"
 install -d ${PREFIX}/share/man/man1
 install -m 644 data/man/terminix ${PREFIX}/share/man/man1/terminix.1
-gzip -f /usr/share/man/man1/terminix.1
+gzip -f ${PREFIX}/share/man/man1/terminix.1
+
+if type po4a-translate >/dev/null 2>&1; then
+    for f in data/man/po/*.man.po
+    do
+        LOCALE=$(basename "$f" .man.po)
+        install -d ${PREFIX}/share/man/${LOCALE}/man1
+        po4a-translate -f man -m data/man/terminix -p data/man/po/${LOCALE}.man.po -l ${PREFIX}/share/man/${LOCALE}/man1/terminix.1
+        gzip -f ${PREFIX}/share/man/${LOCALE}/man1/terminix.1
+    done
+fi
 
 # Copy Icons
 cd data/icons/hicolor

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -25,3 +25,5 @@ rm ${PREFIX}/share/nautilus-python/extensions/open-terminix.py
 rm ${PREFIX}/share/dbus-1/services/com.gexperts.Terminix.service
 rm ${PREFIX}/share/applications/com.gexperts.Terminix.desktop
 rm ${PREFIX}/share/metainfo/com.gexperts.Terminix.appdata.xml
+rm ${PREFIX}/share/man/man1/terminix.1.gz
+rm ${PREFIX}/share/man/*/man1/terminix.1.gz


### PR DESCRIPTION
Fixes #713 

This enables translation of manpages using po4a. [po4a](https://po4a.alioth.debian.org/) is required, however without po4a the install scripts will still work, it will just ignore manpage localization.

The process is as follows:

1. On changes to the manpage `extract-strings.sh` should be run. This was extended to also update the manpage translation template and translations in `data/man/po`
2. To translate into a new language just use `data/man/po/terminix.man.pot` to create a new PO file, name it `data/man/po/[locale].man.pot` (a German translation is included here as an example)
3. On installation `install.sh` will use the translations to place translated manpages in `share/man/[locale]/man1`

Once this is merged we should see to get this into Weblate also. I think we will have to ask Michal  from Weblate to add a new component for the manpage resources to the Terminix Weblate project.