### PR TITLE
Fix Quake mode activation

### DIFF
--- a/source/gx/terminix/application.d
+++ b/source/gx/terminix/application.d
@@ -399,7 +399,7 @@ private:
                 }
             } if (cp.preferences) {
                 presentPreferences();
-            } else {
+            } else if (!cp.quake) {
                 AppWindow aw = getActiveAppWindow();
                 if (aw !is null) {
                     string instanceAction = gsGeneral.getString(SETTINGS_NEW_INSTANCE_MODE_KEY);


### PR DESCRIPTION
Fixes Quake mode activation when "On new instance" is set to "Focus Window" and a standard terminal window is opened before Quake mode is activated.

This seems to fix #749 for me but probably requires a further sanity check.