### PR TITLE
Translator credits

### DIFF
--- a/extract-strings.sh
+++ b/extract-strings.sh
@@ -13,7 +13,8 @@ find ${BASEDIR}/source -name '*.d' | xgettext \
   --directory=$BASEDIR \
   --language=Vala \
   --keyword=C_:1c,2 \
-  --from-code=utf-8
+  --from-code=utf-8 \
+  --add-comments=TRANSLATORS
 
 xgettext \
   --join-existing \

--- a/po/bg.po
+++ b/po/bg.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-08 19:13+0000\n"
 "Last-Translator: Ivaylo Kuzev <ivkuzev@gmail.com>\n"
-"Language-Team: Bulgarian "
-"<https://hosted.weblate.org/projects/terminix/translations/bg/>\n"
+"Language-Team: Bulgarian <https://hosted.weblate.org/projects/terminix/"
+"translations/bg/>\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,177 +18,1590 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.12-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "Вашата версия на GTK е твърде стара, трябва ви минимум %d.%d.%d!"
-
-#: source/app.d:127
-msgid "Unexpected exception occurred"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Грешка: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Версии"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Версия Terminix: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Версия VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "GTK Версия: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Специални възможности Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Известия включени=%b"
-
-#: source/app.d:144
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Triggers enabled=%b"
-msgstr "Триггер включен=%b"
+msgid "ExecuteCommand"
+msgstr "Команда"
 
-#: source/app.d:145
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
 #, fuzzy
-msgid "Badges enabled=%b"
-msgstr "Значки включени=%b"
+msgid "UpdateTitle"
+msgstr "Заглавие"
 
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "изключено"
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Изберете Папка"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Изберете папка"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Изчистете папка"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Добавете отметка"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Редактирайте отметка"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Добре"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Отменете"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Име"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
+#: source/gx/terminix/preferences.d:217
 #, fuzzy
-msgid "Path"
-msgstr "Път"
+msgid "SendText"
+msgstr "Текст"
 
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Изберете път"
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "Заглавие"
+
+#: source/gx/terminix/preferences.d:326
+#, fuzzy, c-format
+msgid "%s (Copy)"
+msgstr "Копиране"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Общи"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Команда"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Протокол"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Цвят"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Хост"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Придвижване"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Потребител"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Съвместимост"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Параметри"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Допълнителни"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Изберете Отметка"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Име на профила"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Начален размер на терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "Колони"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "Реда"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Възстановяване"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Форма на курсора"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Правоъгълник"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Вертикална черта"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Подчертаване"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Режим на примигване"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Система"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+#, fuzzy
+msgid "On"
+msgstr "Вкл"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+#, fuzzy
+msgid "Off"
+msgstr "Изкл"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+#, fuzzy
+msgid "Terminal bell"
+msgstr "Звук на терминала"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Икона"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Заглавие на терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
 #, fuzzy
-msgid "Root"
-msgstr "Root"
+msgid "Badge"
+msgstr "Значка"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
-msgstr "Не може да се заредят отметки поради неочаквана грешка"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Папка"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Отдалечен"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Външен вид на текста"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Позволяване на получер текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Потребителски шрифт"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Избор на шрифт за терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Цветова схема"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Потребителска"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Цветова палитра"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Опции"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+#, fuzzy
+msgid "Use theme colors for foreground/background"
+msgstr "Използване на цветовете от системната тема за текста и фона"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Прозрачност"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+#, fuzzy
+msgid "Unfocused dim"
+msgstr "Фокусиране неактивно състояние"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Фон"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+#, fuzzy
+msgid "Select Cursor Foreground Color"
+msgstr "Изберете цвят за текста на курсора"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+#, fuzzy
+msgid "Select Cursor Background Color"
+msgstr "Изберете цвят за фона на курсора"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Неактивно състояние"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+#, fuzzy
+msgid "Select Dim Color"
+msgstr "Изберете цвят за неактивно състояние на терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Изберете %s Цвят"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Изберете цвят за фона"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Изберете цвят за текста"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+#, fuzzy
+msgid "Foreground"
+msgstr "Цвят на текста"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Черен"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Червен"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Зелен"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Оранжев"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Син"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Лилав"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Тюркоаз"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Сив"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Изберете %s Цвят"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Изберете %s Светъл Цвят"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Цветова схема"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Запазване"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Отменете"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Всички JSON файлове"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Всички файлове"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Лента за придвижване"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Придвижване при изваждане на текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Придвижване при натискане на клавиш"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Ограничаване на придвижването назад до:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Клавишът Backspace генерира"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Екранираща последователност"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Връщане на настройките"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Кодиране"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+#, fuzzy
+msgid "Ambiguous-width characters"
+msgstr "Символи със неточна ширина"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Изпълнение на команда като обвивка при влизане"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Изпълняване на команда вместо стандартната обвивка"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Излизане от терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Рестартиране на командата"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Задържане на терминала отворен"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+#, fuzzy
+msgid "Custom Links"
+msgstr "Потребителски шрифт"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Редактиране"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Изтриване"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Действие"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Редактиране на профила"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Терминал"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "Прозорец"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "Отваряне на настройки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Основен"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+#, fuzzy
+msgid "Appearance"
+msgstr "Външен вид"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Отметки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Клавишни комбинации"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Профил"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Редактиране на профила"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "Нов профил"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Настройки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Профили"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Профили"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "Възстановяване на терминал"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+#, fuzzy
+msgid "Enabled"
+msgstr "Разрешено"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Клавишни комбинации"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+#, fuzzy
+msgid "Overwrite Existing Shortcut"
+msgstr "Презапиши Съществуващите Комбинации"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Разрешаване на прозрачност, нужен е рестарт"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Прозорец"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+#, fuzzy
+msgid "Theme variant"
+msgstr "Вариант на темата"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#, fuzzy
+msgid "Light"
+msgstr "Светъл"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#, fuzzy
+msgid "Dark"
+msgstr "Тъмен"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+#, fuzzy
+msgid "Background image"
+msgstr "Фон"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+#, fuzzy
+msgid "Select Image"
+msgstr "Избиране на всичко"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+#, fuzzy
+msgid "All Image Files"
+msgstr "Всички текстови Файлове"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+#, fuzzy
+msgid "Reset background image"
+msgstr "Прозрачен фон"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "Преминаване в сесия 1"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "Приложение"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Светъл"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Запазете съдържанието на терминала"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Поведение"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Фокус на терминал когато мишката е над него"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Автоматично скриване на показалеца на мишката когато пишете"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Изпратете уведомяване на десктопа когато процеса завърши"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "На нова инстанция"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Нов прозорец"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Нова сесия"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#, fuzzy
+msgid "Split Right"
+msgstr "Разделяне Надясно"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#, fuzzy
+msgid "Split Down"
+msgstr "Разделяне Надолу"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Фокусирай Прозорец"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+#, fuzzy
+msgid "Clipboard"
+msgstr "Клипборд"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Заглавие"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Не показвай отново това съобщение"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "Прозорец"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "Сесия"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "Приложение"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "Фокусирай Прозорец"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "Нова сесия"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Добре"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+#, fuzzy
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Тази команда изисква права на администратор за компютъра"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+#, fuzzy
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Копиране на команди от интернет може да бъде опасно. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+#, fuzzy
+msgid "Be sure you understand what each part of this command does."
+msgstr "Бъдете сигурни че разбирате всяка част от тази команда какво прави."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Допълнителни"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Поставяне"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Име"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Нов"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Търсене на опции"
+
+#: source/gx/terminix/terminal/search.d:135
+#, fuzzy
+msgid "Find next"
+msgstr "Следваща поява"
+
+#: source/gx/terminix/terminal/search.d:141
+#, fuzzy
+msgid "Find previous"
+msgstr "Предишна поява"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Затваряне"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Максимизиране"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Изключване входната синхронизация за този терминал"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Само за четене"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Редактиране на профила"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Кодиране"
+
+#: source/gx/terminix/terminal/terminal.d:606
+#, fuzzy
+msgid "Enable input synchronization for this terminal"
+msgstr "Разрешаване входната синхронизация за този терминал"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Търсене…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Добавяне на Отметки..."
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Добавяне на Отметки..."
+
+#: source/gx/terminix/terminal/terminal.d:726
+#, fuzzy
+msgid "Save Output…"
+msgstr "Запазване Като…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Възстановяване и изчистване"
+
+#: source/gx/terminix/terminal/terminal.d:733
+#, fuzzy
+msgid "Layout Options…"
+msgstr "Разпределение Опции…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Други"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Възстановяване"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Отваряне на адрес"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+#, fuzzy
+msgid "Copy Link Address"
+msgstr "Копиране адреса на връзката"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Копиране"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Избиране на всичко"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Синхронизация вход"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2715
+#, fuzzy
+msgid "Save Terminal Output"
+msgstr "Запазване изхода от Терминала"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Всички текстови Файлове"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:30
+#, fuzzy
+msgid "Layout Options"
+msgstr "Разпределение Опции"
+
+#: source/gx/terminix/terminal/layout.d:45
+#, fuzzy
+msgid "Active"
+msgstr "Активен"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Зареждане на сесия"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:320
+#, fuzzy
+msgid "View session sidebar"
+msgstr "Покажи сесия в страничната лента"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Създайте нова сесия"
+
+#: source/gx/terminix/appwindow.d:363
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Преминаване в десен терминал"
+
+#: source/gx/terminix/appwindow.d:367
+#, fuzzy
+msgid "Add terminal down"
+msgstr "Задържане на терминала отворен"
+
+#: source/gx/terminix/appwindow.d:373
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Излизане от терминала"
+
+#: source/gx/terminix/appwindow.d:586
+#, fuzzy
+msgid "Change Session Name"
+msgstr "Променяне името на сесията"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Въведете ново има за сесията"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Отваряне…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Запазване Като…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Име…"
+
+#: source/gx/terminix/appwindow.d:649
+#, fuzzy
+msgid "Synchronize Input"
+msgstr "Синхронизация Вход"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Има процеси които все още се изпълняват, затворете при всички случай?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, fuzzy, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Името на файла '%s' не съществува"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1278
+#, fuzzy
+msgid "Open"
+msgstr "Отваряне…"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1309
+#, fuzzy
+msgid "Save Session"
+msgstr "Запазване на Сесия"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Относно"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Изход"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Ivaylo Kuzev"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Задаване на стартов профил"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Задаване работната директория на терминала"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Отваряне на определена сесия"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Изпращане на действие до текущата инстанция на Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Максимизирай прозореца на терминала"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Максимизирай прозореца на терминала"
+
+#: source/gx/terminix/application.d:631
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "На цял екран прозореца на терминала"
+
+#: source/gx/terminix/application.d:632
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "Фокусирай съществуващия прозорец"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:802
+#, fuzzy
+msgid "Configuration Issue Detected"
+msgstr "Открита е грешка със конфигурацията"
+
+#: source/gx/terminix/application.d:814
+#, fuzzy
+msgid "Do not show this message again"
+msgstr "Не показвай отново това съобщение"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Файла %s не е цветова схема съвместима с JSON файла"
+
+#: source/gx/terminix/colorschemes.d:245
+#, fuzzy
+msgid "Color scheme palette requires 16 colors"
+msgstr "Цветовата схема палитра изисква 16 цвята"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr ""
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -213,78 +1626,44 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Заглавие"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Заглавие икона"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Директория"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Име на хост"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Потребителско име"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "Колони"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Реда"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Име на приложението"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Име на сесия"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Номер на сесия"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr ""
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Профил"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Нова сесия"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -424,1456 +1803,6 @@ msgstr "Виетнамски"
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:30
-#, fuzzy
-msgid "Layout Options"
-msgstr "Разпределение Опции"
-
-#: source/gx/terminix/terminal/layout.d:45
-#, fuzzy
-msgid "Active"
-msgstr "Активен"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-#, fuzzy
-msgid "Badge"
-msgstr "Значка"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Зареждане на сесия"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Терминал"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Затваряне"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Максимизиране"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Изключване входната синхронизация за този терминал"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Само за четене"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-#, fuzzy
-msgid "Terminal bell"
-msgstr "Звук на терминала"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Редактиране на профила"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Кодиране"
-
-#: source/gx/terminix/terminal/terminal.d:606
-#, fuzzy
-msgid "Enable input synchronization for this terminal"
-msgstr "Разрешаване входната синхронизация за този терминал"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-#, fuzzy
-msgid "Save Output…"
-msgstr "Запазване Като…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Възстановяване"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Възстановяване и изчистване"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Профили"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Кодиране"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Добавяне на Отметки..."
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Изберете Отметка..."
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Отметки"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Търсене…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-#, fuzzy
-msgid "Layout Options…"
-msgstr "Разпределение Опции…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Възстановяване"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Отваряне на адрес"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-#, fuzzy
-msgid "Copy Link Address"
-msgstr "Копиране адреса на връзката"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Копиране"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Поставяне"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Избиране на всичко"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-#, fuzzy
-msgid "Clipboard"
-msgstr "Клипборд"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Синхронизация вход"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2693
-#, fuzzy
-msgid "Save Terminal Output"
-msgstr "Запазване изхода от Терминала"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Запазване"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Всички текстови Файлове"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Всички файлове"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Търсене на опции"
-
-#: source/gx/terminix/terminal/search.d:135
-#, fuzzy
-msgid "Find next"
-msgstr "Следваща поява"
-
-#: source/gx/terminix/terminal/search.d:141
-#, fuzzy
-msgid "Find previous"
-msgstr "Предишна поява"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:33
-#, fuzzy
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Тази команда изисква права на администратор за компютъра"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-#, fuzzy
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Копиране на команди от интернет може да бъде опасно. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-#, fuzzy
-msgid "Be sure you understand what each part of this command does."
-msgstr "Бъдете сигурни че разбирате всяка част от тази команда какво прави."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Допълнителни"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Нов"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Редактиране"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Изтриване"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Не показвай отново това съобщение"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "Прозорец"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "Сесия"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "Приложение"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "Фокусирай Прозорец"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "Нова сесия"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Нов прозорец"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Настройки"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Клавишни комбинации"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Относно"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Изход"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Задаване на стартов профил"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Отваряне на определена сесия"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Изпращане на действие до текущата инстанция на Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Максимизирай прозореца на терминала"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Максимизирай прозореца на терминала"
-
-#: source/gx/terminix/application.d:630
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "На цял екран прозореца на терминала"
-
-#: source/gx/terminix/application.d:631
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "Фокусирай съществуващия прозорец"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:801
-#, fuzzy
-msgid "Configuration Issue Detected"
-msgstr "Открита е грешка със конфигурацията"
-
-#: source/gx/terminix/application.d:813
-#, fuzzy
-msgid "Do not show this message again"
-msgstr "Не показвай отново това съобщение"
-
-#: source/gx/terminix/appwindow.d:320
-#, fuzzy
-msgid "View session sidebar"
-msgstr "Покажи сесия в страничната лента"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Създайте нова сесия"
-
-#: source/gx/terminix/appwindow.d:363
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Преминаване в десен терминал"
-
-#: source/gx/terminix/appwindow.d:367
-#, fuzzy
-msgid "Add terminal down"
-msgstr "Задържане на терминала отворен"
-
-#: source/gx/terminix/appwindow.d:373
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Излизане от терминала"
-
-#: source/gx/terminix/appwindow.d:586
-#, fuzzy
-msgid "Change Session Name"
-msgstr "Променяне името на сесията"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Въведете ново има за сесията"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Отваряне…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Запазване Като…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Име…"
-
-#: source/gx/terminix/appwindow.d:649
-#, fuzzy
-msgid "Synchronize Input"
-msgstr "Синхронизация Вход"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Има процеси които все още се изпълняват, затворете при всички случай?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Всички JSON файлове"
-
-#: source/gx/terminix/appwindow.d:1241
-#, fuzzy, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Името на файла '%s' не съществува"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1274
-#, fuzzy
-msgid "Open"
-msgstr "Отваряне…"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1305
-#, fuzzy
-msgid "Save Session"
-msgstr "Запазване на Сесия"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Файла %s не е цветова схема съвместима с JSON файла"
-
-#: source/gx/terminix/colorschemes.d:245
-#, fuzzy
-msgid "Color scheme palette requires 16 colors"
-msgstr "Цветовата схема палитра изисква 16 цвята"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "Отваряне на настройки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Основен"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-#, fuzzy
-msgid "Appearance"
-msgstr "Външен вид"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Редактиране на профила"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "Нов профил"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Профили"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "Възстановяване на терминал"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-#, fuzzy
-msgid "Enabled"
-msgstr "Разрешено"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Действие"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Клавишни комбинации"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-#, fuzzy
-msgid "Overwrite Existing Shortcut"
-msgstr "Презапиши Съществуващите Комбинации"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Разрешаване на прозрачност, нужен е рестарт"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Прозорец"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-#, fuzzy
-msgid "Theme variant"
-msgstr "Вариант на темата"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-#, fuzzy
-msgid "Light"
-msgstr "Светъл"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-#, fuzzy
-msgid "Dark"
-msgstr "Тъмен"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-#, fuzzy
-msgid "Background image"
-msgstr "Фон"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-#, fuzzy
-msgid "Select Image"
-msgstr "Избиране на всичко"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-#, fuzzy
-msgid "All Image Files"
-msgstr "Всички текстови Файлове"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-#, fuzzy
-msgid "Reset background image"
-msgstr "Прозрачен фон"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "Преминаване в сесия 1"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "Приложение"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Светъл"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Опции"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Задаване работната директория на терминала"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Запазете съдържанието на терминала"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Поведение"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Фокус на терминал когато мишката е над него"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Автоматично скриване на показалеца на мишката когато пишете"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Изпратете уведомяване на десктопа когато процеса завърши"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "На нова инстанция"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#, fuzzy
-msgid "Split Right"
-msgstr "Разделяне Надясно"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#, fuzzy
-msgid "Split Down"
-msgstr "Разделяне Надолу"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Фокусирай Прозорец"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Общи"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Цвят"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Придвижване"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Съвместимост"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Допълнителни"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Име на профила"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Начален размер на терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "Колони"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "Реда"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Форма на курсора"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Правоъгълник"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Вертикална черта"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Подчертаване"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Режим на примигване"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Система"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-#, fuzzy
-msgid "On"
-msgstr "Вкл"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-#, fuzzy
-msgid "Off"
-msgstr "Изкл"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Заглавие на терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Външен вид на текста"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Позволяване на получер текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Потребителски шрифт"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Избор на шрифт за терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Цветова схема"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Потребителска"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Цветова палитра"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-#, fuzzy
-msgid "Use theme colors for foreground/background"
-msgstr "Използване на цветовете от системната тема за текста и фона"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Прозрачност"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-#, fuzzy
-msgid "Unfocused dim"
-msgstr "Фокусиране неактивно състояние"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Фон"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-#, fuzzy
-msgid "Select Cursor Foreground Color"
-msgstr "Изберете цвят за текста на курсора"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-#, fuzzy
-msgid "Select Cursor Background Color"
-msgstr "Изберете цвят за фона на курсора"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Неактивно състояние"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-#, fuzzy
-msgid "Select Dim Color"
-msgstr "Изберете цвят за неактивно състояние на терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Изберете %s Цвят"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Изберете цвят за фона"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Изберете цвят за текста"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-#, fuzzy
-msgid "Foreground"
-msgstr "Цвят на текста"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Черен"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Червен"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Зелен"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Оранжев"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Син"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Лилав"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Тюркоаз"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Сив"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Изберете %s Цвят"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Изберете %s Светъл Цвят"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Цветова схема"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Лента за придвижване"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Придвижване при изваждане на текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Придвижване при натискане на клавиш"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Ограничаване на придвижването назад до:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Клавишът Backspace генерира"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Автоматично"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Екранираща последователност"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Връщане на настройките"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-#, fuzzy
-msgid "Ambiguous-width characters"
-msgstr "Символи със неточна ширина"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Изпълнение на команда като обвивка при влизане"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Изпълняване на команда вместо стандартната обвивка"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Излизане от терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Рестартиране на командата"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Задържане на терминала отворен"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-#, fuzzy
-msgid "Custom Links"
-msgstr "Потребителски шрифт"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Редактиране на профила"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Прозорец"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1904,46 +1833,131 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
+#: source/gx/terminix/bookmark/manager.d:512
 #, fuzzy
-msgid "ExecuteCommand"
-msgstr "Команда"
+msgid "Root"
+msgstr "Root"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Не може да се заредят отметки поради неочаквана грешка"
+
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Папка"
+
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+#, fuzzy
+msgid "Path"
+msgstr "Път"
+
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Отдалечен"
+
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Изберете Папка"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Изберете папка"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Изчистете папка"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Добавете отметка"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Редактирайте отметка"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Изберете път"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Протокол"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Хост"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Потребител"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Параметри"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Изберете Отметка"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "изключено"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "Вашата версия на GTK е твърде стара, трябва ви минимум %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/app.d:128
+msgid "Error: "
+msgstr "Грешка: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Версии"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Версия Terminix: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Версия VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "GTK Версия: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Специални възможности Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Известия включени=%b"
+
+#: source/app.d:144
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "Заглавие"
+msgid "Triggers enabled=%b"
+msgstr "Триггер включен=%b"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:217
+#: source/app.d:145
 #, fuzzy
-msgid "SendText"
-msgstr "Текст"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "Заглавие"
-
-#: source/gx/terminix/preferences.d:326
-#, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Копиране"
+msgid "Badges enabled=%b"
+msgstr "Значки включени=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"
@@ -2507,6 +2521,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr ""
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Изберете Отметка..."
 
 #, fuzzy
 #~ msgid "There are processes that are still running, close anyway?"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-12 01:39+0000\n"
 "Last-Translator: Marek Suchánek <marek.suchanek@protonmail.com>\n"
-"Language-Team: Czech "
-"<https://hosted.weblate.org/projects/terminix/translations/cs/>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/terminix/"
+"translations/cs/>\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,173 +18,1536 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 2.12-dev\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "AktualizovatStav"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "ProvéstPříkaz"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "PoslatOznámení"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "AktualizovatTitulek"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "Zazvonit"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "PoslatText"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "VložitHeslo"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "AktualizovatOdznak"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "Máte příliš starou verzi GTK, potřebujete nejméně GTK %d.%d.%d!"
+msgid "%s (Copy)"
+msgstr "%s (Kopírovat)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Nastala neočekávaná výjimka"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Obecné"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Chyba: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Verze"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Verze Terminixu: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Verze VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Verze GTK: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Speciální vlastnosti Terminixu"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Oznámení povolena=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Spouštěče povoleny=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Odznaky povoleny=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "zakázáno"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Vybrat složku"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Vybrat složku"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Vyčistit složku"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Přidat záložku"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Upravit záložku"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Budiž"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Název"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr "Cesta"
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Vybrat cestu"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Příkaz"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Protokol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Barva"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Hostitel"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Posouvání"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Uživatel"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Kompatibilita"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Parametry"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Pokročilé"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Vybrat záložku"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Název profilu"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Velikost terminálu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "sloupce"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "řádky"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Obnovit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Kurzor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Blokový"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Svislá čára"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Podtrhávací čára"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Mód blikání"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Podle systému"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Zapnuto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Vypnuto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Zvonek terminálu"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Žádný"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Zvuk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Ikona"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr "Chyba při deserializaci záložky"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Ikona a zvuk"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr "Kořen"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Titulek terminálu"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
-msgstr "Načítání záložek selhalo kvůli neočekávané chybě"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Odznak"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Složka"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Umístění odznaku"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Vzdálené"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Severozápad"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Severovýchod"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Jihozápad"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Jihovýchod"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Vzhled textu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Povolit tučný text"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Při změně velikosti znovu zalomit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Vlastní písmo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Vyberte písmo terminálu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Barevné schéma"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Vlastní"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exportovat"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Barevná paleta"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Možnosti"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Použít barvy z motivu i pro popředí/pozadí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Průhlednost"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Ztlumení nezaměřeného okna"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Text"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Pozadí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Vyberte barvu popředí kurzoru"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Vyberte barvu pozadí kurzoru"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Zvýraznění"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Vyberte barvu zvýraznění popředí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Vyberte barvu zvýraznění pozadí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Ztlumení"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Vyberte barvu ztlumení"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Vyberte barvu odznaku"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Vyberte barvu pozadí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Vyberte barvu popředí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Popředí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "černá"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "červená"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "zelená"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "oranžová"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "modrá"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "fialová"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "tyrkysová"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "šedá"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Vyberte barvu „%s“"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Vyberte barvu „světlá %s“"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Exportovat barevné schéma"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Uložit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Všechny soubory JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Všechny soubory"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Ukazovat posuvník"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Posouvat při výstupu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Posouvat při stisku klávesy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Omezit historii posouvání na:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Klávesa Backspace posílá"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automaticky"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Únikovou sekvenci"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Klávesa Delete posílá"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Kódování"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Znaky nejednoznačné šířky"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Úzké"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Široké"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Spustit příkaz jako přihlašovací shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Místo mého shellu spustit vlastní příkaz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Až příkaz skončí"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Zavřít terminál"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Znovu spustit příkaz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Podržet terminál otevřený"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Vlastní odkazy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Seznam uživatelem definovaných odkazů, na něž je možné v terminálu kliknout, "
+"zakládající se na regulérních výrazech."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Upravit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Spouštěče"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Spouštěče jsou regulérní výrazy, které slouží k vyhledávání textu ve výstupu "
+"terminálu. Když je nalezena shoda, provede se nastavená činnost."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Automatické přepínání profilu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
+"Hodnoty se zapisují ve formátu <i>uživatelské_jméno@hostitel:adresář</i>. "
+"Buď hostitele nebo adresář je možné vynechat, ale je nutné zachovat "
+"dvojtečku. Položky postrádající hostitele i adresář nejsou povoleny."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
+"Hodnoty se zapisují ve formátu <i>hostitel:adresář</i>. Buď hostitele nebo "
+"adresář je možné vynechat, ale je nutné zachovat dvojtečku. Položky "
+"postrádající hostitele i adresář nejsou povoleny."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Shoda"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Přidat"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Zadejte shodu pro uživatel@hostitel:adresář"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Zadejte shodu pro hostitel:adresář"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Přidat novou shodu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Upravit shodu pro uživatel@hostitel:adresář"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Upravit shodu pro hostitel:adresář"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Upravit shodu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Smazat"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Regulérní výraz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Nerozlišovat velikost"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Upravit vlastní odkazy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Použít"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Činnost"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parametr"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Omezit počet řádků, v nichž hledat spouštěče, na:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Upravit spouštěče"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr "Řádek %d: "
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminál"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr "Okno"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr "Nápověda"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Předvolby Terminixu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Obecné"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Vzhled"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Záložky"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Klávesové zkratky"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Přidat profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Smazat profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Předvolby"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profily"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profil: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Klonovat"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Použít pro nové terminály"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Kódování zobrazená v nabídce:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Povoleno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Klávesová zkratka"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Povolit zkratky"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Přepsat stávající zkratku"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Zkratka %s je už přiřazena k %s.\n"
+"Odejmout zkratku od stávající akce a přiřadit ji místo toho sem?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Povolit průhlednost; vyžaduje restart"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr "Styl okna"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normální"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr "Zakázat CSD"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr "Zakázat CSD, skrýt panel nástrojů"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr "Bez okrajů"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr "Nutný restart okna"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Styl titulku terminálu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Malý"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Varianta motivu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Výchozí"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Světlý"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Tmavý"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Obrázek na pozadí"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Vybrat obrázek"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Všechny obrázky"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Odstranit obrázek na pozadí"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Škálovat"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Dlaždice"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Vystředit"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Roztáhnout"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Výchozí název sezení"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Titulek aplikace"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Použít široký oddělovač terminálů"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Umístit boční panel doprava"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Ukazovat titulek terminálu, i když je to jediný terminál"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Velikost"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Procenta výšky"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Procenta šířky"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Poloha"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Vlevo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Vpravo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Ukazovat terminál na všech plochách"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Nastavit pro správce oken příznak k potlačení animace"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Při ztrátě zaměření skrýt okno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Skrýt titulek okna"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Zobrazit terminál na aktivním monitoru"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Zobrazit na zvoleném monitoru"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Chování"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Upozornit při vytváření nového sezení"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Zaměřit terminál, když na něj ukáže myš"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Při psaní automaticky skrývat kurzor myši"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Zavřít terminál kliknutím prostředním tlačítkem na titulek"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Přibližte terminál pomocí <Controlu>u a kolečka myši"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Zavřít okno, když se zavře poslední sezení"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Po skončení procesu zaslat upozornění"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Při nové instanci"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nové okno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nové sezení"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Rozdělit doprava"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Rozdělit dolů"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Zaměřit okno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Schránka"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Vždy použít dialog pokročilého vkládání"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Varovat při pokusu o nebezpečné vkládání"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Odstranit první znak vkládaného, pokud jde o komentář nebo deklaraci proměnné"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Při označení automaticky zkopírovat text do schránky"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr "Přidat záložku"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr "Upravit záložku"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr "Smazat záložku"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr "Zrušit vybrání záložky"
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Titulek"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Příště už neukazovat"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Okno (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sezení (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Zavřít aplikaci"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Zavřít okno"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Zavřít sezení"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Budiž"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Tento příkaz vás žádá o administrátorský přístup k počítači"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Kopírování příkazu z internetu může být nebezpečné. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Ujistěte se, že rozumíte, co která část příkazu znamená."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformace"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Převést mezery na tabulátory"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Převést CRLF a CR na LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Pokročilé vkládání"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Vložit"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Název"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Nový"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "S heslem zadejte i znak nového řádku"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Vložit heslo"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Heslo"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Potvrdit heslo"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Přidat heslo"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Upravit heslo"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Možnosti hledání"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Hledat další"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Hledat předchozí"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Rozlišovat velikost"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Hledat jen celá slova"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Hledat jako regulérní výraz"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Pokračovat při dosažení konce"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Zavřít"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximalizovat"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Pro tento terminál vypnout synchronizaci vstupu"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Jen pro čtení"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Upravit profil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr "Upravit kódování"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Pro tento terminál zapnout synchronizaci vstupu"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Knihovnu %s se nepodařilo načíst; funkcionalita související s hesly není "
+"dostupná."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Knihovna nenačtena"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Najít…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Heslo"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Přidat záložku…"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Přidat záložku…"
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Uložit výstup…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Obnovit a vyčistit"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Možnosti rozložení…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Další"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Přidat vpravo"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Přidat dolů"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Obnovit"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Otevřít odkaz"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Zkopírovat adresu odkazu"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Kopírovat"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Vybrat vše"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Synchronizovat vstup"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr "Regulérní výraz odkazu ‚%s‘ obsahuje chybu, ignoruje se"
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Nastala neočekávaná chyba, bližší informace nejsou dostupné"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Nastala neočekávaná chyba: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Uložit výstup terminálu"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Všechny textové soubory"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Proces potomka skončil normálně se statusem %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Proces potomka byl ukončen signálem %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Proces potomka byl ukončen."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Znovu spustit"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Nevkládat"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Přesto vložit"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Možnosti rozložení"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Aktivní"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Načíst sezení"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktivní předvolby vždy platí a zapínají se okamžitě.\n"
+"Možnosti „Načítání sezení“ se uplatňují, jen když se načítá sezení."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Ukázat boční panel sezení"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Vytvořit nové sezení"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Přidat terminál vpravo"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Přidat terminál dolů"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Hledat v terminálu text"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Změnit název sezení"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Napište nový název sezení"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Otevřít…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Uložit jako…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Název…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Synchronizovat vstup"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Je otevřeno více sezení; přesto zavřít?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Soubor „%s“ neexistuje"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Načíst sezení"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Otevřít"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr "Načítání sezení selhalo kvůli neočekávané chybě."
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Chyba při načítání sezení"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Uložit sezení"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "O aplikaci"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Ukončit"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Marek Suchánek"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Zásluhy"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Nastavit pracovní adresář terminálu"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "ADRESÁŘ"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Nastavit výchozí profil"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NÁZEV_PROFILU"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Nastavit titulek nového terminálu"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITULEK"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Otevřít zvolené sezení"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NÁZEV_SEZENÍ"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Poslat akci běžící instanci Terminixu"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NÁZEV_AKCE"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Provést předaný parametr jako příkaz"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "PŘÍKAZ"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximalizovat okno terminálu"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Minimalizovat okno terminálu"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Roztáhnout okno na celou obrazovku"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Zaměřit stávající okno"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Spouštět další instanci jako nový proces (Nedoporučováno)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Nastavit velikost okna; například 80x24 nebo 80x24+200+200 (SLOUPCExŘÁDKY+X"
+"+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIE"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Otevře okno v módu „quake“ nebo přepne viditelnost stávajícího okna „quake“"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Ukázat verze Terminixu a závislých komponentů"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Ukázat dialog s předvolbami Terminixu přímo"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Skrytý argument k předání UUID terminálu"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINÁLU"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Byl zřejmě nalezen problém s konfigurací terminálu. Není vážný,\n"
+"ale jeho náprava zpříjemní používání aplikace.\n"
+"Pro další informace klikněte na odkaz níže:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Detekován problém v konfiguraci"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Tuto zprávu již neukazovat"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Soubor %s není JSON obsahující platné barevné schéma"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Paleta barevného schématu vyžaduje 16 barev"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Nebylo možno nalézt přetažený terminál"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Nebylo možno nalézt sezení pro přetažený terminál"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -212,75 +1575,41 @@ msgstr "GtkD za to, že vytvořili tak skvělý obal okolo GTK"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org za vynikající jazyk D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Titulek"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr "Název ikony"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Adresář"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Jméno hostitele"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr "Sloupce"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Řádky"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Název aplikace"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Název sezení"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
 msgstr "Číslo sezení"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Nebylo možno nalézt přetažený terminál"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Nebylo možno nalézt sezení pro přetažený terminál"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Výchozí"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nové sezení"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -417,1405 +1746,6 @@ msgstr "vietnamské"
 msgid "Thai"
 msgstr "thajské"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Možnosti rozložení"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Aktivní"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Odznak"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Načíst sezení"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktivní předvolby vždy platí a zapínají se okamžitě.\n"
-"Možnosti „Načítání sezení“ se uplatňují, jen když se načítá sezení."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminál"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Zavřít"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximalizovat"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Pro tento terminál vypnout synchronizaci vstupu"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Jen pro čtení"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Zvonek terminálu"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Upravit profil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr "Upravit kódování"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Pro tento terminál zapnout synchronizaci vstupu"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Knihovnu %s se nepodařilo načíst; funkcionalita související s hesly není "
-"dostupná."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Knihovna nenačtena"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Uložit výstup…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Obnovit"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Obnovit a vyčistit"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profily"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Kódování"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Přidat záložku…"
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Vybrat záložku…"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Záložky"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Najít…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Možnosti rozložení…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Přidat vpravo"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Přidat dolů"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Obnovit"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Otevřít odkaz"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Zkopírovat adresu odkazu"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Kopírovat"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Vložit"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Vybrat vše"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Schránka"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Synchronizovat vstup"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr "Regulérní výraz odkazu ‚%s‘ obsahuje chybu, ignoruje se"
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Nastala neočekávaná chyba, bližší informace nejsou dostupné"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Nastala neočekávaná chyba: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Uložit výstup terminálu"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Uložit"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Všechny textové soubory"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Všechny soubory"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Proces potomka skončil normálně se statusem %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Proces potomka byl ukončen signálem %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Proces potomka byl ukončen."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Znovu spustit"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Nevkládat"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Přesto vložit"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Možnosti hledání"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Hledat další"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Hledat předchozí"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Rozlišovat velikost"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Hledat jen celá slova"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Hledat jako regulérní výraz"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Pokračovat při dosažení konce"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Tento příkaz vás žádá o administrátorský přístup k počítači"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Kopírování příkazu z internetu může být nebezpečné. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Ujistěte se, že rozumíte, co která část příkazu znamená."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformace"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Převést mezery na tabulátory"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Převést CRLF a CR na LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Pokročilé vkládání"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nový"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Upravit"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Smazat"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "S heslem zadejte i znak nového řádku"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Vložit heslo"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Použít"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Heslo"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Potvrdit heslo"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Přidat heslo"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Upravit heslo"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Příště už neukazovat"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Okno (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sezení (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Zavřít aplikaci"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Zavřít okno"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Zavřít sezení"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nové okno"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Předvolby"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Klávesové zkratky"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "O aplikaci"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Ukončit"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Zásluhy"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Nastavit pracovní adresář terminálu"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "ADRESÁŘ"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Nastavit výchozí profil"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NÁZEV_PROFILU"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Nastavit titulek nového terminálu"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITULEK"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Otevřít zvolené sezení"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NÁZEV_SEZENÍ"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Poslat akci běžící instanci Terminixu"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NÁZEV_AKCE"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Provést předaný parametr jako příkaz"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "PŘÍKAZ"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximalizovat okno terminálu"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Minimalizovat okno terminálu"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Roztáhnout okno na celou obrazovku"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Zaměřit stávající okno"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Spouštět další instanci jako nový proces (Nedoporučováno)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Nastavit velikost okna; například 80x24 nebo 80x24+200+200 (SLOUPCExŘÁDKY+X"
-"+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIE"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Otevře okno v módu „quake“ nebo přepne viditelnost stávajícího okna „quake“"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Ukázat verze Terminixu a závislých komponentů"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Ukázat dialog s předvolbami Terminixu přímo"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Skrytý argument k předání UUID terminálu"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINÁLU"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Byl zřejmě nalezen problém s konfigurací terminálu. Není vážný,\n"
-"ale jeho náprava zpříjemní používání aplikace.\n"
-"Pro další informace klikněte na odkaz níže:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Detekován problém v konfiguraci"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Tuto zprávu již neukazovat"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Ukázat boční panel sezení"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Vytvořit nové sezení"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Přidat terminál vpravo"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Přidat terminál dolů"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Hledat v terminálu text"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Změnit název sezení"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Napište nový název sezení"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Otevřít…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Uložit jako…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Název…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Synchronizovat vstup"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Je otevřeno více sezení; přesto zavřít?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Všechny soubory JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Soubor „%s“ neexistuje"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Načíst sezení"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Otevřít"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Načítání sezení selhalo kvůli neočekávané chybě."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Chyba při načítání sezení"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Uložit sezení"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Soubor %s není JSON obsahující platné barevné schéma"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Paleta barevného schématu vyžaduje 16 barev"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr "Přidat záložku"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr "Upravit záložku"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr "Smazat záložku"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr "Zrušit vybrání záložky"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Předvolby Terminixu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Obecné"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Vzhled"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Přidat profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Smazat profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profil: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Klonovat"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Použít pro nové terminály"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Kódování zobrazená v nabídce:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Povoleno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Činnost"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Klávesová zkratka"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Povolit zkratky"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Přepsat stávající zkratku"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Zkratka %s je už přiřazena k %s.\n"
-"Odejmout zkratku od stávající akce a přiřadit ji místo toho sem?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Povolit průhlednost; vyžaduje restart"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr "Styl okna"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normální"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr "Zakázat CSD"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr "Zakázat CSD, skrýt panel nástrojů"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr "Bez okrajů"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr "Nutný restart okna"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Styl titulku terminálu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Malý"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Žádný"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Varianta motivu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Světlý"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Tmavý"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Obrázek na pozadí"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Vybrat obrázek"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Všechny obrázky"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Odstranit obrázek na pozadí"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Škálovat"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Dlaždice"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Vystředit"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Roztáhnout"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Výchozí název sezení"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Titulek aplikace"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Použít široký oddělovač terminálů"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Umístit boční panel doprava"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Ukazovat titulek terminálu, i když je to jediný terminál"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Velikost"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Procenta výšky"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Procenta šířky"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Poloha"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Vlevo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Vpravo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Možnosti"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Ukazovat terminál na všech plochách"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Nastavit pro správce oken příznak k potlačení animace"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Při ztrátě zaměření skrýt okno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Skrýt titulek okna"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Zobrazit terminál na aktivním monitoru"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Zobrazit na zvoleném monitoru"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Chování"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Upozornit při vytváření nového sezení"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Zaměřit terminál, když na něj ukáže myš"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Při psaní automaticky skrývat kurzor myši"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Zavřít terminál kliknutím prostředním tlačítkem na titulek"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Přibližte terminál pomocí <Controlu>u a kolečka myši"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Zavřít okno, když se zavře poslední sezení"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Po skončení procesu zaslat upozornění"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Při nové instanci"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Rozdělit doprava"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Rozdělit dolů"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Zaměřit okno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Vždy použít dialog pokročilého vkládání"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Varovat při pokusu o nebezpečné vkládání"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Odstranit první znak vkládaného, pokud jde o komentář nebo deklaraci proměnné"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Při označení automaticky zkopírovat text do schránky"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Obecné"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Barva"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Posouvání"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Kompatibilita"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Pokročilé"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Název profilu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Velikost terminálu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "sloupce"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "řádky"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Kurzor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Blokový"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Svislá čára"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Podtrhávací čára"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Mód blikání"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Podle systému"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Zapnuto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Vypnuto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Zvuk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Ikona a zvuk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Titulek terminálu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Umístění odznaku"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Severozápad"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Severovýchod"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Jihozápad"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Jihovýchod"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Vzhled textu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Povolit tučný text"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Při změně velikosti znovu zalomit"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Vlastní písmo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Vyberte písmo terminálu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Barevné schéma"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Vlastní"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exportovat"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Barevná paleta"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Použít barvy z motivu i pro popředí/pozadí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Průhlednost"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Ztlumení nezaměřeného okna"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Text"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Pozadí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Vyberte barvu popředí kurzoru"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Vyberte barvu pozadí kurzoru"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Zvýraznění"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Vyberte barvu zvýraznění popředí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Vyberte barvu zvýraznění pozadí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Ztlumení"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Vyberte barvu ztlumení"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Vyberte barvu odznaku"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Vyberte barvu pozadí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Vyberte barvu popředí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Popředí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "černá"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "červená"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "zelená"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "oranžová"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "modrá"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "fialová"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "tyrkysová"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "šedá"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Vyberte barvu „%s“"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Vyberte barvu „světlá %s“"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Exportovat barevné schéma"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Ukazovat posuvník"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Posouvat při výstupu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Posouvat při stisku klávesy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Omezit historii posouvání na:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Klávesa Backspace posílá"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automaticky"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Únikovou sekvenci"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Klávesa Delete posílá"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Znaky nejednoznačné šířky"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Úzké"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Široké"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Spustit příkaz jako přihlašovací shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Místo mého shellu spustit vlastní příkaz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Až příkaz skončí"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Zavřít terminál"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Znovu spustit příkaz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Podržet terminál otevřený"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Vlastní odkazy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Seznam uživatelem definovaných odkazů, na něž je možné v terminálu kliknout, "
-"zakládající se na regulérních výrazech."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Spouštěče"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Spouštěče jsou regulérní výrazy, které slouží k vyhledávání textu ve výstupu "
-"terminálu. Když je nalezena shoda, provede se nastavená činnost."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Automatické přepínání profilu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
-"Hodnoty se zapisují ve formátu <i>uživatelské_jméno@hostitel:adresář</i>. "
-"Buď hostitele nebo adresář je možné vynechat, ale je nutné zachovat "
-"dvojtečku. Položky postrádající hostitele i adresář nejsou povoleny."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profily se vybírají automaticky podle hodnot zde zadaných.\n"
-"Hodnoty se zapisují ve formátu <i>hostitel:adresář</i>. Buď hostitele nebo "
-"adresář je možné vynechat, ale je nutné zachovat dvojtečku. Položky "
-"postrádající hostitele i adresář nejsou povoleny."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Shoda"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Přidat"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Zadejte shodu pro uživatel@hostitel:adresář"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Zadejte shodu pro hostitel:adresář"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Přidat novou shodu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Upravit shodu pro uživatel@hostitel:adresář"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Upravit shodu pro hostitel:adresář"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Upravit shodu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Regulérní výraz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Nerozlišovat velikost"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Upravit vlastní odkazy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parametr"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Omezit počet řádků, v nichž hledat spouštěče, na:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Upravit spouštěče"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr "Řádek %d: "
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr "Okno"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr "Nápověda"
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1850,42 +1780,127 @@ msgstr ""
 "Mód „quake“ nemůžete použít s parametry maximalizace, minimalizace či "
 "geometrie"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "AktualizovatStav"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr "Chyba při deserializaci záložky"
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "ProvéstPříkaz"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr "Kořen"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "PoslatOznámení"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Načítání záložek selhalo kvůli neočekávané chybě"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "AktualizovatTitulek"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Složka"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "Zazvonit"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr "Cesta"
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "PoslatText"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Vzdálené"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "VložitHeslo"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Vybrat složku"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "AktualizovatOdznak"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Vybrat složku"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Vyčistit složku"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Přidat záložku"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Upravit záložku"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Vybrat cestu"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Protokol"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Hostitel"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Uživatel"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Parametry"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Vybrat záložku"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "zakázáno"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Kopírovat)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "Máte příliš starou verzi GTK, potřebujete nejméně GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Nastala neočekávaná výjimka"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Chyba: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Verze"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Verze Terminixu: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Verze VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Verze GTK: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Speciální vlastnosti Terminixu"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Oznámení povolena=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Spouštěče povoleny=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Odznaky povoleny=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"
@@ -2425,6 +2440,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix je testován v GNOME a Unity."
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Vybrat záložku…"
 
 #~ msgid "The expression %s is not a valid regex"
 #~ msgstr "Výraz %s není platný regulérní výraz"

--- a/po/de.po
+++ b/po/de.po
@@ -2,11 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: German (Terminix)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-06 11:16+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German "
-"<https://hosted.weblate.org/projects/terminix/translations/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/terminix/"
+"translations/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -14,177 +14,1552 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.11\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "Status aktualisieren"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "Befehl ausführen"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "Benachrichtigung senden"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "Titel aktualisieren"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "Terminal-Glocke läuten"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "Text senden"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "Passwort einfügen"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "Badge aktualisieren"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"Die installierte GTK-Version ist zu alt, es ist mindestens GTK %d.%d.%d "
-"erforderlich!"
+msgid "%s (Copy)"
+msgstr "%s (Kopie)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Unerwartete Ausnahme aufgetreten"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Allgemein"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Fehler:"
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Versionen"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Terminix-Version:  %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "VTE-Version: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "GTK-Version: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Terminix-Sonderfunktionen"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Benachrichtigungen aktiviert=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Auslöser aktiviert=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Badges aktiviert=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "deaktiviert"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Ordner wählen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Ordner wählen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Ordnerauswahl leeren"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Lesezeichen hinzufügen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Lesezeichen bearbeiten"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Name"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr "Pfad"
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Pfad wählen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Befehl"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Protokoll"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Farbe"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Rechnername"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Bildlauf"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Benutzer"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Kompatibilität"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Parameter"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Erweitert"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Lesezeichen wählen"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Profilname"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Terminal-Größe"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "Spalten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "Zeilen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Eingabemarke"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Block"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Senkrechter Strich"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Unterstrich"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Eingabemarke blinkt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "System"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "An"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Aus"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Terminal-Glocke"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Keine"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Ton"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Symbol"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr "Fehler beim Deserialisieren des Lesezeichens"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Symbol und Ton"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr "Basisordner"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Terminal-Titel"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Badge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Badge-Position"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Oben links"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Oben rechts"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Unten links"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Unten rechts"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Text-Erscheinungsbild"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Fettformatierten Text zulassen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Bei Größenänderung neu umbrechen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Benutzerdefinierte Schriftart"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Wähle eine Terminal-Schriftart"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Farbschema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exportieren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Farbpalette"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Optionen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Farbe des Themas für Vorder-/Hintergrund verwenden"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparenz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Inaktive Abdunklung"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Text"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Hintergrund"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Vordergrundfarbe für Eingabemarke wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Hintergrundfarbe für Eingabemarke wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Hervorhebung"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Vordergrundfarbe für Hervorhebung wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Hintergrundfarbe für Hervorhebung wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Abdunklung"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Farbe für Abdunklung wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Badge-Farbe wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Hintergrundfarbe wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Vordergrundfarbe wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Vordergrund"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Schwarz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Rot"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Grün"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Orange"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Blau"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Lila"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Türkis"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Grau"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Farbe für »%s« wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Helle Farbe für »%s« wählen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Farbschema exportieren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Speichern"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Alle JSON-Dateien"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Alle Dateien"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Bildlaufleiste anzeigen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Bildlauf bei Ausgabe"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Bildlauf bei Tastendruck"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Zeilenpuffer beschränken auf:"
+
+# Terminix gettext pot file
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Rücktaste erzeugt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Strg-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Escape-Sequenz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Entfernen-Taste erzeugt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Zeichenkodierung"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Zeichen mit unbekannter Breite"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Schmal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Breit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Befehl als Login-Shell ausführen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Einen benutzerdefinierten Befehl statt meiner Shell ausführen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Wenn Befehl beendet:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Terminal verlassen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Befehl neu starten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Terminal geöffnet lassen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Benutzerdefinierte Verweise"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
 msgstr ""
-"Die Lesezeichen konnten wegen eines unerwarteten Fehlers nicht geladen "
-"werden."
+"Eine Liste benutzerdefinierter Verweise basierend auf regulären Ausdrücken, "
+"die im Terminal angeklickt werden können."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Ordner"
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Bearbeiten"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Entfernt"
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Auslöser"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Auslöser sind reguläre Ausdrücke, die auf den Ausgabetext des Terminals "
+"angewendet werden. Bei einem Treffer wird die konfigurierte Aktion "
+"ausgeführt."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Automatischer Profilwechsel"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
+"Die Werte werden im Format <i>Benutzername@Rechnername:Ordner</i> "
+"eingegeben. Sowohl der Rechnername als auch der Ordner können weggelassen "
+"werden, aber der Doppelpunkt muss vorhanden sein. Einträge, die weder "
+"Rechnername noch Ordner enthalten, sind nicht zulässig."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
+"Die Werte werden im Format <i>Rechnername:Ordner</i> eingegeben. Sowohl der "
+"Rechnername als auch der Ordner können weggelassen werden, aber der "
+"Doppelpunkt muss vorhanden sein. Einträge, die weder Rechnername noch Ordner "
+"enthalten, sind nicht zulässig."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Übereinstimmung"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Benutzername@Rechnername:Ordner eingeben"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Rechnername:Ordner eingeben"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Neue Übereinstimmung hinzufügen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Benutzername@Rechnername:Ordner bearbeiten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Rechnername:Ordner bearbeiten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Übereinstimmung bearbeiten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Löschen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Regulärer Ausdruck"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Groß-/Kleinschreibung nicht beachten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Benutzerdefinierte Verweise bearbeiten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Anwenden"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Aktion"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parameter"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Anzahl der Zeilen für Auslöser-Bearbeitung beschränken:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Auslöser bearbeiten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr "Zeile %d: "
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr "Fenster"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr "Hilfe"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Terminix-Einstellungen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Global"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Erscheinungsbild"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Tastenkombinationen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Profil hinzufügen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Profil löschen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profile"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profil: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Klonen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Für neue Terminals verwenden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Im Menü angezeigte Zeichenkodierungen:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Tastenkombination"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Tastenkombinationen aktivieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Bestehende Tastenkombination überschreiben"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Die Tastenkombination %s ist bereits %s zugewiesen. Die Tastenkombination "
+"für die andere Aktion deaktivieren und hier zuweisen?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Aktiviere Transparenz, erforder Neustart"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr "Fensterstil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr "CSD deaktivieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr "CSD deaktivieren, Werkzeugleiste ausblenden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr "Rahmenlos"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr "Neustart des Fensters erforderlich"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Stil der Terminal-Titelzeile:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Klein"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Themen-Variante:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Standard"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Hell"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Dunkel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Hintergrundbild:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Bild wählen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Alle Bilddateien"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Hintergrundbild zurücksetzen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Skalieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Kachel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Zentrieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Strecken"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Standard-Sitzungsname"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Anwendungstitel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Breiten Griff für Fenstertrenner verwenden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Seitenleiste rechts anzeigen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Terminal-Titel anzeigen, selbst wenn es das einzige Terminal ist"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Größe"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Höhe in Prozent"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Breite in Prozent"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Ausrichtung"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Links"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Rechts"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Terminal auf allen Arbeitsflächen anzeigen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Hinweis für Fenstermanager setzen, um Animationen zu deaktivieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Fenster verbergen sobald es den Fokus verliert"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Titelleiste des Fensters ausblenden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Terminal auf dem aktiven Monitor anzeigen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Auf spezifischem Monitor anzeigen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Verhalten"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Beim Erstellen einer neuen Sitzung nachfragen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Terminal beim Überfahren mit der Maus fokusieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Mauszeiger beim Tippen ausblenden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Terminal mit Klick der mittleren Maustaste auf den Titel schließen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Terminal mit <Strg> und Mausrad vergrößern/verkleinern"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Fenster schließen, wenn die letzte Sitzung geschlossen wird"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Desktop-Benachrichtigung bei Beendigung des Prozesses senden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Beim Öffnen einer neuen Instanz:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Neues Fenster"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Neue Sitzung"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Nach rechts teilen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Nach unten teilen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Fenster fokussieren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Zwischenablage"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Immer erweiterten Einfügedialog verwenden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Vor unsicherem Einfügen warnen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Das erste Zeichen beim Einfügen von Kommentaren oder Variablendeklarationen "
+"entfernen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Text beim Markieren automatisch in Zwischenablage kopieren"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr "Lesezeichen hinzufügen"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr "Lesezeichen bearbeiten"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr "Lesezeichen löschen"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr "Lesezeichen abwählen"
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Nicht wieder anzeigen"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Fenster (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sitzung (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Anwendung schließen"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Fenster schließen"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Sitzung schließen"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+"Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
+"macht."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Umwandeln"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Leerzeichen in Tabstopps umwandeln"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "CRLF und CR in LF umwandeln"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Erweitertes Einfügen"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Einfügen"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Name"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Neu"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Passwort mit Zeilenumbruch abschließen"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Passwort eingeben"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Passwort"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Passwort bestätigen"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Passwort hinzufügen"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Passwort bearbeiten"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Suchoptionen"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Nächster Treffer"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Vorheriger Treffer"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Groß-/Kleinschreibung beachten"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Nur vollständige Wörter berücksichtigen"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Als regulären Ausdruck verarbeiten"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Schließen"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximieren"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Eingabesynchronisierung für dieses Terminal deaktivieren"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Nur lesen"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Profil bearbeiten"
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr "Zeichenkodierungen bearbeiten"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Eingabesynchronisierung für dieses Terminal aktivieren"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Die Bibliothek %s konnte nicht geladen werden, Passwort-Funktionalität ist "
+"nicht verfügbar."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Bibliothek nicht geladen"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Suchen …"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Passwort"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Lesezeichen hinzufügen…"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Lesezeichen hinzufügen…"
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Ausgabe speichern …"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Zurücksetzen und leeren"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Layout-Optionen …"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Sonstige"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Rechts hinzufügen"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Unten hinzufügen"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Wiederherstellen"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Verweis öffnen"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Verweisadresse kopieren"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Kopieren"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Alles markieren"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Eingabe synchronisieren"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+"Der reguläre Ausdruck \"%s\" für einen benutzerdefinierten Verweis hat einen "
+"Fehler, ignoriere"
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Unerwarteter Fehler aufgetreten: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Terminalausgabe speichern"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Alle Textdateien"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Der Kindprozess wurde normal mit Status %d beendet."
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Der Kindprozess wurde mit Signal %d beendet."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Der Kindprozess wurde beendet."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Neustart"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Nicht einfügen"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Trotzdem einfügen"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Layout-Optionen"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Aktiv"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Sitzung"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktive Optionen sind immer aktiv und werden sofort angewendet. Sitzungs-"
+"Optionen werden nur beim Laden der Sitzung angewendet."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Sitzungs-Seitenleiste anzeigen"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Neue Sitzung erstellen"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Terminal rechts hinzufügen"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Terminal unten hinzufügen"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Text in Terminal suchen"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Sitzungsnamen ändern"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Öffnen …"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Speichern unter …"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Name …"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Eingabe synchronisieren"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Es sind mehrere Sitzungen geöffnet, trotzdem beenden?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Dateiname »%s« existiert nicht"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Sitzung laden"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Öffnen"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr ""
+"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Fehler beim Laden der Sitzung"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Sitzung speichern"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Info"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Beenden"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Philipp Wolfer <ph.wolfer@gmail.com>"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Mitwirkende"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Arbeitsordner des Terminals wählen"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "ORDNER"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Als Startprofil festlegen"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "PROFIL_NAME"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Titel des neuen Terminals setzen"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITEL"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Die angegebene Sitzung öffnen"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "SITZUNGS_NAME"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "AKTIONS_NAME"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Parameter als Befehl ausführen"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "BEFEHL"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Terminalfenster maximieren"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Terminalfenster minimieren"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Terminalfenster im Vollbildmodus anzeigen"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Vorhandenes Fenster fokussieren"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Neue Instanzen in separaten Prozessen starten (nicht empfohlen)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Fenstergröße setzen, z.B. 80x24 oder 80x24+200+200 (SPALTENxZEILEN+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIE"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Öffnet ein Fenster im Quake-Modus oder schaltet die Sichtbarkeit eines "
+"vorhandenen Fensters im Quake-Modus um"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Versionsnummern von Terminix und abhängigen Komponenten anzeigen"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Terminix-Einstellungsdialog direkt anzeigen"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
+"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
+"Klicken Sie auf den unten stehenden Verweis für weitere Informationen:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Probleme mit der Konfiguration entdeckt"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Diese Meldung nicht mehr anzeigen"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Die Datei %s ist keine konforme Farbschema-Datei"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Die Palette des Farbschemas erfordert 16 Farben"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Das abgelegte Terminal konnte nicht gefunden werden"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Die Sitzung für das abgelegte Terminal konnte nicht gefunden werden"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -212,75 +1587,41 @@ msgstr "GtkD für die Bereitstellung eines hervorragenden GTK-Wrappers"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org für eine hervorragende Sprache, D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr "Symbol-Titel"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Ordner"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Rechnername"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Benutzername"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr "Spalten"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Zeilen"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Anwendungsname"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Sitzungsname"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
 msgstr "Sitzungsnummer"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Das abgelegte Terminal konnte nicht gefunden werden"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Die Sitzung für das abgelegte Terminal konnte nicht gefunden werden"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Standard"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Neue Sitzung"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -420,1421 +1761,6 @@ msgstr "Vietnamesisch"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Layout-Optionen"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Aktiv"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Badge"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Sitzung"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktive Optionen sind immer aktiv und werden sofort angewendet. Sitzungs-"
-"Optionen werden nur beim Laden der Sitzung angewendet."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Schließen"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximieren"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Eingabesynchronisierung für dieses Terminal deaktivieren"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Nur lesen"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Terminal-Glocke"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Profil bearbeiten"
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr "Zeichenkodierungen bearbeiten"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Eingabesynchronisierung für dieses Terminal aktivieren"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Die Bibliothek %s konnte nicht geladen werden, Passwort-Funktionalität ist "
-"nicht verfügbar."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Bibliothek nicht geladen"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Ausgabe speichern …"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Zurücksetzen"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Zurücksetzen und leeren"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profile"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Zeichenkodierung"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Lesezeichen hinzufügen…"
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Lesezeichen wählen…"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Lesezeichen"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Suchen …"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Layout-Optionen …"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Rechts hinzufügen"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Unten hinzufügen"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Wiederherstellen"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Verweis öffnen"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Verweisadresse kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Kopieren"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Einfügen"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Alles markieren"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Zwischenablage"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Eingabe synchronisieren"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-"Der reguläre Ausdruck \"%s\" für einen benutzerdefinierten Verweis hat einen "
-"Fehler, ignoriere"
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Unerwarteter Fehler aufgetreten, es ist keine weitere Information verfügbar"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Unerwarteter Fehler aufgetreten: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Terminalausgabe speichern"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Speichern"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Alle Textdateien"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Alle Dateien"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Der Kindprozess wurde normal mit Status %d beendet."
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Der Kindprozess wurde mit Signal %d beendet."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Der Kindprozess wurde beendet."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Neustart"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Nicht einfügen"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Trotzdem einfügen"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Suchoptionen"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Nächster Treffer"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Vorheriger Treffer"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Groß-/Kleinschreibung beachten"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Nur vollständige Wörter berücksichtigen"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Als regulären Ausdruck verarbeiten"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Suche beim Erreichen des Endes am Anfang fortsetzen"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Dieser Befehl fordert Administrationszugang zu Ihrem Rechner an"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Befehle aus dem Internet zu kopieren kann gefährlich sein."
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-"Stellen Sie sicher, dass Sie wissen, was jeder Bestandteil dieses Befehls "
-"macht."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Umwandeln"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Leerzeichen in Tabstopps umwandeln"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "CRLF und CR in LF umwandeln"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Erweitertes Einfügen"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Neu"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Löschen"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Passwort mit Zeilenumbruch abschließen"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Passwort eingeben"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Anwenden"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Passwort"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Passwort bestätigen"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Passwort hinzufügen"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Passwort bearbeiten"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Nicht wieder anzeigen"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Fenster (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sitzung (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Anwendung schließen"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Fenster schließen"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Sitzung schließen"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Neues Fenster"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Tastenkombinationen"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Info"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Beenden"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Mitwirkende"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Arbeitsordner des Terminals wählen"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "ORDNER"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Als Startprofil festlegen"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "PROFIL_NAME"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Titel des neuen Terminals setzen"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITEL"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Die angegebene Sitzung öffnen"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "SITZUNGS_NAME"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Eine Aktion an die aktuelle Terminix-Instanz senden"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "AKTIONS_NAME"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Parameter als Befehl ausführen"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "BEFEHL"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Terminalfenster maximieren"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Terminalfenster minimieren"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Terminalfenster im Vollbildmodus anzeigen"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Vorhandenes Fenster fokussieren"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Neue Instanzen in separaten Prozessen starten (nicht empfohlen)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Fenstergröße setzen, z.B. 80x24 oder 80x24+200+200 (SPALTENxZEILEN+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIE"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Öffnet ein Fenster im Quake-Modus oder schaltet die Sichtbarkeit eines "
-"vorhandenen Fensters im Quake-Modus um"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Versionsnummern von Terminix und abhängigen Komponenten anzeigen"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Terminix-Einstellungsdialog direkt anzeigen"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Versteckter parameter, um Terminal-UUID zu übergeben"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Es scheint ein Problem mit der Konfiguration des Terminals zu geben. Es ist "
-"nichts ernstes, aber es zu beheben wird Ihr Benutzererlebnis verbessern. "
-"Klicken Sie auf den unten stehenden Verweis für weitere Informationen:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Probleme mit der Konfiguration entdeckt"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Diese Meldung nicht mehr anzeigen"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Sitzungs-Seitenleiste anzeigen"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Neue Sitzung erstellen"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Terminal rechts hinzufügen"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Terminal unten hinzufügen"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Text in Terminal suchen"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Sitzungsnamen ändern"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Geben Sie einen neuen Namen für die Sitzung ein"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Öffnen …"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Speichern unter …"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Name …"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Eingabe synchronisieren"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Es sind mehrere Sitzungen geöffnet, trotzdem beenden?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Alle JSON-Dateien"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Dateiname »%s« existiert nicht"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Sitzung laden"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Öffnen"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr ""
-"Die Sitzung konnte wegen eines unerwarteten Fehlers nicht geladen werden."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Fehler beim Laden der Sitzung"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Sitzung speichern"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Die Datei %s ist keine konforme Farbschema-Datei"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Die Palette des Farbschemas erfordert 16 Farben"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr "Lesezeichen hinzufügen"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr "Lesezeichen bearbeiten"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr "Lesezeichen löschen"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr "Lesezeichen abwählen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Terminix-Einstellungen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Global"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Erscheinungsbild"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Profil hinzufügen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Profil löschen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profil: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Klonen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Für neue Terminals verwenden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Im Menü angezeigte Zeichenkodierungen:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Aktiviert"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Aktion"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Tastenkombination"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Tastenkombinationen aktivieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Bestehende Tastenkombination überschreiben"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Die Tastenkombination %s ist bereits %s zugewiesen. Die Tastenkombination "
-"für die andere Aktion deaktivieren und hier zuweisen?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Aktiviere Transparenz, erforder Neustart"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr "Fensterstil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr "CSD deaktivieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr "CSD deaktivieren, Werkzeugleiste ausblenden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr "Rahmenlos"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr "Neustart des Fensters erforderlich"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Stil der Terminal-Titelzeile:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Klein"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Keine"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Themen-Variante:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Hell"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Dunkel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Hintergrundbild:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Bild wählen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Alle Bilddateien"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Hintergrundbild zurücksetzen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Skalieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Kachel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Zentrieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Strecken"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Standard-Sitzungsname"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Anwendungstitel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Breiten Griff für Fenstertrenner verwenden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Seitenleiste rechts anzeigen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Terminal-Titel anzeigen, selbst wenn es das einzige Terminal ist"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Größe"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Höhe in Prozent"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Breite in Prozent"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Ausrichtung"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Links"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Rechts"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Optionen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Terminal auf allen Arbeitsflächen anzeigen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Hinweis für Fenstermanager setzen, um Animationen zu deaktivieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Fenster verbergen sobald es den Fokus verliert"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Titelleiste des Fensters ausblenden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Terminal auf dem aktiven Monitor anzeigen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Auf spezifischem Monitor anzeigen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Verhalten"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Beim Erstellen einer neuen Sitzung nachfragen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Terminal beim Überfahren mit der Maus fokusieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Mauszeiger beim Tippen ausblenden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Terminal mit Klick der mittleren Maustaste auf den Titel schließen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Terminal mit <Strg> und Mausrad vergrößern/verkleinern"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Fenster schließen, wenn die letzte Sitzung geschlossen wird"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Desktop-Benachrichtigung bei Beendigung des Prozesses senden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Beim Öffnen einer neuen Instanz:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Nach rechts teilen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Nach unten teilen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Fenster fokussieren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Immer erweiterten Einfügedialog verwenden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Vor unsicherem Einfügen warnen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Das erste Zeichen beim Einfügen von Kommentaren oder Variablendeklarationen "
-"entfernen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Text beim Markieren automatisch in Zwischenablage kopieren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Allgemein"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Farbe"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Bildlauf"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Kompatibilität"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Erweitert"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Profilname"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Terminal-Größe"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "Spalten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "Zeilen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Eingabemarke"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Block"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Senkrechter Strich"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Unterstrich"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Eingabemarke blinkt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "System"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "An"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Aus"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Ton"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Symbol und Ton"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Terminal-Titel"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Badge-Position"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Oben links"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Oben rechts"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Unten links"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Unten rechts"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Text-Erscheinungsbild"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Fettformatierten Text zulassen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Bei Größenänderung neu umbrechen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Benutzerdefinierte Schriftart"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Wähle eine Terminal-Schriftart"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Farbschema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exportieren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Farbpalette"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Farbe des Themas für Vorder-/Hintergrund verwenden"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparenz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Inaktive Abdunklung"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Text"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Hintergrund"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Vordergrundfarbe für Eingabemarke wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Hintergrundfarbe für Eingabemarke wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Hervorhebung"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Vordergrundfarbe für Hervorhebung wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Hintergrundfarbe für Hervorhebung wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Abdunklung"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Farbe für Abdunklung wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Badge-Farbe wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Hintergrundfarbe wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Vordergrundfarbe wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Vordergrund"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Schwarz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Rot"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Grün"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Orange"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Blau"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Lila"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Türkis"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Grau"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Farbe für »%s« wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Helle Farbe für »%s« wählen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Farbschema exportieren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Bildlaufleiste anzeigen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Bildlauf bei Ausgabe"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Bildlauf bei Tastendruck"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Zeilenpuffer beschränken auf:"
-
-# Terminix gettext pot file
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Rücktaste erzeugt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatisch"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Strg-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Escape-Sequenz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Entfernen-Taste erzeugt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Zeichen mit unbekannter Breite"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Schmal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Breit"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Befehl als Login-Shell ausführen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Einen benutzerdefinierten Befehl statt meiner Shell ausführen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Wenn Befehl beendet:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Terminal verlassen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Befehl neu starten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Terminal geöffnet lassen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Benutzerdefinierte Verweise"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Eine Liste benutzerdefinierter Verweise basierend auf regulären Ausdrücken, "
-"die im Terminal angeklickt werden können."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Auslöser"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Auslöser sind reguläre Ausdrücke, die auf den Ausgabetext des Terminals "
-"angewendet werden. Bei einem Treffer wird die konfigurierte Aktion "
-"ausgeführt."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Automatischer Profilwechsel"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
-"Die Werte werden im Format <i>Benutzername@Rechnername:Ordner</i> "
-"eingegeben. Sowohl der Rechnername als auch der Ordner können weggelassen "
-"werden, aber der Doppelpunkt muss vorhanden sein. Einträge, die weder "
-"Rechnername noch Ordner enthalten, sind nicht zulässig."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profile werden automatisch anhand der hier gesetzten Werte gewählt.\n"
-"Die Werte werden im Format <i>Rechnername:Ordner</i> eingegeben. Sowohl der "
-"Rechnername als auch der Ordner können weggelassen werden, aber der "
-"Doppelpunkt muss vorhanden sein. Einträge, die weder Rechnername noch Ordner "
-"enthalten, sind nicht zulässig."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Übereinstimmung"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Benutzername@Rechnername:Ordner eingeben"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Rechnername:Ordner eingeben"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Neue Übereinstimmung hinzufügen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Benutzername@Rechnername:Ordner bearbeiten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Rechnername:Ordner bearbeiten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Übereinstimmung bearbeiten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Regulärer Ausdruck"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Groß-/Kleinschreibung nicht beachten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Benutzerdefinierte Verweise bearbeiten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parameter"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Anzahl der Zeilen für Auslöser-Bearbeitung beschränken:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Auslöser bearbeiten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr "Zeile %d: "
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr "Fenster"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr "Hilfe"
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1872,42 +1798,131 @@ msgstr ""
 "Der Quake-Modus kann nicht mit den Parametern maximize, minimize oder "
 "geometry zusammen verwendet werden"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "Status aktualisieren"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr "Fehler beim Deserialisieren des Lesezeichens"
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "Befehl ausführen"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr "Basisordner"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "Benachrichtigung senden"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr ""
+"Die Lesezeichen konnten wegen eines unerwarteten Fehlers nicht geladen "
+"werden."
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "Titel aktualisieren"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Ordner"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "Terminal-Glocke läuten"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr "Pfad"
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "Text senden"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Entfernt"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "Passwort einfügen"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Ordner wählen"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "Badge aktualisieren"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Ordner wählen"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Ordnerauswahl leeren"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Lesezeichen hinzufügen"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Lesezeichen bearbeiten"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Pfad wählen"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Rechnername"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Benutzer"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Parameter"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Lesezeichen wählen"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Kopie)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"Die installierte GTK-Version ist zu alt, es ist mindestens GTK %d.%d.%d "
+"erforderlich!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Unerwartete Ausnahme aufgetreten"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Fehler:"
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Versionen"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Terminix-Version:  %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "VTE-Version: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "GTK-Version: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Terminix-Sonderfunktionen"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Benachrichtigungen aktiviert=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Auslöser aktiviert=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Badges aktiviert=%b"
 
 # ******************
 # Nautilus extension
@@ -2465,6 +2480,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix wurde mit GNOME und Unity getestet."
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Lesezeichen wählen…"
 
 #~ msgid "The expression %s is not a valid regex"
 #~ msgstr "%s ist kein gültiger regulärer Ausdruck"

--- a/po/el.po
+++ b/po/el.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-11-09 23:12+0200\n"
 "Last-Translator: Tom Tryfonidis <tomtryf@gnome.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/terminix/"
@@ -17,179 +17,1530 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr ""
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "Σφάλμα:"
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "Συνεδρία"
+msgid "ExecuteCommand"
+msgstr "Εντολή"
 
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
 msgstr ""
 
-#: source/app.d:140
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "Κείμενο"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "Ετικέτα"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "Συνεδρία"
+msgid "%s (Copy)"
+msgstr "Αντιγραφή"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Γενικά"
 
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr ""
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Επιλογή όλων"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Επιλογή όλων"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Eντάξει"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Ακύρωση"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Όνομα"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Επιλογή όλων"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Εντολή"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Χρώμα"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Κύλιση"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Συμβατότητα"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Παράμετρος"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Για προχωρημένους"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Επιλογή χρώματος ετικέτας"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "'Ονομα προφίλ"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Μεγέθος τερματικού"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "στήλες"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "σειρές"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Επαναφορά"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Κέρσορας"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Τούβλο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Δέσμη"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Υπογραμμίση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Αναβόσβημα"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Σύστημα"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "On"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Off"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Κουδούνι  τερματικού"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Κανένα"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Ήχος"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Εικονίδιο"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Εικονίδιο και ήχος"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Τίτλος τερματικού"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Ετικέτα"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Θέση ετικέτας"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Βορειοδυτικά"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Βορειοανατολικά"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Νοτιοδυτικά"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Νοτιοανατολικά"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Εμφάνιση κειμένου"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Να επιτραπεί έντονο κέιμενο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Αναδίπλωση κατά την αυξομείωση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Προσαρμοσμένη γραμματοσειρά"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Επιλογή γραμματοσειράς τερματικού"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "Αναγνωριστικό: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Θέμα χρώματος"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Προσαρμοσμένο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Εξαγωγή"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Παλέτα χρωμάτων"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Χρήση χρωμάτων θέματος για το προσήνιο/παρασκήνιο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Διαφάνεια"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Κείμενο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Φόντο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Επισήμανση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Επιλογή χρώματος ετικέτας"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Επιλογή χρώματος παρασκηνίου"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Επιλογή χρώματος προσκήνιου"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Προσκήνιο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Μαύρο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Κόκκινο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Πράσινο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Πορτοκαλί"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Μπλε"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Μωβ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Τιρκουάζ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Γκρίζο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Εξαγωγή χρωματικού συνδυασμού"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Αποθήκευση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Ακύρωση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Όλα τα αρχεία JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Όλα τα αρχεία"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Εμφάνιση γραμμή κύλισης"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Κύλιση στην έξοδο"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Κύλιση στην πληκτρολόγηση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Περιορισμός οπισθοκύλισης σε:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Το πλήκτρο οπισθοδρόμησης προκαλεί"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Αυτόματα"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Ακολουθία διαφυγής"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Το πλήκτρο διαγραφής προκαλεί"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Κωδικοποίηση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Χαρακτήρες ασαφούς πλάτους"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Στενοί"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Πλατιοί"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Κατά την έξοδο της εντολής"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Έξοδος από το τερματικό"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Επανεκτέλεση της εντολής"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Διατήρηση του τερματικού ανοιχτό"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Προσαρμοσμένοι σύνδεσμοι"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Εναύσματα"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Αντιστοίχιση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Επεξεργασία αντιστοιχίας"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Διαγραφή"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Κανονική έκφραση"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Διάκριση πεζών/κεφαλαίων"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Επεξεργασία προσαρμοσμένων συνδέσμων"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Εφαρμογή"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Ενέργεια"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Παράμετρος"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Επεξεργασία εναυσμάτων"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Τερματικό"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Window"
+msgstr "Παράθυρο"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Εμφάνιση"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Συντομεύσεις"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Προφίλ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Επεξεργασία προφίλ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "Νέο προφίλ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Προφίλ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Προφίλ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Κλωνοποίηση"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "Επαναφορά του τερματικού"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Κωδικοποιήσεις που εμφανίζονται στο μενού:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Ενεργοποιημένα"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Πλήκτρο συντόμευσης"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Ενεργοποίηση συντομεύσεων"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Αντικατάσταση της υπάρχουσας συντόμευσης"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Παράθυρο"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Παραλλαγή θέματος"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Φωτεινό"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Σκούρο"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Εικόνα παρασκηνίου"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Επιλογή εικόνας"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Όλα τα αρχεία εικόνων"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Επαναφορά εικόνας παρασκηνίου"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Κλιμάκωση"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Παράθεση"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Κεντράρισμα"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Παραμόρφωση"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Προεπιλεγμένο όνομα συνεδρίας"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "Εφαρμογή"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Τοποθέτηση της πλευρικής στήλης στα δεξιά"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Ορισμός του αρχικού τίτλου του τερματικού"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Μέγεθος"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Ποσοστό ήψους"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Ποσοστό πλάτους"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Φωτεινό"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Ορισμός του αρχικού τίτλου του τερματικού"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Συμπεριφορά"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Νέο παράθυρο"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Νέα συνεδρία"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Διαχωρισμός στα δεξιά"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Διαχωρισμός κάτω"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Εστίαση παραθύρου"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Πρόχειρο"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Τίτλος"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Να μην εμφανιστεί αυτό ξανά"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "Παράθυρο"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "Συνεδρία"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "Εφαρμογή"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "Εστίαση παραθύρου"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "Νέα συνεδρία"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Eντάξει"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Μετασχηματισμός"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Προχωρημένη επικόλληση"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Επικόλληση"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Όνομα"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "Αναγνωριστικό "
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Νέο"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Εισαγωγή κωδικού πρόσβασης"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Κωδικός πρόσβασης"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Επιβεβαίωση κωδικού πρόσβασης"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Προσθήκη κωδικού πρόσβασης"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Επεξεργασία κωδικού πρόσβασης"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Επιλογές αναζήτησης"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Εύρεση επομένου"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Εύρεση προηγουμένου"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Ταίριασμα πεζών-κεφαλαίων"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Ταίριασμα μόνο ολόκληρης λέξης"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Ταίριασμα ως κανονική έκφραση"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Αναδίπλωση γύρω"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Κλείσιμο"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Μεγιστοποίηση"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Μόνο για ανάγνωση"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Επεξεργασία προφίλ"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Κωδικοποίηση"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Δεν φορτώθηκε η βιβλιοθήκη"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Εύρεση…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Κωδικός πρόσβασης"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Επιλογή χρώματος ετικέτας"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Αποθήκευση εξόδου κονσόλας…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Επαναφορά και καθαρισμός"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Επιλογές διάταξης…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Άλλα"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Προσθήκη δεξιά"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Προσθήκη κάτω"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Επαναφορά"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Άνοιγμα συνδέσμου"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Αντιγραφή διεύθυνσης συνδέσμου"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Αντιγραφή"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Επιλογή όλων"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Συγχρονισμός εξόδου"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Συνέβη ένα απρόσμενο σφάλμα: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Αποθήκευση εξόδου κονσόλας"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Όλα τα αρχεία κειμένου"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Η θυγατρική διεργασία τερματίσθηκε κανονικά με κατάσταση %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Επανεκκίνηση"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Να μη γίνει επικόλληση"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Επικόλληση ούτως ή άλλως"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Επιλογές διάταξης"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Ενεργό"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Φόρτωση συνεδρίας"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Προβολή στήλης συνεδρίας"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Δημιουργία νέας συνεδρίας"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Προσθήκη τερματικού δεξιά"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Προσθήκη τερματικού κάτω"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Εύρεση κειμένου στο τερματικό"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Αλλαγή ονόματος συνεδρίας"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Εισάγετε ένα νέο όνομα για την συνεδρία"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Άνοιγμα…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Αποθήκευση ως…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Όνομα…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Συγχρονισμός εισόδου"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Δεν υπάρχει το όνομα αρχείου '%s'"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Φόρτωση συνεδρίας"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Αδυναμία φόρτωσης της συνεδρίας λόγω ενός απρόσμενου σφάλματος."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Σφάλμα κατά την φόρτωση της συνεδρίας"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Αποθήκευση συνεδρίας"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Περί"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Έξοδος"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"alex285\n"
+"Tom Tryfonidis"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Μνεία"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Ορισμός καταλόγου εργασίας του τερματικού"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "ΚΑΤΑΛΟΓΟΣ"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Ορισμός του αρχικού προφίλ"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "ΟΝΟΜΑ_ΠΡΟΦΙΛ"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Ορισμός του αρχικού τίτλου του τερματικού"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "ΤΙΤΛΟΣ"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Άνοιγμα της καθορισμένης συνεδρίας"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "ΟΝΟΜΑ_ΣΥΝΕΔΡΙΑΣ"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ΟΝΟΜΑ_ΕΝΕΡΓΕΙΑΣ"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Εκτέλεση της παραμέτρου ως εντολή"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "ΕΝΤΟΛΗ"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Μεγιστοποίηση του παραθύρου τερματικού"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Ελαχιστοποίηση του παραθύρου τερματικού"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Πλήρης οθόνη του παραθύρου τερματικού"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Εστίαση του τρέχοντος παραθύρου"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Ορίστε το μεγέθους του παραθύρου· για παράδειγμα: 80x24, ή 80x24+200+200 "
+"(COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "ΓΕΩΜΕΤΡΙΑ"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Να μην εμφανιστεί ξανά αυτό το μήνυμα"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Το αρχείο %s δεν είναι συμβατό θέμα χρωμάτων με JSON"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Η χρωματική παλέτα απαιτεί 16 χρώματα"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
 msgstr ""
 
 #: source/gx/terminix/constants.d:60
@@ -215,80 +1566,46 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Τίτλος"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Εφαρμογή"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Αναγνωριστικό "
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "στήλες"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Εφαρμογή"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Φόρτωση συνεδρίας"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Συνεδρία"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr ""
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Προφίλ"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Νέα συνεδρία"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -425,1396 +1742,6 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Επιλογές διάταξης"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Ενεργό"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Ετικέτα"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Φόρτωση συνεδρίας"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Τερματικό"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Κλείσιμο"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Μεγιστοποίηση"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Μόνο για ανάγνωση"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Κουδούνι  τερματικού"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Επεξεργασία προφίλ"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Κωδικοποίηση"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Δεν φορτώθηκε η βιβλιοθήκη"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Αποθήκευση εξόδου κονσόλας…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Επαναφορά"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Επαναφορά και καθαρισμός"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Προφίλ"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Κωδικοποίηση"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Επιλογή χρώματος ετικέτας"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Εύρεση…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Επιλογές διάταξης…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Προσθήκη δεξιά"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Προσθήκη κάτω"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Επαναφορά"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Άνοιγμα συνδέσμου"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Αντιγραφή διεύθυνσης συνδέσμου"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Αντιγραφή"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Επικόλληση"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Επιλογή όλων"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Πρόχειρο"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Συγχρονισμός εξόδου"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Συνέβη ένα απρόσμενο σφάλμα: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Αποθήκευση εξόδου κονσόλας"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Αποθήκευση"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Όλα τα αρχεία κειμένου"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Όλα τα αρχεία"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Η θυγατρική διεργασία τερματίσθηκε κανονικά με κατάσταση %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Επανεκκίνηση"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Να μη γίνει επικόλληση"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Επικόλληση ούτως ή άλλως"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Επιλογές αναζήτησης"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Εύρεση επομένου"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Εύρεση προηγουμένου"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Ταίριασμα πεζών-κεφαλαίων"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Ταίριασμα μόνο ολόκληρης λέξης"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Ταίριασμα ως κανονική έκφραση"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Αναδίπλωση γύρω"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Μετασχηματισμός"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Προχωρημένη επικόλληση"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Νέο"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Επεξεργασία"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Διαγραφή"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Εισαγωγή κωδικού πρόσβασης"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Εφαρμογή"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Κωδικός πρόσβασης"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Επιβεβαίωση κωδικού πρόσβασης"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Προσθήκη κωδικού πρόσβασης"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Επεξεργασία κωδικού πρόσβασης"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Να μην εμφανιστεί αυτό ξανά"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "Παράθυρο"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "Συνεδρία"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "Εφαρμογή"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "Εστίαση παραθύρου"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "Νέα συνεδρία"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Νέο παράθυρο"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Συντομεύσεις"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Περί"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Έξοδος"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Μνεία"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Ορισμός καταλόγου εργασίας του τερματικού"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "ΚΑΤΑΛΟΓΟΣ"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Ορισμός του αρχικού προφίλ"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "ΟΝΟΜΑ_ΠΡΟΦΙΛ"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Ορισμός του αρχικού τίτλου του τερματικού"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "ΤΙΤΛΟΣ"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Άνοιγμα της καθορισμένης συνεδρίας"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "ΟΝΟΜΑ_ΣΥΝΕΔΡΙΑΣ"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ΟΝΟΜΑ_ΕΝΕΡΓΕΙΑΣ"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Εκτέλεση της παραμέτρου ως εντολή"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "ΕΝΤΟΛΗ"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Μεγιστοποίηση του παραθύρου τερματικού"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Ελαχιστοποίηση του παραθύρου τερματικού"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Πλήρης οθόνη του παραθύρου τερματικού"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Εστίαση του τρέχοντος παραθύρου"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Ορίστε το μεγέθους του παραθύρου· για παράδειγμα: 80x24, ή 80x24+200+200 "
-"(COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "ΓΕΩΜΕΤΡΙΑ"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Να μην εμφανιστεί ξανά αυτό το μήνυμα"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Προβολή στήλης συνεδρίας"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Δημιουργία νέας συνεδρίας"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Προσθήκη τερματικού δεξιά"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Προσθήκη τερματικού κάτω"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Εύρεση κειμένου στο τερματικό"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Αλλαγή ονόματος συνεδρίας"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Εισάγετε ένα νέο όνομα για την συνεδρία"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Άνοιγμα…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Αποθήκευση ως…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Όνομα…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Συγχρονισμός εισόδου"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Όλα τα αρχεία JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Δεν υπάρχει το όνομα αρχείου '%s'"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Φόρτωση συνεδρίας"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Άνοιγμα"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Αδυναμία φόρτωσης της συνεδρίας λόγω ενός απρόσμενου σφάλματος."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Σφάλμα κατά την φόρτωση της συνεδρίας"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Αποθήκευση συνεδρίας"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Το αρχείο %s δεν είναι συμβατό θέμα χρωμάτων με JSON"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Η χρωματική παλέτα απαιτεί 16 χρώματα"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Εμφάνιση"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Επεξεργασία προφίλ"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "Νέο προφίλ"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Προφίλ"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Κλωνοποίηση"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "Επαναφορά του τερματικού"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Κωδικοποιήσεις που εμφανίζονται στο μενού:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Ενεργοποιημένα"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Ενέργεια"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Πλήκτρο συντόμευσης"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Ενεργοποίηση συντομεύσεων"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Αντικατάσταση της υπάρχουσας συντόμευσης"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Παράθυρο"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Κανένα"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Παραλλαγή θέματος"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Φωτεινό"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Σκούρο"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Εικόνα παρασκηνίου"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Επιλογή εικόνας"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Όλα τα αρχεία εικόνων"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Επαναφορά εικόνας παρασκηνίου"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Κλιμάκωση"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Παράθεση"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Κεντράρισμα"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Παραμόρφωση"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Προεπιλεγμένο όνομα συνεδρίας"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "Εφαρμογή"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Τοποθέτηση της πλευρικής στήλης στα δεξιά"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Ορισμός του αρχικού τίτλου του τερματικού"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Μέγεθος"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Ποσοστό ήψους"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Ποσοστό πλάτους"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Φωτεινό"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Ορισμός του αρχικού τίτλου του τερματικού"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Συμπεριφορά"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Διαχωρισμός στα δεξιά"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Διαχωρισμός κάτω"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Εστίαση παραθύρου"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Γενικά"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Χρώμα"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Κύλιση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Συμβατότητα"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Για προχωρημένους"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "'Ονομα προφίλ"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Μεγέθος τερματικού"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "στήλες"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "σειρές"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Κέρσορας"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Τούβλο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Δέσμη"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Υπογραμμίση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Αναβόσβημα"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Σύστημα"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "On"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Off"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Ήχος"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Εικονίδιο και ήχος"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Τίτλος τερματικού"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Θέση ετικέτας"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Βορειοδυτικά"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Βορειοανατολικά"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Νοτιοδυτικά"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Νοτιοανατολικά"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Εμφάνιση κειμένου"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Να επιτραπεί έντονο κέιμενο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Αναδίπλωση κατά την αυξομείωση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Προσαρμοσμένη γραμματοσειρά"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Επιλογή γραμματοσειράς τερματικού"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "Αναγνωριστικό: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Θέμα χρώματος"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Προσαρμοσμένο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Εξαγωγή"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Παλέτα χρωμάτων"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Χρήση χρωμάτων θέματος για το προσήνιο/παρασκήνιο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Διαφάνεια"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Κείμενο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Φόντο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Επισήμανση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Επιλογή χρώματος ετικέτας"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Επιλογή χρώματος παρασκηνίου"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Επιλογή χρώματος προσκήνιου"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Προσκήνιο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Μαύρο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Κόκκινο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Πράσινο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Πορτοκαλί"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Μπλε"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Μωβ"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Τιρκουάζ"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Γκρίζο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Εξαγωγή χρωματικού συνδυασμού"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Εμφάνιση γραμμή κύλισης"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Κύλιση στην έξοδο"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Κύλιση στην πληκτρολόγηση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Περιορισμός οπισθοκύλισης σε:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Το πλήκτρο οπισθοδρόμησης προκαλεί"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Αυτόματα"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Ακολουθία διαφυγής"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Το πλήκτρο διαγραφής προκαλεί"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Χαρακτήρες ασαφούς πλάτους"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Στενοί"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Πλατιοί"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Κατά την έξοδο της εντολής"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Έξοδος από το τερματικό"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Επανεκτέλεση της εντολής"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Διατήρηση του τερματικού ανοιχτό"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Προσαρμοσμένοι σύνδεσμοι"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Εναύσματα"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Αντιστοίχιση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Προσθήκη"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Επεξεργασία αντιστοιχίας"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Κανονική έκφραση"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Διάκριση πεζών/κεφαλαίων"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Επεξεργασία προσαρμοσμένων συνδέσμων"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Παράμετρος"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Επεξεργασία εναυσμάτων"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Παράθυρο"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1845,45 +1772,134 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "ExecuteCommand"
-msgstr "Εντολή"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Αδυναμία φόρτωσης της συνεδρίας λόγω ενός απρόσμενου σφάλματος."
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
 #, fuzzy
-msgid "SendText"
-msgstr "Κείμενο"
+msgid "Select Folder"
+msgstr "Επιλογή όλων"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Επιλογή όλων"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "Ετικέτα"
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Επιλογή όλων"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "Παράμετρος"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Επιλογή χρώματος ετικέτας"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr ""
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr ""
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Σφάλμα:"
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "Συνεδρία"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr ""
+
+#: source/app.d:140
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Αντιγραφή"
+msgid "VTE version: %s"
+msgstr "Συνεδρία"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr ""
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/en.po
+++ b/po/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-05-07 02:09+0000\n"
 "Last-Translator: Gerald Nunn <gerald.b.nunn@gmail.com>\n"
 "Language-Team: English <https://hosted.weblate.org/projects/terminix/"
@@ -14,180 +14,1569 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr ""
-
-#: source/app.d:128
-msgid "Error: "
-msgstr ""
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "Persian"
+msgid "ExecuteCommand"
+msgstr "Command"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "Preferences"
+msgid "%s (Copy)"
+msgstr "Copy"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "Preferences"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "General"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "Preferences"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "disabled"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Select %s Color"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Select %s Color"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Name"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Select All"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Command"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Scrolling"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibility"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:216
 #, fuzzy
-msgid "Select Bookmark"
-msgstr "Select %s Color"
+msgid "Profile name"
+msgstr "Profile Name"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+#, fuzzy
+msgid "Terminal size"
+msgstr "Terminal Size"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "columns"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "rows"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Reset"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Block"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Underline"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+#, fuzzy
+msgid "Terminal bell"
+msgstr "Terminal Bell"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
-
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:301
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Terminal title"
+msgstr "Terminal Title"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+#, fuzzy
+msgid "Southeast"
+msgstr "South European"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Text Appearance"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Allow bold text"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Rewrap on resize"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+#, fuzzy
+msgid "Custom font"
+msgstr "Custom Font"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Choose A Terminal Font"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Color scheme"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Custom"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Color palette"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Options"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Use theme colors for foreground/background"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparency"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Background"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+#, fuzzy
+msgid "Select Cursor Foreground Color"
+msgstr "Select Foreground Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+#, fuzzy
+msgid "Select Cursor Background Color"
+msgstr "Select Background Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+#, fuzzy
+msgid "Select Highlight Foreground Color"
+msgstr "Select Foreground Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+#, fuzzy
+msgid "Select Highlight Background Color"
+msgstr "Select Background Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+#, fuzzy
+msgid "Select Dim Color"
+msgstr "Select %s Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Select %s Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Select Background Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Select Foreground Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Foreground"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Black"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Red"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Green"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Orange"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Blue"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Purple"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turquoise"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Grey"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Select %s Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Select %s Light Color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Color scheme"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Save"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Show scrollbar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Scroll on output"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Scroll on keystroke"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Limit scrollback to:"
+
+# Terminix gettext pot file
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Backspace key generates"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatic"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Escape sequence"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Delete key generates"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Encoding"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Ambiguous-width characters"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Narrow"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Wide"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Run command as a login shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Run a custom command instead of my shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "When command exits"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Exit the terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Restart the command"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+#, fuzzy
+msgid "Custom Links"
+msgstr "Custom Font"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Edit"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+#, fuzzy
+msgid "Match"
+msgstr "Match case"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Delete"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Action"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Edit Profile"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "New Window"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "Preferences"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Global"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+#, fuzzy
+msgid "Appearance"
+msgstr "Appearance"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profile"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Edit Profile"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "New Profile"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferences"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profiles"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Profiles"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "Exit the terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Encodings showing in menu:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Enabled"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Shortcut Key"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Shortcuts"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "New Window"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "disabled"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+#, fuzzy
+msgid "Terminal title style"
+msgstr "Terminal Title"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+#, fuzzy
+msgid "Theme variant"
+msgstr "Theme Variant"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Default"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Light"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Dark"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+#, fuzzy
+msgid "Background image"
+msgstr "Background"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+#, fuzzy
+msgid "Select Image"
+msgstr "Select All"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+#, fuzzy
+msgid "Reset background image"
+msgstr "Transparency"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "Switch To Session 1"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "Action"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Light"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Behavior"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Prompt when creating a new session"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Focus a terminal when the mouse moves over it"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Send desktop notification on process complete"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "New Window"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "New Session"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Split Right"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Split Down"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#, fuzzy
+msgid "Focus Window"
+msgstr "New Window"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Warn when attempting unsafe paste"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "Strip first character of paste if comment or variable declaration"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Do not show this message again"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "New Window"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "Session"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "Action"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "New Window"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "New Session"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Paste"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Name"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "New"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Search Options"
+
+#: source/gx/terminix/terminal/search.d:135
+#, fuzzy
+msgid "Find next"
+msgstr "Find Next"
+
+#: source/gx/terminix/terminal/search.d:141
+#, fuzzy
+msgid "Find previous"
+msgstr "Find Previous"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Match case"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Match entire word only"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Match as regular expression"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Wrap around"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Close"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+#, fuzzy
+msgid "Maximize"
+msgstr "Maximize"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Read-Only"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Edit Profile"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Encoding"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Find…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Select %s Color"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+#, fuzzy
+msgid "Save Output…"
+msgstr "Save As…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:736
+msgid "Other"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:745
+#, fuzzy
+msgid "Add Right"
+msgstr "Split Right"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Copy"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Select All"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+#, fuzzy
+msgid "Synchronize input"
+msgstr "Synchronize Input"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Don't Paste"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Layout Options"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "View session sidebar"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Create a new session"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Add terminal right"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Add terminal down"
+
+#: source/gx/terminix/appwindow.d:373
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Exit the terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Change Session Name"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Enter a new name for the session"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Save As…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Name…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Synchronize Input"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Filename '%s' does not exist"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Load Session"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Could not load session due to unexpected error."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Error Loading Session"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Save Session"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "About"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Quit"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Gerald Nunn <gerald.b.nunn@gmail.com>"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
 msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Set the starting profile"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Set the working directory of the terminal"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Open the specified session"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Send an action to current Terminix instance"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Execute the passed command"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:631
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:632
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "Hold the terminal open"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"There appears to be an issue with the configuration of the terminal. This\n"
+"issue is not serious, but correcting it will improve your experience. Click\n"
+"the link below for more information:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Configuration Issue Detected"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Do not show this message again"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Could not locate dropped terminal"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Could not locate session for dropped terminal"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -212,80 +1601,46 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Action"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "columns"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Action"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Session"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Session"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Could not locate dropped terminal"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Could not locate session for dropped terminal"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Default"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profile"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "New Session"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -425,1440 +1780,6 @@ msgstr "Vietnamese"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Layout Options"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Close"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-#, fuzzy
-msgid "Maximize"
-msgstr "Maximize"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Read-Only"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-#, fuzzy
-msgid "Terminal bell"
-msgstr "Terminal Bell"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Edit Profile"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Encoding"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-#, fuzzy
-msgid "Save Output…"
-msgstr "Save As…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Reset"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profiles"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Encoding"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Select %s Color"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Find…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:737
-#, fuzzy
-msgid "Add Right"
-msgstr "Split Right"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Copy"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Paste"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Select All"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1465
-#, fuzzy
-msgid "Synchronize input"
-msgstr "Synchronize Input"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Save"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Don't Paste"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Search Options"
-
-#: source/gx/terminix/terminal/search.d:135
-#, fuzzy
-msgid "Find next"
-msgstr "Find Next"
-
-#: source/gx/terminix/terminal/search.d:141
-#, fuzzy
-msgid "Find previous"
-msgstr "Find Previous"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Match case"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Match entire word only"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Match as regular expression"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Wrap around"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "New"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Edit"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Delete"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Do not show this message again"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "New Window"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "Session"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "Action"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "New Window"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "New Session"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "New Window"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferences"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Shortcuts"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "About"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Quit"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Set the starting profile"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Open the specified session"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Send an action to current Terminix instance"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Execute the passed command"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:630
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:631
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"There appears to be an issue with the configuration of the terminal. This\n"
-"issue is not serious, but correcting it will improve your experience. Click\n"
-"the link below for more information:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Configuration Issue Detected"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Do not show this message again"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "View session sidebar"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Create a new session"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Add terminal right"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Add terminal down"
-
-#: source/gx/terminix/appwindow.d:373
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Exit the terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Change Session Name"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Enter a new name for the session"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Save As…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Name…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Synchronize Input"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Filename '%s' does not exist"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Load Session"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Could not load session due to unexpected error."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Error Loading Session"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Save Session"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr ""
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "Preferences"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Global"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-#, fuzzy
-msgid "Appearance"
-msgstr "Appearance"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Edit Profile"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "New Profile"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Profiles"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "Exit the terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Encodings showing in menu:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Enabled"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Action"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Shortcut Key"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Shortcuts"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "New Window"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "disabled"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-#, fuzzy
-msgid "Terminal title style"
-msgstr "Terminal Title"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-#, fuzzy
-msgid "Theme variant"
-msgstr "Theme Variant"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Light"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Dark"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-#, fuzzy
-msgid "Background image"
-msgstr "Background"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-#, fuzzy
-msgid "Select Image"
-msgstr "Select All"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-#, fuzzy
-msgid "Reset background image"
-msgstr "Transparency"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "Switch To Session 1"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "Action"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Light"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Options"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Set the working directory of the terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Behavior"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Prompt when creating a new session"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Focus a terminal when the mouse moves over it"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Send desktop notification on process complete"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Split Right"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Split Down"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#, fuzzy
-msgid "Focus Window"
-msgstr "New Window"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Warn when attempting unsafe paste"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "Strip first character of paste if comment or variable declaration"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "General"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Scrolling"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibility"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-#, fuzzy
-msgid "Profile name"
-msgstr "Profile Name"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-#, fuzzy
-msgid "Terminal size"
-msgstr "Terminal Size"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "columns"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "rows"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Block"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "IBeam"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Underline"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-#, fuzzy
-msgid "Terminal title"
-msgstr "Terminal Title"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "South European"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Text Appearance"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Allow bold text"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Rewrap on resize"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-#, fuzzy
-msgid "Custom font"
-msgstr "Custom Font"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Choose A Terminal Font"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Color scheme"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Custom"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Color palette"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Use theme colors for foreground/background"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparency"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Background"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-#, fuzzy
-msgid "Select Cursor Foreground Color"
-msgstr "Select Foreground Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-#, fuzzy
-msgid "Select Cursor Background Color"
-msgstr "Select Background Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-#, fuzzy
-msgid "Select Highlight Foreground Color"
-msgstr "Select Foreground Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-#, fuzzy
-msgid "Select Highlight Background Color"
-msgstr "Select Background Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-#, fuzzy
-msgid "Select Dim Color"
-msgstr "Select %s Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Select %s Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Select Background Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Select Foreground Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Foreground"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Black"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Red"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Green"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Orange"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Blue"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Purple"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turquoise"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Grey"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Select %s Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Select %s Light Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Color scheme"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Show scrollbar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Scroll on output"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Scroll on keystroke"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Limit scrollback to:"
-
-# Terminix gettext pot file
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Backspace key generates"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatic"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Escape sequence"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Delete key generates"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Ambiguous-width characters"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Narrow"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Wide"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Run command as a login shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Run a custom command instead of my shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "When command exits"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Exit the terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Restart the command"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Hold the terminal open"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-#, fuzzy
-msgid "Custom Links"
-msgstr "Custom Font"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-#, fuzzy
-msgid "Match"
-msgstr "Match case"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Edit Profile"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "New Window"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1889,43 +1810,134 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "ExecuteCommand"
-msgstr "Command"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Could not load session due to unexpected error."
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "Select %s Color"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Select %s Color"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Select All"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Select %s Color"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "disabled"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr ""
+
+#: source/app.d:128
+msgid "Error: "
+msgstr ""
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "Persian"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Copy"
+msgid "Terminix version: %s"
+msgstr "Preferences"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "Preferences"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "Preferences"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"

--- a/po/es.po
+++ b/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-11-18 13:47+0000\n"
 "Last-Translator: Carlos Arguello <carguello@fztedu.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/terminix/"
@@ -18,182 +18,1574 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.10-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
-"¡Su versión de GTK es demasiado antigua, necesita por lo menos GTK %d.%d.%d!"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Se produjo una excepción inesperada"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "Error: "
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "Persa"
+msgid "ExecuteCommand"
+msgstr "Comando"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Título"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "Texto"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "Título"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "Abrir Terminix en %s"
+msgid "%s (Copy)"
+msgstr "Copiar"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "Abrir Terminix en %s"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "General"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "Abrir preferencias"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "desactivado"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Seleccionar color %s"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Seleccionar color %s"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Aceptar"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Nombre"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Seleccionar todo"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Comando"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Color"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Desplazamiento"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibilidad"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Parámetro"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Avanzado"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Seleccionar color de la tarjeta"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nombre del perfil"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Tamaño del terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "columnas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "filas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Reiniciar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Bloque"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Doble T"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Subrayado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Modo de parpadeo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Sistema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Activado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Desactivado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Campana de la terminal"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Ninguno"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Sonido"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Icono"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Icono y sonido"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Título de la terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Tarjeta"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Posición de la tarjeta"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Superior izquierda"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Superior derecha"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Inferior izquierda"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Inferior derecha"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Apariencia del texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Permitir texto en negrita"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Reajustar al redimensionar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Fuente personalizada"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Elija una tipografía para la terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Combinación de colores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Personalizado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exportar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Paleta de color"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Opciones"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Usar los colores del tema para el primer plano/fondo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparencia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Difuminado sin el foco"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Fondo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Seleccionar el color de primer plano del cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Seleccionar el color de fondo del cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Resaltar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Seleccionar el color de resaltado para el primer plano"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Seleccionar el color de resaltado para el fondo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Difuminar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Seleccionar el color de difuminado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Seleccionar color de la tarjeta"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Seleccionar el color de fondo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Seleccionar el color del primer plano"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Primer plano"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Negro"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Rojo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Verde"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Naranja"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Azul"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Púrpura"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turquesa"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Gris"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Seleccionar color %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Seleccionar el color claro %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Exportar combinación de colores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Guardar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Todos los ficheros JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Todos los ficheros"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Mostrar la barra de desplazamiento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Desplazar en la salida"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Desplazar al pulsar letras"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Limitar el desplazamiento hacía atrás a:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "La tecla Retroceso genera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automático"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII para Supr."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Secuencia de escape"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "La tecla Suprimir genera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Codificación"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Caracteres de anchura ambigua"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Estrechos"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Anchos"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Ejecutar el comando como intérprete de conexión"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Ejecutar un comando personalizado en vez de mi intérprete"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Cuando el comando termina"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Salir de la terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Reiniciar el comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Mantener la terminal abierta"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Enlaces personalizados"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Una lista de enlaces cliqueables en la terminal definidos por el usuario. "
+"Basados en las definiciones de expresiones regulares."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Editar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Desencadenadores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Los desencadenadores son expresiones regulares para comprobar texto de "
+"salida en la terminal. Cuando se detecte una coincidencia, se ejecutará una "
+"acción configurada."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Cambio de perfil automático"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Los perfiles se seleccionan automáticamente según los valores que se "
+"introduzcan aquí.\n"
+"Los valores se proporcionan en el formato <i>nombredeusuario@nombredeequipo:"
+"directorio</i>. Pueden omitirse tanto el nombre de equipo como el "
+"directorio, pero los dos puntos deben estar presentes. No se permiten "
+"entradas sin nombre de equipo y sin directorio."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Los perfiles se seleccionan de manera automática basados en los valores "
+"introducidos aquí.\n"
+"Los valores tienen que tener el siguiente formato: <i>nombre de host:"
+"directorio</i>. Tanto el nombre de host o el directorio pueden ser omitidos, "
+"pero los dos puntos tienen que estar presentes. No se permiten entradas sin "
+"el nombre de host o directorio."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Coincidir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Añadir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+"Escriba un nombredeusuario@nombredeequipo:directorio para buscar "
+"coincidencias"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Introduce el nombre de host:directorio para coincidir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Añadir nueva coincidencia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+"Edite un nombredeusuario@nombredeequipo:directorio para buscar coincidencias"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Editar nombre de host:directorio para coincidir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Editar coincidencia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Eliminar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Expresión regular"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Ignora mayús./minús."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Editar links personalizados"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Aplicar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Acción"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parámetro"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Editar desencadenadores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Window"
+msgstr "Ventana"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "Abrir preferencias"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Global"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Apariencia"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Atajos del teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "Nuevo perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Perfiles"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Perfiles"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "Reiniciar la terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Codificaciones mostradas en el menú:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Activado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Tecla de atajo del teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Activar atajos de teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Sobrescribir atajo del teclado existente"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Este atajo del teclado %s está asignado a %s\n"
+"¿Quieres desactivar el atajo del teclado para la otra acción y asignarla a "
+"esta?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Activar transparencia, requiere reiniciar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Ventana"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "desactivado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Estilo del título de la terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Pequeño"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Variante del tema"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Por defecto"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Claro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Oscuro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Imagen de fondo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Seleccionar imagen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Todas las imagenes"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Restablecer imagen de fondo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Ampliar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Repetir"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centrar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Estirar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nombre de sesión predeterminado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "Aplicación"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Utilizar un separador ancho para los divisores"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Situar la barra lateral en la derecha"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Mostrar el título de la terminal incluso si es la única"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Tamaño"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Porcentaje de altura"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Porcentaje de anchura"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Claro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Mostrar la terminal en todas las áreas de trabajo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Indicar al gestor de ventanas que desactive las animaciones"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Ocultar la ventana cuando se pierde el foco"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Establecer título de la nueva terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Mostrar la terminal en el monitor activo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Mostrar en un monitor específico"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Comportamiento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Preguntar al crear una sesión nueva"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Dar el foco a la terminal al situar el ratón sobre ella"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Ocultar automáticamente el puntero del ratón mientras se escribe"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+"Cerrar terminales al pulsar con el botón central del ratón sobre el título"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Cerrar la ventana cuando se cierre la última sesión"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Enviar una notificación de escritorio cuando un proceso termine"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "En una instancia nueva"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nueva ventana"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nueva sesión"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Dividir a la derecha"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Dividir abajo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Dar el foco a la ventana"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Portapapeles"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Usar siempre el cuadro de diálogo de pegado avanzado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Advertir al hacer un pegado inseguro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Quitar el primer carácter del texto pegado si es un comentario o una "
+"declaración de variable"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Copiar texto automáticamente al portapapeles al seleccionar"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Título"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "No mostrar de nuevo"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "Ventana"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "Sesión"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "Aplicación"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "Dar el foco a la ventana"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "Nueva sesión"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Aceptar"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Este comando está solicitando acceso administrativo en su ordenador"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiar comandos de Internet puede ser peligroso. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Asegúrese de entender qué hace cada parte de este comando."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformar"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+#, fuzzy
+msgid "Convert spaces to tabs"
+msgstr "Convertir espacios en tabulaciones"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Pegado avanzado"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Pegar"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Nombre"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "Id."
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Nuevo"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Incluir carácter de retorno en la contraseña"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Insertar contraseña"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Contraseña"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Confirmar contraseña"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Añadir contraseña"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Editar contraseña"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Opciones de búsqueda"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Buscar siguiente"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Buscar anterior"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Coincidir con capitalización"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Coincidir sólo con la palabra entera"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Coincidir con expresión regular"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Volver al principio"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Cerrar"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximinar"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Desactivar sincronización en esta terminal"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Sólo lectura"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Codificación"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Activar sincronización de entrada para esta terminal"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"No se pudo cargar la biblioteca %s. La funcionalidad de contraseñas no está "
+"disponible."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Biblioteca no cargada"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Buscar…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Contraseña"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Seleccionar color de la tarjeta"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Guardar salida…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Reiniciar y limpiar"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Opciones de diseño…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Otro"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Añadir a la derecha"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Añadir abajo"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Restaurar"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Abrir enlace"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Copiar dirección del enlace"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Copiar"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Seleccionar todo"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Se produjo un error inesperado, no hay información adicional disponible"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Se produjo un error inesperado: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Guardar salida de la terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Todos los ficheros de texto"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "El proceso hijo finalizó correctamente con el estado %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Se interrumpió el proceso hijo con la señal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Se interrumpió el proceso hijo."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Relanzar"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "No pegar"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Pegar igualmente"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Opciones de diseño"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Activar"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Cargar sesión"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Las opciones activas siempre son efectivas y se aplican inmediatamente.\n"
+"Las opciones de carga de sesión se aplican únicamente al cargar un fichero "
+"de sesión."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Mostrar la barra lateral de sesiones"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Crear nueva sesión"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Añadir terminal a la derecha"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Añadir terminal abajo"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Buscar texto en la terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Cambiar el nombre de la sesión"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Introduzca un nuevo nombre para la sesión"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Abrir…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Guardar como…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nombre…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Hay varias sesiones abiertas. ¿Quiere cerrar de todos modos?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "El fichero '%s' no existe"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Cargar sesión"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Abrir"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "No se pudo cargar la sesión debido a un error inesperado."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Error cargando la sesión"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Guardar sesión"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Acerca de"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Salir"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Adolfo Jayme Barrientos\n"
+"Carlos Arguello\n"
+"Cristian Ferreyra\n"
+"Eduardo Bellido Bellido"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Créditos"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Establecer directorio de trabajo de la terminal"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIRECTORIO"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Establecer perfil de inicio"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NOMBRE-DEL-PERFIL"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Establecer título de la nueva terminal"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TÍTULO"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Abrir la sesión especificada"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NOMBRE-DE-SESIÓN"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Enviar una acción a la instancia de Terminix actual"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NOMRE-DE-LA-ACCIÓN"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Ejecutar el parámetro como una orden"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "ORDEN"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximizar la ventana de la terminal"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Minimizar la ventana de la terminal"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Poner a pantalla completa la ventana de la terminal"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Dar el foco a la ventana existente"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Iniciar instancia adicional como un nuevo proceso (no recomendado)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Establecer el tamaño de la ventana; por ejemplo: 80x24, o 80x24+200+200 "
+"(COLUMNASxFILAS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRÍA"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Abre una ventana en modo Quake o cambia la visibilidad de una ventana en "
+"modo Quake existente"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Mostrar las versiones de Terminix y de sus componentes dependientes"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argumento oculto para pasar el UUID de la terminal"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID-DE-LA-TERMINAL"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
 msgstr ""
+"Parece que hay un problema con la configuración de la terminal. Este\n"
+"problema no es grave, pero corregirlo puede mejorar tu experiencia. Abre\n"
+"el siguiente enlace para más información:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Detectado un problema de configuración"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "No volver a mostrar este mensaje"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "«%s» no es un archivo JSON de combinación de colores válido"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "La paleta de la combinación de colores requiere 16 colores"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "No se pudo localizar la terminal que ha sido soltada"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "No se pudo localizar la sesión para la terminal que ha sido soltada"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -222,80 +1614,46 @@ msgstr "GtkD por proporcionar un excelente envoltorio para GTK"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org por tan execelente lenguaje, D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Título"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Aplicación"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Id."
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "columnas"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Aplicación"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Cargar sesión"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Sesión"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "No se pudo localizar la terminal que ha sido soltada"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "No se pudo localizar la sesión para la terminal que ha sido soltada"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Por defecto"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Perfil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nueva sesión"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -432,1436 +1790,6 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandés"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Opciones de diseño"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Activar"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Tarjeta"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Cargar sesión"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Las opciones activas siempre son efectivas y se aplican inmediatamente.\n"
-"Las opciones de carga de sesión se aplican únicamente al cargar un fichero "
-"de sesión."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Cerrar"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximinar"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Desactivar sincronización en esta terminal"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Sólo lectura"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Campana de la terminal"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Codificación"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Activar sincronización de entrada para esta terminal"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"No se pudo cargar la biblioteca %s. La funcionalidad de contraseñas no está "
-"disponible."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Biblioteca no cargada"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Guardar salida…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Reiniciar"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Reiniciar y limpiar"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Perfiles"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Codificación"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Seleccionar color de la tarjeta"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Buscar…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Opciones de diseño…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Añadir a la derecha"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Añadir abajo"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Restaurar"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Abrir enlace"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Copiar dirección del enlace"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Copiar"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Pegar"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Seleccionar todo"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Portapapeles"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Se produjo un error inesperado, no hay información adicional disponible"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Se produjo un error inesperado: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Guardar salida de la terminal"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Guardar"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Todos los ficheros de texto"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Todos los ficheros"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "El proceso hijo finalizó correctamente con el estado %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Se interrumpió el proceso hijo con la señal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Se interrumpió el proceso hijo."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Relanzar"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "No pegar"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Pegar igualmente"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Opciones de búsqueda"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Buscar siguiente"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Buscar anterior"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Coincidir con capitalización"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Coincidir sólo con la palabra entera"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Coincidir con expresión regular"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Volver al principio"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Este comando está solicitando acceso administrativo en su ordenador"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiar comandos de Internet puede ser peligroso. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Asegúrese de entender qué hace cada parte de este comando."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformar"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-#, fuzzy
-msgid "Convert spaces to tabs"
-msgstr "Convertir espacios en tabulaciones"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Pegado avanzado"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nuevo"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Editar"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Eliminar"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Incluir carácter de retorno en la contraseña"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Insertar contraseña"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Aplicar"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Contraseña"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Confirmar contraseña"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Añadir contraseña"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Editar contraseña"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "No mostrar de nuevo"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "Ventana"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "Sesión"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "Aplicación"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "Dar el foco a la ventana"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "Nueva sesión"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nueva ventana"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Atajos del teclado"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Acerca de"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Salir"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Créditos"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Establecer directorio de trabajo de la terminal"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIRECTORIO"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Establecer perfil de inicio"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NOMBRE-DEL-PERFIL"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Establecer título de la nueva terminal"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TÍTULO"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Abrir la sesión especificada"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NOMBRE-DE-SESIÓN"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Enviar una acción a la instancia de Terminix actual"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NOMRE-DE-LA-ACCIÓN"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Ejecutar el parámetro como una orden"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "ORDEN"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximizar la ventana de la terminal"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Minimizar la ventana de la terminal"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Poner a pantalla completa la ventana de la terminal"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Dar el foco a la ventana existente"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Iniciar instancia adicional como un nuevo proceso (no recomendado)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Establecer el tamaño de la ventana; por ejemplo: 80x24, o 80x24+200+200 "
-"(COLUMNASxFILAS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRÍA"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Abre una ventana en modo Quake o cambia la visibilidad de una ventana en "
-"modo Quake existente"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Mostrar las versiones de Terminix y de sus componentes dependientes"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argumento oculto para pasar el UUID de la terminal"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID-DE-LA-TERMINAL"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Parece que hay un problema con la configuración de la terminal. Este\n"
-"problema no es grave, pero corregirlo puede mejorar tu experiencia. Abre\n"
-"el siguiente enlace para más información:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Detectado un problema de configuración"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "No volver a mostrar este mensaje"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Mostrar la barra lateral de sesiones"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Crear nueva sesión"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Añadir terminal a la derecha"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Añadir terminal abajo"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Buscar texto en la terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Cambiar el nombre de la sesión"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Introduzca un nuevo nombre para la sesión"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Abrir…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Guardar como…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nombre…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Hay varias sesiones abiertas. ¿Quiere cerrar de todos modos?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Todos los ficheros JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "El fichero '%s' no existe"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Cargar sesión"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Abrir"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "No se pudo cargar la sesión debido a un error inesperado."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Error cargando la sesión"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Guardar sesión"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "«%s» no es un archivo JSON de combinación de colores válido"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "La paleta de la combinación de colores requiere 16 colores"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "Abrir preferencias"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Global"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Apariencia"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "Nuevo perfil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Perfiles"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "Reiniciar la terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Codificaciones mostradas en el menú:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Activado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Acción"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Tecla de atajo del teclado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Activar atajos de teclado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Sobrescribir atajo del teclado existente"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Este atajo del teclado %s está asignado a %s\n"
-"¿Quieres desactivar el atajo del teclado para la otra acción y asignarla a "
-"esta?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Activar transparencia, requiere reiniciar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Ventana"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "desactivado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Estilo del título de la terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Pequeño"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Ninguno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Variante del tema"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Claro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Oscuro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Imagen de fondo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Seleccionar imagen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Todas las imagenes"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Restablecer imagen de fondo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Ampliar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Repetir"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centrar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Estirar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nombre de sesión predeterminado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "Aplicación"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Utilizar un separador ancho para los divisores"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Situar la barra lateral en la derecha"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Mostrar el título de la terminal incluso si es la única"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Tamaño"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Porcentaje de altura"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Porcentaje de anchura"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Claro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Opciones"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Mostrar la terminal en todas las áreas de trabajo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Indicar al gestor de ventanas que desactive las animaciones"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Ocultar la ventana cuando se pierde el foco"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Establecer título de la nueva terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Mostrar la terminal en el monitor activo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Mostrar en un monitor específico"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Comportamiento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Preguntar al crear una sesión nueva"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Dar el foco a la terminal al situar el ratón sobre ella"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Ocultar automáticamente el puntero del ratón mientras se escribe"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-"Cerrar terminales al pulsar con el botón central del ratón sobre el título"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Cerrar la ventana cuando se cierre la última sesión"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Enviar una notificación de escritorio cuando un proceso termine"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "En una instancia nueva"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Dividir a la derecha"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Dividir abajo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Dar el foco a la ventana"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Usar siempre el cuadro de diálogo de pegado avanzado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Advertir al hacer un pegado inseguro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Quitar el primer carácter del texto pegado si es un comentario o una "
-"declaración de variable"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Copiar texto automáticamente al portapapeles al seleccionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "General"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Desplazamiento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibilidad"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nombre del perfil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Tamaño del terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "columnas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "filas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Bloque"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Doble T"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Subrayado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Modo de parpadeo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Sistema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Activado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Desactivado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Sonido"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Icono y sonido"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Título de la terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Posición de la tarjeta"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Superior izquierda"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Superior derecha"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Inferior izquierda"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Inferior derecha"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Apariencia del texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Permitir texto en negrita"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Reajustar al redimensionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Fuente personalizada"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Elija una tipografía para la terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Combinación de colores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Personalizado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exportar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Paleta de color"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Usar los colores del tema para el primer plano/fondo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparencia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Difuminado sin el foco"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Fondo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Seleccionar el color de primer plano del cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Seleccionar el color de fondo del cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Resaltar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Seleccionar el color de resaltado para el primer plano"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Seleccionar el color de resaltado para el fondo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Difuminar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Seleccionar el color de difuminado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Seleccionar color de la tarjeta"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Seleccionar el color de fondo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Seleccionar el color del primer plano"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Primer plano"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Negro"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Rojo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Verde"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Naranja"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Azul"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Púrpura"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turquesa"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Gris"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Seleccionar color %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Seleccionar el color claro %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Exportar combinación de colores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Mostrar la barra de desplazamiento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Desplazar en la salida"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Desplazar al pulsar letras"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Limitar el desplazamiento hacía atrás a:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "La tecla Retroceso genera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automático"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII para Supr."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Secuencia de escape"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "La tecla Suprimir genera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Caracteres de anchura ambigua"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Estrechos"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Anchos"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Ejecutar el comando como intérprete de conexión"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Ejecutar un comando personalizado en vez de mi intérprete"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Cuando el comando termina"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Salir de la terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Reiniciar el comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Mantener la terminal abierta"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Enlaces personalizados"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Una lista de enlaces cliqueables en la terminal definidos por el usuario. "
-"Basados en las definiciones de expresiones regulares."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Desencadenadores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Los desencadenadores son expresiones regulares para comprobar texto de "
-"salida en la terminal. Cuando se detecte una coincidencia, se ejecutará una "
-"acción configurada."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Cambio de perfil automático"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Los perfiles se seleccionan automáticamente según los valores que se "
-"introduzcan aquí.\n"
-"Los valores se proporcionan en el formato <i>nombredeusuario@nombredeequipo:"
-"directorio</i>. Pueden omitirse tanto el nombre de equipo como el "
-"directorio, pero los dos puntos deben estar presentes. No se permiten "
-"entradas sin nombre de equipo y sin directorio."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Los perfiles se seleccionan de manera automática basados en los valores "
-"introducidos aquí.\n"
-"Los valores tienen que tener el siguiente formato: <i>nombre de host:"
-"directorio</i>. Tanto el nombre de host o el directorio pueden ser omitidos, "
-"pero los dos puntos tienen que estar presentes. No se permiten entradas sin "
-"el nombre de host o directorio."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Coincidir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Añadir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-"Escriba un nombredeusuario@nombredeequipo:directorio para buscar "
-"coincidencias"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Introduce el nombre de host:directorio para coincidir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Añadir nueva coincidencia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-"Edite un nombredeusuario@nombredeequipo:directorio para buscar coincidencias"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Editar nombre de host:directorio para coincidir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Editar coincidencia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Expresión regular"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Ignora mayús./minús."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Editar links personalizados"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parámetro"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Editar desencadenadores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Ventana"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1897,46 +1825,136 @@ msgstr ""
 "No se puede utilizar el modo Quake con los parámetros «maximize», «minimize» "
 "o «geometry»"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Comando"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "Título"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "No se pudo cargar la sesión debido a un error inesperado."
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "Texto"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "Título"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "Seleccionar color %s"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Seleccionar color %s"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Seleccionar todo"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "Parámetro"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Seleccionar color de la tarjeta"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "desactivado"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"¡Su versión de GTK es demasiado antigua, necesita por lo menos GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Se produjo una excepción inesperada"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Error: "
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "Persa"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Copiar"
+msgid "Terminix version: %s"
+msgstr "Abrir Terminix en %s"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "Abrir Terminix en %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "Abrir preferencias"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-12-30 18:42+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/terminix/"
@@ -14,181 +14,1574 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.11-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"Votre version de GTK est trop vieille, vous avez besoin au moins de GTK %d."
-"%d.%d !"
-
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Une exception inattendue est survenue"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "Erreur : "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Versions"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Version de Terminix : %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Version de VTE : %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Version de GTK : %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Fonctionnalités spéciales de Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Notifications activées=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Déclencheurs activés=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Badges activés=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "désactivé"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/preferences.d:212
 #, fuzzy
-msgid "Select Folder"
-msgstr "Sélectionner la couleur : %s"
+msgid "UpdateState"
+msgstr "UpdateState"
 
-#: source/gx/terminix/bookmark/bmeditor.d:74
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Select folder"
-msgstr "Sélectionner la couleur : %s"
+msgid "ExecuteCommand"
+msgstr "ExecuteCommand"
 
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Ok"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Annuler"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Nom"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
+#: source/gx/terminix/preferences.d:214
 #, fuzzy
-msgid "Select Path"
-msgstr "Tout sélectionner"
+msgid "SendNotification"
+msgstr "SendNotification"
 
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/preferences.d:215
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Titre"
+
+#: source/gx/terminix/preferences.d:216
+#, fuzzy
+msgid "PlayBell"
+msgstr "PlayBell"
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "Texte"
+
+#: source/gx/terminix/preferences.d:218
+#, fuzzy
+msgid "InsertPassword"
+msgstr "InsertPassword"
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "Titre"
+
+#: source/gx/terminix/preferences.d:326
+#, c-format
+msgid "%s (Copy)"
+msgstr "%s (copier)"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Général"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Commande"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Couleur"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Défilement"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibilité"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Paramètres"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Avancé"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Sélectionner la couleur du badge"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nom du profil"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Taille du terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "colonnes"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "lignes"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Forme du curseur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Bloc"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Barre verticale"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Souligner"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Mode clignotement"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Système"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Activer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Désactiver"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "« Bip » du terminal"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Aucun"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Son"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Icône"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Icône et son"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Titre du terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Badge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Position du badge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Nord-ouest"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Nord-est"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Sud-ouest"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Sud-est"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Apparence du texte"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Activer le texte en gras"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Réaligner après redimensionnement"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Police personnalisée"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Choisissez la police du terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID : %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Palettes prédéfinies"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Personnalisée"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exporter"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Palette de couleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Options"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Utiliser les couleurs du thème système"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparence"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Éclaircissement des terminaux sans le focus"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Texte"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Arrière-plan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Sélectionner la couleur de premier plan du curseur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Sélectionner la couleur de l'arrière-plan du curseur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Surligner"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Sélectionner la couleur de premier plan du surlignage"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Sélectionner la couleur de l'arrière-plan du surlignage"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Éclaircissement"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Sélectionner la couleur d'éclaircissement"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Sélectionner la couleur du badge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Sélectionner la couleur de l'arrière-plan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Sélectionner couleur de premier plan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Premier plan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Noir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Rouge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Vert"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Orange"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Bleu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Violet"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turquoise"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Gris"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Sélectionner la couleur : %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Sélectionner la couleur : %s clair"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Exporter la palette de couleurs"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Enregistrer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Annuler"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Tous les fichiers JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Tous les fichiers"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Afficher la barre de défilement"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Défilement sur la sortie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Défilement sur pression d'une touche"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Limiter les lignes d'historique à :"
+
+# Terminix gettext pot file
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "La touche « Retour arrière » émet"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatique"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Contrôle-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Séquence d'échappement"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "La touche « Suppr » émet"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Codage"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Caractères de largeur ambiguë"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Fins"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Larges"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Lancer la commande en tant que shell de connexion"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Exécuter une commande personnalisée au lieu du shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Lorsqu'une commande se termine"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Quitter le terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Relancer la commande"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Conserver le terminal ouvert"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Liens personnalisés"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Une liste des liens cliquables dans le terminal personnalisés par "
+"l'utilisateur basés sur des définitions d'expressions régulières."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Modifier"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Déclencheurs"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Les déclencheurs sont des expressions régulières utilisées pour contrôler le "
+"texte affiché dans le terminal. Quand un texte correspondant est détecté, "
+"l'action est exécutée."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Changement de profil automatique"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
+"saisies ici.\n"
+"Les valeurs sont saisies en utilisant le format "
+"<i>nom_d_utilisateur@nom_d_hôte:dossier</i>. Le nom d'hôte ou le dossier "
+"peuvent être omis, mais les deux points doivent être présents. Les valeurs "
+"sans nom d'hôte ni dossier ne sont pas permises."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
+"saisies ici.\n"
+"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
+"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
+"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Correspond à"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Ajouter"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Entrez un nom_d_utilisateur@nom_d_hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Entrez un nom_d'hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Ajouter une nouvelle correspondance"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Éditer un nom_d_utilisateur@nom_d_hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Éditer un nom_d'hôte:dossier qui doit correspondre"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Éditer la correspondance"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Supprimer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Expression régulière"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Insensible à la casse"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Éditer les liens personnalisés"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Appliquer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Action"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Paramètres"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Limiter le nombre de lignes que le déclencheur doit traiter à :"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Modifier les déclencheurs"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/titleeditor.d:108
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Window"
+msgstr "Nouvelle fenêtre"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Préférences"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Général"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Apparence"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Ajouter un profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Supprimer le profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Préférences"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profils"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profil : %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Cloner"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Utiliser pour les nouveaux terminaux"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Codages affichés dans le menu :"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Activé"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Touche de raccourci"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Activer les raccourcis"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Écraser le raccourcis actuel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Le raccourcis %s est déjà assigné à %s.\n"
+"Désactiver le raccourcis pour l'autre option et l'assigner à celle-ci à la "
+"place ?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Activer la transparence, requiert un redémarrage"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Fenêtre (%s)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "désactivé"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Style du titre du terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Petit"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Variante de thème"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Par défaut"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Clair"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Sombre"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Image d'arrière-plan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Sélectionner l'image"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Tous les fichiers image"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Réinitialiser l'image de fond d'écran"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Mettre à l'échelle"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Paver"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centrer"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Étirer"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nom de session par défaut"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Titre de l'application"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Utiliser une poignée large pour les séparateurs"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Mettre la barre latérale à droite"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Montrer le titre du terminal même s'il est le seul ouvert"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Taille"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Pourcentage de la hauteur"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Pourcentage de la largeur"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Alignement"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Gauche"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Droite"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Afficher le terminal sur tous les espaces de travail"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Demander au gestionnaire de fenêtres de désactiver l'animation"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Cacher la fenêtre quand le focus est perdu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Cacher la barre de titre de la fenêtre"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Afficher le terminal sur le moniteur actif"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Afficher sur un moniteur spécifique"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Comportement"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Invite de commande lors de la création d'une nouvelle session"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Faire le point sur le terminal lors du survolement de la souris"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Cacher automatiquement le pointeur de la souris pendant la frappe"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Fermer le terminal en faisant un clic du milieu sur le titre"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Zoomer sur le terminal en utilisant <ctrl> et la molette de la souris"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Fermer la fenêtre quand la dernière session est close"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Envoyer une notification bureau une fois le processus accompli"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Lors d'une nouvelle instance"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nouvelle fenêtre"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nouvelle Session"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Division droite"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Division basse"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Donner le focus à la fenêtre"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Presse-papier"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Toujours utiliser la fenêtre de dialogue avancée pour coller"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Alerter lors d'un collage dangeureux"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Supprimer le premier caractère si c'est un commentaire ou une déclaration de "
+"variable"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+"Copier automatiquement le texte dans le presse-papier quand sélectionné"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Titre"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Ne plus afficher ce message"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Fenêtre (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Session (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Fermer l'application"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Fermer la fenêtre"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Fermer la session"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Ok"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+"Cette commande demande les droits d'administrateur sur votre ordinateur"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copier des commandes depuis l'internet peut être dangereux. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Soyez sûr de comprendre ce que fait chaque partie de la commande."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformer"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Convertir les espaces en tabulations"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+"Convertir les retours chariot + sauts de ligne (CRLF) et les retours chariot "
+"(CR) en sauts de ligne (LF)"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Outil de collage avancé"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Coller"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Nom"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Nouveau"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Inclure le caractère de retour à la ligne dans le mot de passe"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Insérer le mot de passe"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Mot de passe"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Confirmer le mot de passe"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Ajouter un mot de passe"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Éditer le mot de passe"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Options de recherche"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Rechercher le suivant"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Rechercher le précédent"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Respecter la case"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Mots entiers seulement"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Utiliser comme expression régulière"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Recherche circulaire"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Fermer"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximiser"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Désactiver la synchronisation d'entrée pour ce terminal"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Lecture seule"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Modifier le profil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Codage"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Activer la synchronisation d'entrée pour ce terminal"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"La bibliothèque %s n'a pu être chargée, la fonctionnalité des mots de passe "
+"n'est pas disponible."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Bibliothèque non chargée"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Rechercher…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Mot de passe"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Sélectionner la couleur du badge"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Enregistrer la sortie sous…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Réinitialiser et effacer"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Options de disposition…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Autre"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Division à droite"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Division en bas"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Restaurer"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Ouvrir le lien"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Copier l'adresse du lien"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Copier"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Tout sélectionner"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Synchroniser l'entrée"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Une erreur inattendue est survenue, aucune information supplémentaire n'est "
+"disponible"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Une erreur inattendue est survenue : %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Sauvegarder la sortie du terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Tous les fichiers texte"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Les processus fils a quitté normalement avec le status %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Le processus fils a été interrompu par le signal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Le processus fils a été interrompu."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Relancer"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Ne pas coller"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Coller quand même"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Options de disposition"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Actif"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Chargement de session"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Les options « Actif » sont toujours actives et prennent effet "
+"immédiatement.\n"
+"Les options « Chargement de session » s'appliquent seulement quand une "
+"session est chargée."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Voir la barre latérale de session"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Créer une nouvelle session"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Ajouter un terminal à droite"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Ajouter un terminal en bas"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Chercher le texte dans le terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Changer le nom de la sesssion"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Entrer un nouveau nom pour la session"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Ouvrir…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Enregistrer sous…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nom…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Synchroniser l'entrée"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Plusieurs sessions sont ouvertes, fermer quand-même ?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Le nom de fichier « %s » n'existe pas"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Charger la session"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Ouvrir"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Impossible de charger la session en raison d'une erreur inattendue."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr ""
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Erreur lors du chargement de la session"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Sauvegarder la session"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "À propos"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Quitter"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
 msgstr ""
+"Boiethios\n"
+"MetotoSakamoto"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Crédits"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Définir le répertoire de travail pour le terminal"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DOSSIER"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Définir le profil de démarrage"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NOM_PROFIL"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Définir le titre du nouveau terminal"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITRE"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Ouvrir la session specifiée"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NOM_SESSION"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Envoyer une action à l'instance actuelle Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NOM_ACTION"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Exécuter le paramètre en tant que commande"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "COMMANDE"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximiser la fenêtre du terminal"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Réduire la fenêtre du terminal"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Mettre la fenêtre du terminal en plein écran"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Donner le focus à la fenêtre existante"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+"Démarrer une instance supplémentaire en tant que nouveau processus (non "
+"recommandé)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Définir la taille de la fenêtre ; par exemple : 80x24, ou 80x24+200+200 "
+"(COLSxLIGNES+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIE"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Ouvre une fenêtre à la quake ou change la visibilité d'une fenêtre déjà "
+"ouverte en mode quake"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Montre la version de Terminix et de ses composants"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Montrer directement la fenêtre de préférences de Terminix"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argument caché passant l'UUID du terminal"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINAL"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Il semble y avoir un problème avec la configuration du terminal.\n"
+"Ce problème n'est pas grave, mais le corriger permettra d'améliorer votre "
+"expérience.\n"
+"Cliquez sur le lien ci-dessous pour plus d'informations :"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Problème de configuration détecté"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Ne pas réafficher ce message"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Le fichier %s n'est pas un fichier JSON de palette de couleurs"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Une palette de couleurs requiert 16 couleurs"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Impossible de localiser le terminal lâché"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Impossible de localiser une session pour le terminal lâché"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -218,80 +1611,46 @@ msgstr "GtkD pour avoir fourni un wrapper GTK si excellent"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org pour le D, un langage si excellent"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Titre"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Titre de l'application"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "colonnes"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Application"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Chargement de session"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Session"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Impossible de localiser le terminal lâché"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Impossible de localiser une session pour le terminal lâché"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Par défaut"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nouvelle Session"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -431,1434 +1790,6 @@ msgstr "Vietnamien"
 msgid "Thai"
 msgstr "Thaï"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Options de disposition"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Actif"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Badge"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Chargement de session"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Les options « Actif » sont toujours actives et prennent effet "
-"immédiatement.\n"
-"Les options « Chargement de session » s'appliquent seulement quand une "
-"session est chargée."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Fermer"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximiser"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Désactiver la synchronisation d'entrée pour ce terminal"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Lecture seule"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "« Bip » du terminal"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Modifier le profil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Codage"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Activer la synchronisation d'entrée pour ce terminal"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"La bibliothèque %s n'a pu être chargée, la fonctionnalité des mots de passe "
-"n'est pas disponible."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Bibliothèque non chargée"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Enregistrer la sortie sous…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Réinitialiser"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Réinitialiser et effacer"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profils"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Codage"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Sélectionner la couleur du badge"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Rechercher…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Options de disposition…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Division à droite"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Division en bas"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Restaurer"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Ouvrir le lien"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Copier l'adresse du lien"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Copier"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Coller"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Tout sélectionner"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Presse-papier"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Synchroniser l'entrée"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Une erreur inattendue est survenue, aucune information supplémentaire n'est "
-"disponible"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Une erreur inattendue est survenue : %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Sauvegarder la sortie du terminal"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Enregistrer"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Tous les fichiers texte"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Tous les fichiers"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Les processus fils a quitté normalement avec le status %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Le processus fils a été interrompu par le signal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Le processus fils a été interrompu."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Relancer"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Ne pas coller"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Coller quand même"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Options de recherche"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Rechercher le suivant"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Rechercher le précédent"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Respecter la case"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Mots entiers seulement"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Utiliser comme expression régulière"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Recherche circulaire"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-"Cette commande demande les droits d'administrateur sur votre ordinateur"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copier des commandes depuis l'internet peut être dangereux. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Soyez sûr de comprendre ce que fait chaque partie de la commande."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformer"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Convertir les espaces en tabulations"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-"Convertir les retours chariot + sauts de ligne (CRLF) et les retours chariot "
-"(CR) en sauts de ligne (LF)"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Outil de collage avancé"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nouveau"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Modifier"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Supprimer"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Inclure le caractère de retour à la ligne dans le mot de passe"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Insérer le mot de passe"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Appliquer"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Mot de passe"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Confirmer le mot de passe"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Ajouter un mot de passe"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Éditer le mot de passe"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Ne plus afficher ce message"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Fenêtre (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Session (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Fermer l'application"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Fermer la fenêtre"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Fermer la session"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nouvelle fenêtre"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Préférences"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Raccourcis"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "À propos"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Quitter"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Crédits"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Définir le répertoire de travail pour le terminal"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DOSSIER"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Définir le profil de démarrage"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NOM_PROFIL"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Définir le titre du nouveau terminal"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITRE"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Ouvrir la session specifiée"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NOM_SESSION"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Envoyer une action à l'instance actuelle Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NOM_ACTION"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Exécuter le paramètre en tant que commande"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "COMMANDE"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximiser la fenêtre du terminal"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Réduire la fenêtre du terminal"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Mettre la fenêtre du terminal en plein écran"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Donner le focus à la fenêtre existante"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-"Démarrer une instance supplémentaire en tant que nouveau processus (non "
-"recommandé)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Définir la taille de la fenêtre ; par exemple : 80x24, ou 80x24+200+200 "
-"(COLSxLIGNES+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIE"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Ouvre une fenêtre à la quake ou change la visibilité d'une fenêtre déjà "
-"ouverte en mode quake"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Montre la version de Terminix et de ses composants"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Montrer directement la fenêtre de préférences de Terminix"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argument caché passant l'UUID du terminal"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINAL"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Il semble y avoir un problème avec la configuration du terminal.\n"
-"Ce problème n'est pas grave, mais le corriger permettra d'améliorer votre "
-"expérience.\n"
-"Cliquez sur le lien ci-dessous pour plus d'informations :"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Problème de configuration détecté"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Ne pas réafficher ce message"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Voir la barre latérale de session"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Créer une nouvelle session"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Ajouter un terminal à droite"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Ajouter un terminal en bas"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Chercher le texte dans le terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Changer le nom de la sesssion"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Entrer un nouveau nom pour la session"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Ouvrir…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Enregistrer sous…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nom…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Synchroniser l'entrée"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Plusieurs sessions sont ouvertes, fermer quand-même ?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Tous les fichiers JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Le nom de fichier « %s » n'existe pas"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Charger la session"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Ouvrir"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Impossible de charger la session en raison d'une erreur inattendue."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Erreur lors du chargement de la session"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Sauvegarder la session"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Le fichier %s n'est pas un fichier JSON de palette de couleurs"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Une palette de couleurs requiert 16 couleurs"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Préférences"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Général"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Apparence"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Ajouter un profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Supprimer le profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profil : %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Cloner"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Utiliser pour les nouveaux terminaux"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Codages affichés dans le menu :"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Activé"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Action"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Touche de raccourci"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Activer les raccourcis"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Écraser le raccourcis actuel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Le raccourcis %s est déjà assigné à %s.\n"
-"Désactiver le raccourcis pour l'autre option et l'assigner à celle-ci à la "
-"place ?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Activer la transparence, requiert un redémarrage"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Fenêtre (%s)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "désactivé"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Style du titre du terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Petit"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Aucun"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Variante de thème"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Clair"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Sombre"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Image d'arrière-plan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Sélectionner l'image"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Tous les fichiers image"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Réinitialiser l'image de fond d'écran"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Mettre à l'échelle"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Paver"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centrer"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Étirer"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nom de session par défaut"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Titre de l'application"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Utiliser une poignée large pour les séparateurs"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Mettre la barre latérale à droite"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Montrer le titre du terminal même s'il est le seul ouvert"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Taille"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Pourcentage de la hauteur"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Pourcentage de la largeur"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Alignement"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Gauche"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Droite"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Options"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Afficher le terminal sur tous les espaces de travail"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Demander au gestionnaire de fenêtres de désactiver l'animation"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Cacher la fenêtre quand le focus est perdu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Cacher la barre de titre de la fenêtre"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Afficher le terminal sur le moniteur actif"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Afficher sur un moniteur spécifique"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Comportement"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Invite de commande lors de la création d'une nouvelle session"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Faire le point sur le terminal lors du survolement de la souris"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Cacher automatiquement le pointeur de la souris pendant la frappe"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Fermer le terminal en faisant un clic du milieu sur le titre"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Zoomer sur le terminal en utilisant <ctrl> et la molette de la souris"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Fermer la fenêtre quand la dernière session est close"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Envoyer une notification bureau une fois le processus accompli"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Lors d'une nouvelle instance"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Division droite"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Division basse"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Donner le focus à la fenêtre"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Toujours utiliser la fenêtre de dialogue avancée pour coller"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Alerter lors d'un collage dangeureux"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Supprimer le premier caractère si c'est un commentaire ou une déclaration de "
-"variable"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-"Copier automatiquement le texte dans le presse-papier quand sélectionné"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Général"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Couleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Défilement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibilité"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Avancé"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nom du profil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Taille du terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "colonnes"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "lignes"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Forme du curseur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Bloc"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Barre verticale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Souligner"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Mode clignotement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Système"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Activer"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Désactiver"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Son"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Icône et son"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Titre du terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Position du badge"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Nord-ouest"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Nord-est"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Sud-ouest"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Sud-est"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Apparence du texte"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Activer le texte en gras"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Réaligner après redimensionnement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Police personnalisée"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Choisissez la police du terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID : %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Palettes prédéfinies"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Personnalisée"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exporter"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Palette de couleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Utiliser les couleurs du thème système"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparence"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Éclaircissement des terminaux sans le focus"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Texte"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Arrière-plan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Sélectionner la couleur de premier plan du curseur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Sélectionner la couleur de l'arrière-plan du curseur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Surligner"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Sélectionner la couleur de premier plan du surlignage"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Sélectionner la couleur de l'arrière-plan du surlignage"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Éclaircissement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Sélectionner la couleur d'éclaircissement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Sélectionner la couleur du badge"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Sélectionner la couleur de l'arrière-plan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Sélectionner couleur de premier plan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Premier plan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Noir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Rouge"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Vert"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Orange"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Bleu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Violet"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turquoise"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Gris"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Sélectionner la couleur : %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Sélectionner la couleur : %s clair"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Exporter la palette de couleurs"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Afficher la barre de défilement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Défilement sur la sortie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Défilement sur pression d'une touche"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Limiter les lignes d'historique à :"
-
-# Terminix gettext pot file
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "La touche « Retour arrière » émet"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatique"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Contrôle-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Séquence d'échappement"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "La touche « Suppr » émet"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Caractères de largeur ambiguë"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Fins"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Larges"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Lancer la commande en tant que shell de connexion"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Exécuter une commande personnalisée au lieu du shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Lorsqu'une commande se termine"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Quitter le terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Relancer la commande"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Conserver le terminal ouvert"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Liens personnalisés"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Une liste des liens cliquables dans le terminal personnalisés par "
-"l'utilisateur basés sur des définitions d'expressions régulières."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Déclencheurs"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Les déclencheurs sont des expressions régulières utilisées pour contrôler le "
-"texte affiché dans le terminal. Quand un texte correspondant est détecté, "
-"l'action est exécutée."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Changement de profil automatique"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
-"saisies ici.\n"
-"Les valeurs sont saisies en utilisant le format "
-"<i>nom_d_utilisateur@nom_d_hôte:dossier</i>. Le nom d'hôte ou le dossier "
-"peuvent être omis, mais les deux points doivent être présents. Les valeurs "
-"sans nom d'hôte ni dossier ne sont pas permises."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Les profils sont automatiquement sélectionnés en se basant sur les valeurs "
-"saisies ici.\n"
-"Les valeurs sont saisies en utilisant le format <i>nom_d_hôte:dossier</i>. "
-"Le nom d'hôte ou le dossier peuvent être omis, mais les deux points doivent "
-"être présents. Les valeurs sans nom d'hôte ni dossier ne sont pas permises."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Correspond à"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Ajouter"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Entrez un nom_d_utilisateur@nom_d_hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Entrez un nom_d'hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Ajouter une nouvelle correspondance"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Éditer un nom_d_utilisateur@nom_d_hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Éditer un nom_d'hôte:dossier qui doit correspondre"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Éditer la correspondance"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Expression régulière"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Insensible à la casse"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Éditer les liens personnalisés"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Paramètres"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Limiter le nombre de lignes que le déclencheur doit traiter à :"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Modifier les déclencheurs"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Nouvelle fenêtre"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1895,50 +1826,135 @@ msgstr ""
 "Vous ne pouvez pas utiliser le mode quake avec les paramètres de "
 "maximisation, de réduction, de plein écran, ou de géométrie"
 
-#: source/gx/terminix/preferences.d:212
-#, fuzzy
-msgid "UpdateState"
-msgstr "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "ExecuteCommand"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:214
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "SendNotification"
-msgstr "SendNotification"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Impossible de charger la session en raison d'une erreur inattendue."
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "Titre"
+msgid "Select Folder"
+msgstr "Sélectionner la couleur : %s"
 
-#: source/gx/terminix/preferences.d:216
+#: source/gx/terminix/bookmark/bmeditor.d:74
 #, fuzzy
-msgid "PlayBell"
-msgstr "PlayBell"
+msgid "Select folder"
+msgstr "Sélectionner la couleur : %s"
 
-#: source/gx/terminix/preferences.d:217
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
 #, fuzzy
-msgid "SendText"
-msgstr "Texte"
+msgid "Select Path"
+msgstr "Tout sélectionner"
 
-#: source/gx/terminix/preferences.d:218
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
 #, fuzzy
-msgid "InsertPassword"
-msgstr "InsertPassword"
+msgid "Parameters"
+msgstr "Paramètres"
 
-#: source/gx/terminix/preferences.d:219
+#: source/gx/terminix/bookmark/bmchooser.d:104
 #, fuzzy
-msgid "UpdateBadge"
-msgstr "Titre"
+msgid "Select Bookmark"
+msgstr "Sélectionner la couleur du badge"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "désactivé"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (copier)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"Votre version de GTK est trop vieille, vous avez besoin au moins de GTK %d."
+"%d.%d !"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Une exception inattendue est survenue"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Erreur : "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Versions"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Version de Terminix : %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Version de VTE : %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Version de GTK : %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Fonctionnalités spéciales de Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Notifications activées=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Déclencheurs activés=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Badges activés=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"

--- a/po/he.po
+++ b/po/he.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-10-21 14:33+0000\n"
 "Last-Translator: Niv Baehr <bloop93@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/terminix/"
@@ -18,181 +18,1570 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.9-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "גרסת GTK ישנה מדי, נדרש GTK  %d.%d.%d לפחות!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr ""
 
-#: source/app.d:127
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Unexpected exception occurred"
-msgstr "אירעה חריגה לא צפויה"
+msgid "ExecuteCommand"
+msgstr "פקודה"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "שגיאה: "
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
 
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:215
 #, fuzzy
-msgid "Versions"
-msgstr "פרסית"
+msgid "UpdateTitle"
+msgstr "כותרת"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "טקסט"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "כותרת"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "פתיחת Terminix ב־%s"
+msgid "%s (Copy)"
+msgstr "העתקה"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "פתיחת Terminix ב־%s"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "כללי"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "פתיחת העדפות"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "מושבת"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "בחירת צבע %s"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "בחירת צבע %s"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "אישור"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "ביטול"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "שם"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "בחירת הכל"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "פקודה"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "צבע"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "גלילה"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "תאימות"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "מתקדם"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "בחירת צבע %s"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "שם פרופיל"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "גודל מסוף"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "עמודות"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "שורות"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "איפוס"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "סמן"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "בלוק"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "קו תחתון"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "מצב הבהוב"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "מערכת"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "גע"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "תוק"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "פעמון מסוף"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "ללא"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "צליל"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "סמל"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "סמל וצליל"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "כותרת מסוף"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Southeast"
+msgstr "דרום אירופאי"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "מראה טקסט"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "אפשור טקסט מודגש"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "גלישה בעת שינוי הגודל"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "גופן מותאם אישית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "בחירת גופן מסוף"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "מזהה: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "תכנית צבעים"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "מותאם אישית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "לוח צבעים"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "אפשרויות"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "שימוש בצבעי ערכת הנושא עבור חזית/רקע"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "שקיפות"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "עמעום לא ממוקד"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "טקסט"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "רקע"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "בחירת צבע סמן חזית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "בחירת צבע סמן רקע"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "הדגשה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "בחירת צבע הדגשת חזית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "בחירת צבע הדגשת רקע"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "עמעום"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "בחירת צבע עמעום"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "בחירת צבע %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "בחירת צבע רקע"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "בחירת צבע חזית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "חזית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "שחור"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "אדום"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "ירוק"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "כתום"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "כחול"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "סגול"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "טורקיז"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "אפור"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "בחירת צבע %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, fuzzy, c-format
+msgid "Select %s Light Color"
+msgstr "בחירת צבע %s בהיר"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "תכנית צבעים"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "שמירה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "ביטול"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "כל קובצי ה־JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "כל הקבצים"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "הצגת פס הגלילה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+#, fuzzy
+msgid "Scroll on output"
+msgstr "גלילה בעת פלט"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+#, fuzzy
+msgid "Scroll on keystroke"
+msgstr "גלילה בעת לחיצה על מקש"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+#, fuzzy
+msgid "Limit scrollback to:"
+msgstr "הגבלת הגלילה ל:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "מקש Backspace מחולל"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+#, fuzzy
+msgid "Automatic"
+msgstr "אוטומטי"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "רצף מילוט"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "מקש Delete מחולל"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "קידוד"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+#, fuzzy
+msgid "Ambiguous-width characters"
+msgstr "תוים ברוחב משתנה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "צר"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "רחב"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "הרצת פקודה כמעטפת כניסה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "הרצת פקודה מותאמת אישית במקום המעטפת"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+#, fuzzy
+msgid "When command exits"
+msgstr "בעת יציאת פקודה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "יציאה מהמסוף"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "הפעלת הפקודה מחדש"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "השארת המסוף פתוח"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+#, fuzzy
+msgid "Custom Links"
+msgstr "גופן מותאם אישית"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "עריכה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "מעבר פרופיל אוטומטי"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "התאמה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+#, fuzzy
+msgid "Add"
+msgstr "הוספה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "הוספת התאמה חדשה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "עריכת התאמה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "מחיקה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "לא תלוי רישיות"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "החלה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "פעולה"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "עריכת פרופיל"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "מסוף"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "חלון"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "פתיחת העדפות"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "כללי"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "מראה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "קיצורים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "פרופיל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "עריכת פרופיל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "פרופיל חדש"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "העדפות"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "פרופילים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "פרופילים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "איפוס המסוף"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "קידודים המוצגים בתפריט:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "מופעל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "מקש קיצור"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "קיצורים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "דרוס קיצור קיים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, fuzzy, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"קיצור הדרך %s כבר מוגדר עבור %s\n"
+"האם לבטל את קיצור הדרך עבור הפעולה האחרת ולהגדיר אותו כאן במקומה?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "אפשור שקיפות, נדרשת הפעלה מחדש"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "חלון"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "רגיל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "מושבת"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "סגנון כותרת מסוף"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "קטן"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+#, fuzzy
+msgid "Theme variant"
+msgstr "גוון ערכת נושא"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "ברירת מחדל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "בהיר"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "כהה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "תמונת רקע"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "בחירת תמונה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "כל קובצי התמונה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "איפוס תמונת רקע"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "אריח"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "מרכז"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "מתיחה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "שם הפעלה ברירת מחדל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "יישום"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+#, fuzzy
+msgid "Use a wide handle for splitters"
+msgstr "שימוש בידית רחבה עבור המפרידים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "הגדרת תיקיית העבודה של המסוף"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "גודל"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "אחוז גובה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "אחוז רוחב"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "בהיר"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "קביעת כותרת המסוף החדש"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "שמירת תכני מסוף"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "התנהגות"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "בקשה בעת יצירת הפעלה חדשה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "מיקוד מסוף בעת מעבר העכבר מעליו"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "הסתרה אוטומטית של מצביע העכבר בעת הקלדה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "שליחת התראה לשולחן העבודה בסיום תהליך"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "במופע חדש"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "חלון חדש"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "הפעלה חדשה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "פיצול ימינה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "פיצול למטה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "מיקוד חלון"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "לוח גזירים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "תמיד להשתמש בתיבת דו־השיח של הדבקה מתקדמת"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "אזהרה בעת ניסיון להדבקה לא בטוחה"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "הסרת התו הראשון בהדבקה במקרה של הערה או הצהרת משתנים"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "כותרת"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "לא להציג הודעה זו שוב"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "חלון"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "הפעלה"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "יישום"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "מיקוד חלון"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "הפעלה חדשה"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "אישור"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "פקודה זו מבקשת גישה ניהולית למחשב"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "העתקת פקודות מהאינטרנט עלולה להיות מסוכנת. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "נא לוודא הבנה של כל חלק בפקודה זו."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "הדבקה מתקדמת"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "הדבקה"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "שם"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "חדש"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "אפשרויות חיפוש"
+
+#: source/gx/terminix/terminal/search.d:135
+#, fuzzy
+msgid "Find next"
+msgstr "חיפוש הבא"
+
+#: source/gx/terminix/terminal/search.d:141
+#, fuzzy
+msgid "Find previous"
+msgstr "חיפוש הקודם"
+
+#: source/gx/terminix/terminal/search.d:188
+#, fuzzy
+msgid "Match case"
+msgstr "התאמת רישיות"
+
+#: source/gx/terminix/terminal/search.d:189
+#, fuzzy
+msgid "Match entire word only"
+msgstr "התאמה למילה שלמה בלבד"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "התאמה כביטוי רגולרי"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "גלישת שורות"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "סגירה"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+#, fuzzy
+msgid "Maximize"
+msgstr "הגדלה"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "השבתת סנכרון קלט עבור מסוף זה"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "קריאה בלבד"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "עריכת פרופיל"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "קידוד"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "הפעלת סנכרון קלט עבור מסוף זה"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "חיפוש…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "בחירת צבע %s"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "שמירת הפלט…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "איפוס וניקוי"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "אפשרויות פריסה…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "אחר"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "הוספה ימינה"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "הוספה למטה"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "שחזור"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+#, fuzzy
+msgid "Open Link"
+msgstr "פתיחת קישור"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+#, fuzzy
+msgid "Copy Link Address"
+msgstr "העתקת כתובת קישור"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "העתקה"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "בחירת הכל"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "סנכרון הקלט"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "התרחשה שגיאה בלתי צפויה, אין מידע נוסף זמין"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, fuzzy, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "התרחשה שגיאה בלתי צפויה: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "שמירת פלט מסוף"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "כל קובצי הטקסט"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "תהליך הבן יצא כרגיל במצב %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "תהליך הבן נפל עם האות %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "תהליך הבן נפל."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "הפעלה מחדש"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+#, fuzzy
+msgid "Don't Paste"
+msgstr "לא להדביק"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+#, fuzzy
+msgid "Paste Anyway"
+msgstr "להדביק בכל זאת"
+
+#: source/gx/terminix/terminal/layout.d:30
+#, fuzzy
+msgid "Layout Options"
+msgstr "אפשרויות פריסה"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "פעיל"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "טעינת הפעלה"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"אפשרויות פעילות תמיד פעילות ומיושמות מיד.\n"
+"אפשרויות טעינת הפעלה מיושמות רק בעת טעינת קובץ הפעלה."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "הצגת חלונית הצד להפעלה"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "יצירת הפעלה חדשה"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "הוספת מסוף מימין"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "הוספת מסוף למטה"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "מציאת טקסט במסוף"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "שינוי שם ההפעלה"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "הזנת שם עבור ההפעלה"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "פתיחה…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "שמירה בשם…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "שם…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "סנכרון קלט"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "ישנם תהליכים שעדיין רצים, האם לסגור בכל זאת?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "הקובץ „%s” אינו קיים"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "טעינת הפעלה"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "פתיחה"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "לא ניתן לטעון הפעלה עקב שגיאה בלתי צפויה."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "שגיאה בטעינת הפעלה"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "שמירת הפעלה"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "אודות"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "יציאה"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Niv Baehr"
+
+#: source/gx/terminix/application.d:284
+#, fuzzy
+msgid "Credits"
+msgstr "תודות"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "הגדרת תיקיית העבודה של המסוף"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:624
+#, fuzzy
+msgid "Set the starting profile"
+msgstr "הגדרת הפרופיל הפותח"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
 msgstr ""
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "קביעת כותרת המסוף החדש"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "פתיחת ההפעלה שצוינה"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+#, fuzzy
+msgid "Send an action to current Terminix instance"
+msgstr "שליחת פעולה למופע Terminix הנוכחי"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "ביצוע הפקודה שהועברה"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "הגדלת חלון המסוף"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "הגדלת חלון המסוף"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "העברת חלון המסוף למסך מלא"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "מיקוד בחלון הקיים"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "התחלת מופע נוסף כתהליך חדש (לא מומלץ)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "קביעת גודל החלון; למשל: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+#, fuzzy
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"נראה שיש בעיה בהגדרות המסוף.\n"
+"זו אינה בעיה רצינית, אך תיקונה יכול לשפר את חווית השימוש.\n"
+"יש ללחוץ על הקישור למטה למידע נוסף:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "זוהתה בעיית תצורה"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "לא להציג הודעה זו שוב"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "הקובץ %s אינו קובץ JSON תואם תכנית צבעים"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "תכנית לוח הצבעים דורשת 16 צבעים"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "לא ניתן לאתר את המסוף שנשמט"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "לא ניתן לאתר הפעלה עבור המסוף שנשמט"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -220,80 +1609,46 @@ msgstr "GtkD שסיפק עוטף Gtk נהדר"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org עבור השפה הנהדרת D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "כותרת"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "יישום"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "עמודות"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "יישום"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "טעינת הפעלה"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "הפעלה"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "לא ניתן לאתר את המסוף שנשמט"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "לא ניתן לאתר הפעלה עבור המסוף שנשמט"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "ברירת מחדל"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "פרופיל"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "הפעלה חדשה"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -430,1437 +1785,6 @@ msgstr "וויאטנמית"
 msgid "Thai"
 msgstr "תאי"
 
-#: source/gx/terminix/terminal/layout.d:30
-#, fuzzy
-msgid "Layout Options"
-msgstr "אפשרויות פריסה"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "פעיל"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "טעינת הפעלה"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"אפשרויות פעילות תמיד פעילות ומיושמות מיד.\n"
-"אפשרויות טעינת הפעלה מיושמות רק בעת טעינת קובץ הפעלה."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "מסוף"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "סגירה"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-#, fuzzy
-msgid "Maximize"
-msgstr "הגדלה"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "השבתת סנכרון קלט עבור מסוף זה"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "קריאה בלבד"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "פעמון מסוף"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "עריכת פרופיל"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "קידוד"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "הפעלת סנכרון קלט עבור מסוף זה"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "שמירת הפלט…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "איפוס"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "איפוס וניקוי"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "פרופילים"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "קידוד"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "בחירת צבע %s"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "חיפוש…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "אפשרויות פריסה…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "הוספה ימינה"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "הוספה למטה"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "שחזור"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-#, fuzzy
-msgid "Open Link"
-msgstr "פתיחת קישור"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-#, fuzzy
-msgid "Copy Link Address"
-msgstr "העתקת כתובת קישור"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "העתקה"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "הדבקה"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "בחירת הכל"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "לוח גזירים"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "סנכרון הקלט"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "התרחשה שגיאה בלתי צפויה, אין מידע נוסף זמין"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, fuzzy, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "התרחשה שגיאה בלתי צפויה: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "שמירת פלט מסוף"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "שמירה"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "כל קובצי הטקסט"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "כל הקבצים"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "תהליך הבן יצא כרגיל במצב %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "תהליך הבן נפל עם האות %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "תהליך הבן נפל."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "הפעלה מחדש"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-#, fuzzy
-msgid "Don't Paste"
-msgstr "לא להדביק"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-#, fuzzy
-msgid "Paste Anyway"
-msgstr "להדביק בכל זאת"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "אפשרויות חיפוש"
-
-#: source/gx/terminix/terminal/search.d:135
-#, fuzzy
-msgid "Find next"
-msgstr "חיפוש הבא"
-
-#: source/gx/terminix/terminal/search.d:141
-#, fuzzy
-msgid "Find previous"
-msgstr "חיפוש הקודם"
-
-#: source/gx/terminix/terminal/search.d:188
-#, fuzzy
-msgid "Match case"
-msgstr "התאמת רישיות"
-
-#: source/gx/terminix/terminal/search.d:189
-#, fuzzy
-msgid "Match entire word only"
-msgstr "התאמה למילה שלמה בלבד"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "התאמה כביטוי רגולרי"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "גלישת שורות"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "פקודה זו מבקשת גישה ניהולית למחשב"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "העתקת פקודות מהאינטרנט עלולה להיות מסוכנת. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "נא לוודא הבנה של כל חלק בפקודה זו."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "הדבקה מתקדמת"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "חדש"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "עריכה"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "מחיקה"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "החלה"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "לא להציג הודעה זו שוב"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "חלון"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "הפעלה"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "יישום"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "מיקוד חלון"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "הפעלה חדשה"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "חלון חדש"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "העדפות"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "קיצורים"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "אודות"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "יציאה"
-
-#: source/gx/terminix/application.d:283
-#, fuzzy
-msgid "Credits"
-msgstr "תודות"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "הגדרת תיקיית העבודה של המסוף"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-#, fuzzy
-msgid "Set the starting profile"
-msgstr "הגדרת הפרופיל הפותח"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "קביעת כותרת המסוף החדש"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "פתיחת ההפעלה שצוינה"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-#, fuzzy
-msgid "Send an action to current Terminix instance"
-msgstr "שליחת פעולה למופע Terminix הנוכחי"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "ביצוע הפקודה שהועברה"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "הגדלת חלון המסוף"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "הגדלת חלון המסוף"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "העברת חלון המסוף למסך מלא"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "מיקוד בחלון הקיים"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "התחלת מופע נוסף כתהליך חדש (לא מומלץ)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "קביעת גודל החלון; למשל: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-#, fuzzy
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"נראה שיש בעיה בהגדרות המסוף.\n"
-"זו אינה בעיה רצינית, אך תיקונה יכול לשפר את חווית השימוש.\n"
-"יש ללחוץ על הקישור למטה למידע נוסף:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "זוהתה בעיית תצורה"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "לא להציג הודעה זו שוב"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "הצגת חלונית הצד להפעלה"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "יצירת הפעלה חדשה"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "הוספת מסוף מימין"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "הוספת מסוף למטה"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "מציאת טקסט במסוף"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "שינוי שם ההפעלה"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "הזנת שם עבור ההפעלה"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "פתיחה…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "שמירה בשם…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "שם…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "סנכרון קלט"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "ישנם תהליכים שעדיין רצים, האם לסגור בכל זאת?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "כל קובצי ה־JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "הקובץ „%s” אינו קיים"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "טעינת הפעלה"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "פתיחה"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "לא ניתן לטעון הפעלה עקב שגיאה בלתי צפויה."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "שגיאה בטעינת הפעלה"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "שמירת הפעלה"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "הקובץ %s אינו קובץ JSON תואם תכנית צבעים"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "תכנית לוח הצבעים דורשת 16 צבעים"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "פתיחת העדפות"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "כללי"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "מראה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "עריכת פרופיל"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "פרופיל חדש"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "פרופילים"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "איפוס המסוף"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "קידודים המוצגים בתפריט:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "מופעל"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "פעולה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "מקש קיצור"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "קיצורים"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "דרוס קיצור קיים"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, fuzzy, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"קיצור הדרך %s כבר מוגדר עבור %s\n"
-"האם לבטל את קיצור הדרך עבור הפעולה האחרת ולהגדיר אותו כאן במקומה?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "אפשור שקיפות, נדרשת הפעלה מחדש"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "חלון"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "רגיל"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "מושבת"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "סגנון כותרת מסוף"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "קטן"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "ללא"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-#, fuzzy
-msgid "Theme variant"
-msgstr "גוון ערכת נושא"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "בהיר"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "כהה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "תמונת רקע"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "בחירת תמונה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "כל קובצי התמונה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "איפוס תמונת רקע"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "אריח"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "מרכז"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "מתיחה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "שם הפעלה ברירת מחדל"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "יישום"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-#, fuzzy
-msgid "Use a wide handle for splitters"
-msgstr "שימוש בידית רחבה עבור המפרידים"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "הגדרת תיקיית העבודה של המסוף"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "גודל"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "אחוז גובה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "אחוז רוחב"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "בהיר"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "אפשרויות"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "קביעת כותרת המסוף החדש"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "שמירת תכני מסוף"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "התנהגות"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "בקשה בעת יצירת הפעלה חדשה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "מיקוד מסוף בעת מעבר העכבר מעליו"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "הסתרה אוטומטית של מצביע העכבר בעת הקלדה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "שליחת התראה לשולחן העבודה בסיום תהליך"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "במופע חדש"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "פיצול ימינה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "פיצול למטה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "מיקוד חלון"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "תמיד להשתמש בתיבת דו־השיח של הדבקה מתקדמת"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "אזהרה בעת ניסיון להדבקה לא בטוחה"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "הסרת התו הראשון בהדבקה במקרה של הערה או הצהרת משתנים"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "כללי"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "צבע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "גלילה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "תאימות"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "מתקדם"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "שם פרופיל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "גודל מסוף"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "עמודות"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "שורות"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "סמן"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "בלוק"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "IBeam"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "קו תחתון"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "מצב הבהוב"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "מערכת"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "גע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "תוק"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "צליל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "סמל וצליל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "כותרת מסוף"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "דרום אירופאי"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "מראה טקסט"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "אפשור טקסט מודגש"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "גלישה בעת שינוי הגודל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "גופן מותאם אישית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "בחירת גופן מסוף"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "מזהה: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "תכנית צבעים"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "מותאם אישית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "לוח צבעים"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "שימוש בצבעי ערכת הנושא עבור חזית/רקע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "שקיפות"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "עמעום לא ממוקד"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "טקסט"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "רקע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "בחירת צבע סמן חזית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "בחירת צבע סמן רקע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "הדגשה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "בחירת צבע הדגשת חזית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "בחירת צבע הדגשת רקע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "עמעום"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "בחירת צבע עמעום"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "בחירת צבע %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "בחירת צבע רקע"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "בחירת צבע חזית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "חזית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "שחור"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "אדום"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "ירוק"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "כתום"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "כחול"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "סגול"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "טורקיז"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "אפור"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "בחירת צבע %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, fuzzy, c-format
-msgid "Select %s Light Color"
-msgstr "בחירת צבע %s בהיר"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "תכנית צבעים"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "הצגת פס הגלילה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-#, fuzzy
-msgid "Scroll on output"
-msgstr "גלילה בעת פלט"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-#, fuzzy
-msgid "Scroll on keystroke"
-msgstr "גלילה בעת לחיצה על מקש"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-#, fuzzy
-msgid "Limit scrollback to:"
-msgstr "הגבלת הגלילה ל:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "מקש Backspace מחולל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-#, fuzzy
-msgid "Automatic"
-msgstr "אוטומטי"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "רצף מילוט"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "מקש Delete מחולל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-#, fuzzy
-msgid "Ambiguous-width characters"
-msgstr "תוים ברוחב משתנה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "צר"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "רחב"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "הרצת פקודה כמעטפת כניסה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "הרצת פקודה מותאמת אישית במקום המעטפת"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-#, fuzzy
-msgid "When command exits"
-msgstr "בעת יציאת פקודה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "יציאה מהמסוף"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "הפעלת הפקודה מחדש"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "השארת המסוף פתוח"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-#, fuzzy
-msgid "Custom Links"
-msgstr "גופן מותאם אישית"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "מעבר פרופיל אוטומטי"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "התאמה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-#, fuzzy
-msgid "Add"
-msgstr "הוספה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "הוספת התאמה חדשה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "עריכת התאמה"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "לא תלוי רישיות"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "עריכת פרופיל"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "חלון"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1893,46 +1817,135 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "פקודה"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "כותרת"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "לא ניתן לטעון הפעלה עקב שגיאה בלתי צפויה."
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "טקסט"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "כותרת"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "בחירת צבע %s"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "בחירת צבע %s"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "בחירת הכל"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "בחירת צבע %s"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "מושבת"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "גרסת GTK ישנה מדי, נדרש GTK  %d.%d.%d לפחות!"
+
+#: source/app.d:127
+#, fuzzy
+msgid "Unexpected exception occurred"
+msgstr "אירעה חריגה לא צפויה"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "שגיאה: "
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "פרסית"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "העתקה"
+msgid "Terminix version: %s"
+msgstr "פתיחת Terminix ב־%s"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "פתיחת Terminix ב־%s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "פתיחת העדפות"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-10-30 04:29+0000\n"
 "Last-Translator: Arrizal Amin <arrizalamin@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/terminix/"
@@ -18,179 +18,1549 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.9-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr ""
-
-#: source/app.d:128
-msgid "Error: "
-msgstr ""
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "Sesi"
+msgid "ExecuteCommand"
+msgstr "Perintah"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "PerbaruiJudul"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "PerbaruiJudul"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "Preferensi"
+msgid "%s (Copy)"
+msgstr "Salin"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "Preferensi"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Umum"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "Preferensi"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Ok"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Batal"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Perintah"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nama profil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:240
 #, fuzzy
-msgid "Select Bookmark"
-msgstr "Pilih Lencana Warna"
+msgid "Terminal size"
+msgstr "Terminal"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+#, fuzzy
+msgid "Terminal bell"
+msgstr "Terminal"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
-
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:301
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Terminal title"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+#, fuzzy
+msgid "Select Dim Color"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Pilih Lencana Warna"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Simpan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Batal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Berkas Semua JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Semua Berkas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Enkoding"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Sunting Profil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "Jendela Baru"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "Preferensi"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+#, fuzzy
+msgid "Appearance"
+msgstr "Preferensi"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Pintasan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Sunting Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "Profil Baru"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferensi"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "Pintasan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Bawaan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+#, fuzzy
+msgid "Select Image"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+#, fuzzy
+msgid "All Image Files"
+msgstr "Semua Berkas Teks"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nama sesi bawaan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Tampilkan judul terminal meskipun itu hanya satu-satunya terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Pisah Kanan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Atur direktori kerja terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Jendela Baru"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Sesi Baru"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Pisah Kanan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Pisah Bawah"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#, fuzzy
+msgid "Focus Window"
+msgstr "Jendela Baru"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Papan Klip"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Judul"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Jangan tampilkan pesan ini lagi"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "Sesi"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "Jendela Baru"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "Sesi Baru"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Ok"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Perintah ini meminta akses Administrasi ke komputer kamu"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Menyalin perintah dari internet bisa jadi berbahaya. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Pastikan anda mengerti apa yang dilakukan setiap bagian perintah ini."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Tempel"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Opsi Pencarian"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Tutup"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maksimalkan"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Nonfungsikan sinkronisasi masukan untuk terminal ini"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Hanya-Baca"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Sunting Profil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Enkoding"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Fungsikan sinkronisasi masukan untuk terminal ini"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Cari…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Pilih Lencana Warna"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+#, fuzzy
+msgid "Save Output…"
+msgstr "Simpan Sebagai…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Opsi Tata Letak…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+msgid "Other"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:745
+#, fuzzy
+msgid "Add Right"
+msgstr "Pisah Kanan"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Pulihkan"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Buka Tautan"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Salin Alamat Tautan"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Salin"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Sinkronisasi masukan"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Terjadi galat tak terduga, tidak ada informasi tambahan yang tersedia"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Terjadi galat tak terduga: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Simpan Keluaran Terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Semua Berkas Teks"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Proses anak keluar secara normal dengan status %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Proses anak dibatalkan dengan sinyal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Proses anak telah dibatalkan."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Jalankan ulang"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Jangan Tempel"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Tempel Saja"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Opsi Tata Letak"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Aktif"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Muatan Sesi"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Opsi aktif selalu berefek dan diaktifkan langsung.\n"
+"Opsi Muatan Sesi hanya diaktifkan ketika memuat berkas sesi."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Lihat bilah samping sesi"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Buat sesi baru"
+
+#: source/gx/terminix/appwindow.d:363
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Terminal"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:373
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Ubah Nama Sesi"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Ketik nama baru untuk sesi"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Buka…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Simpan Sebagai…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nama…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Sinkronisasi Masukan"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Terdapat proses yang masih berjalan, tetap tutup?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Nama Berkas '%s' tidak ada"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Muat Sesi"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Buka"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Tidak dapat memuat sesi dikarenakan galat tak terduga."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Galat Memuat Sesi"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Simpan Sesi"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Tentang"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Keluar"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Aan\n"
+"Arrizal Amin\n"
+"Mohamad Hasan Al Banna"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Kredit"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Atur direktori kerja terminal"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIREKTORI"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Atur profil awalan"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NAMA_PROFIL"
+
+#: source/gx/terminix/application.d:625
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Atur direktori kerja terminal"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Buka sesi spesifik"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NAMA_SESI"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Kirim aksi ke Terminix yang sekarang saat ini"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NAMA_AKSI"
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Eksekusi perintah yang terlewati"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maksimalkan jendela terminal"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Maksimalkan jendela terminal"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Layar-penuh jendela terminal"
+
+#: source/gx/terminix/application.d:632
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "Layar-penuh jendela terminal"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Sembunyikan argumentasi untuk melewati UUID terminal"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINAL"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Sepertinya ada isu dengan konfigurasi terminal.\n"
+"Isu ini tidak serius, tapi memperbaikinya akan memperbagus pengalaman anda.\n"
+"Klik tautan dibawah untuk info selanjutnya:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Isu Konfigurasi Terdeteksi"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Jangan tampilkan pesan ini lagi"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
 msgstr ""
 
 #: source/gx/terminix/constants.d:60
@@ -216,77 +1586,43 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Judul"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr ""
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr ""
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr ""
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Muatan Sesi"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Sesi"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Bawaan"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Sesi Baru"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -423,1417 +1759,6 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Opsi Tata Letak"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Aktif"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Muatan Sesi"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Opsi aktif selalu berefek dan diaktifkan langsung.\n"
-"Opsi Muatan Sesi hanya diaktifkan ketika memuat berkas sesi."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Tutup"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maksimalkan"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Nonfungsikan sinkronisasi masukan untuk terminal ini"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Hanya-Baca"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-#, fuzzy
-msgid "Terminal bell"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Sunting Profil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Enkoding"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Fungsikan sinkronisasi masukan untuk terminal ini"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-#, fuzzy
-msgid "Save Output…"
-msgstr "Simpan Sebagai…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profil"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Enkoding"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Pilih Lencana Warna"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Cari…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Opsi Tata Letak…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-#, fuzzy
-msgid "Add Right"
-msgstr "Pisah Kanan"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Pulihkan"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Buka Tautan"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Salin Alamat Tautan"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Salin"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Tempel"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Papan Klip"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Sinkronisasi masukan"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Terjadi galat tak terduga, tidak ada informasi tambahan yang tersedia"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Terjadi galat tak terduga: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Simpan Keluaran Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Simpan"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Semua Berkas Teks"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Semua Berkas"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Proses anak keluar secara normal dengan status %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Proses anak dibatalkan dengan sinyal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Proses anak telah dibatalkan."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Jalankan ulang"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Jangan Tempel"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Tempel Saja"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Opsi Pencarian"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Perintah ini meminta akses Administrasi ke komputer kamu"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Menyalin perintah dari internet bisa jadi berbahaya. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Pastikan anda mengerti apa yang dilakukan setiap bagian perintah ini."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Jangan tampilkan pesan ini lagi"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "Sesi"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "Jendela Baru"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "Sesi Baru"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Jendela Baru"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferensi"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Pintasan"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Tentang"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Keluar"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Kredit"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Atur direktori kerja terminal"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIREKTORI"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Atur profil awalan"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NAMA_PROFIL"
-
-#: source/gx/terminix/application.d:624
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Atur direktori kerja terminal"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Buka sesi spesifik"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NAMA_SESI"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Kirim aksi ke Terminix yang sekarang saat ini"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NAMA_AKSI"
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Eksekusi perintah yang terlewati"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maksimalkan jendela terminal"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Maksimalkan jendela terminal"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Layar-penuh jendela terminal"
-
-#: source/gx/terminix/application.d:631
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "Layar-penuh jendela terminal"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Sembunyikan argumentasi untuk melewati UUID terminal"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINAL"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Sepertinya ada isu dengan konfigurasi terminal.\n"
-"Isu ini tidak serius, tapi memperbaikinya akan memperbagus pengalaman anda.\n"
-"Klik tautan dibawah untuk info selanjutnya:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Isu Konfigurasi Terdeteksi"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Jangan tampilkan pesan ini lagi"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Lihat bilah samping sesi"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Buat sesi baru"
-
-#: source/gx/terminix/appwindow.d:363
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Terminal"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:373
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Ubah Nama Sesi"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Ketik nama baru untuk sesi"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Buka…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Simpan Sebagai…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nama…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Sinkronisasi Masukan"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Terdapat proses yang masih berjalan, tetap tutup?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Berkas Semua JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Nama Berkas '%s' tidak ada"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Muat Sesi"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Buka"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Tidak dapat memuat sesi dikarenakan galat tak terduga."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Galat Memuat Sesi"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Simpan Sesi"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr ""
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "Preferensi"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-#, fuzzy
-msgid "Appearance"
-msgstr "Preferensi"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Sunting Profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "Profil Baru"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "Terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "Pintasan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-#, fuzzy
-msgid "Select Image"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-#, fuzzy
-msgid "All Image Files"
-msgstr "Semua Berkas Teks"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nama sesi bawaan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Tampilkan judul terminal meskipun itu hanya satu-satunya terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Pisah Kanan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Atur direktori kerja terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Pisah Kanan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Pisah Bawah"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#, fuzzy
-msgid "Focus Window"
-msgstr "Jendela Baru"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Umum"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nama profil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-#, fuzzy
-msgid "Terminal size"
-msgstr "Terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-#, fuzzy
-msgid "Terminal title"
-msgstr "Terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-#, fuzzy
-msgid "Select Dim Color"
-msgstr "Pilih Semua"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Pilih Lencana Warna"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Sunting Profil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Jendela Baru"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1864,44 +1789,134 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "ExecuteCommand"
-msgstr "Perintah"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Tidak dapat memuat sesi dikarenakan galat tak terduga."
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "PerbaruiJudul"
-
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:219
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
 #, fuzzy
-msgid "UpdateBadge"
-msgstr "PerbaruiJudul"
+msgid "Select Folder"
+msgstr "Pilih Semua"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Pilih Semua"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Pilih Lencana Warna"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr ""
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr ""
+
+#: source/app.d:128
+msgid "Error: "
+msgstr ""
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "Sesi"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Salin"
+msgid "Terminix version: %s"
+msgstr "Preferensi"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "Preferensi"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "Preferensi"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"

--- a/po/it.po
+++ b/po/it.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-11 10:15+0000\n"
 "Last-Translator: Al-Xio Luzif <pirulazio@gmail.com>\n"
-"Language-Team: Italian "
-"<https://hosted.weblate.org/projects/terminix/translations/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/terminix/"
+"translations/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,175 +18,1553 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.12-dev\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "Aggiorna Stato"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "Esegui Comando"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "Invia Notifica"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "Aggiorna Titolo"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "Suona Campanella"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "Invia Testo"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "Inserisci Password"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "Aggiorna Badge"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"La tua versione delle GTK è troppo vecchia. Sono necessarie almeno le GTK %d."
-"%d.%d!"
+msgid "%s (Copy)"
+msgstr "%s (Copia)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Si è verificata un'eccezione imprevista"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Generale"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Errore: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Versioni"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Versione di Terminix: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Versione della libreria VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Versione delle GTK: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Caratteristiche speciali di Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Notifiche abilitate=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Trigger abilitati=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Badge abilitati=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "disabilitato"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Seleziona cartella"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Seleziona cartella"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Pulisci cartella"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Aggiungi segnalibro"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Modifica segnalibro"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Annulla"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Nome"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr "Percorso"
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Seleziona percorso"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Comando"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Protocollo di rete"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Colore"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Host"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Scorrimento"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Nome utente"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibilità"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Parametri"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Avanzate"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Seleziona segnalibro"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nome del profilo"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Dimensione del terminale"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "colonne"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "righe"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Azzera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Cursore"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Blocco"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Barra verticale"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Trattino basso"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Modalità di lampeggio"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Impostazione di sistema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Attivo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Disattivo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Campanella del terminale"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Nessuno"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Suono"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Icona"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr "Errore durante la deserializzazione del segnalibro"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Icona e suono"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr "Radice"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Titolo del terminale"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
-msgstr "Impossibile caricare i preferiti a causa di un errore imprevisto"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Badge"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Cartella"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Posizione del badge"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Connessione remota"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Nord-ovest"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Nord-est"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Sud-ovest"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Sud-est"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Aspetto del testo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Consenti il testo in grassetto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Riadatta il testo durante il ridimensionamento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Tipo di carattere personalizzato"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Scegli un tipo di carattere per il terminale"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Schema di colore"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Personalizzato"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Esporta"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Tavolozza dei colori"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Opzioni"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Utilizza i colori del tema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Trasparenza"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Offusca alla perdita del focus"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Testo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Sfondo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Seleziona il colore di primo piano del cursore"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Seleziona il colore di sfondo del cursore"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Evidenzia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Seleziona il colore di primo piano per le evidenziazioni"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Seleziona il colore di sfondo per le evidenziazioni"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Offusca"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Seleziona il colore di offuscamento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Seleziona il colore del badge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Seleziona il colore di sfondo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Seleziona il colore di primo piano"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Primo piano"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Nero"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Rosso"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Verde"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Arancione"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Blu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Viola"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turchese"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Grigio"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Seleziona il colore %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Seleziona il colore %s chiaro"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Esporta lo schema di colore"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Salva"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Annulla"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Tutti i file JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Tutti i file"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Mostra la barra di scorrimento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Scorri in presenza di output"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Scorri durante la battitura dei tasti"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Limita lo scorrimento all'indietro a:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Il tasto «BACKSPACE» genera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatico"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "CTRL-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Sequenza di escape"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Il tasto «Canc» genera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Codifica"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Caratteri a larghezza ambigua"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Stretto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Esteso"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Esegui il comando come una shell di login"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Esegui un comando personalizzato invece della shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Al termine del comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Chiudi il terminale"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Riavvia il comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Mantieni il terminale aperto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Collegamenti personalizzati"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Una lista di collegamenti personalizzati basati su espressioni regolari che "
+"possono essere cliccati nel terminale."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Modifica"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Trigger"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"I trigger sono espressioni regolari che vengono utilizzate per controllare "
+"il testo di output nel terminale. Quando viene rilevata una corrispondenza "
+"viene eseguita un azione predefinita."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Passaggio automatico di profilo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"I profili sono selezionati automaticamente in base ai valori inseriti qui.\n"
+"I valori sono in formato <i>username@hostname:directory</i>. Uno dei due "
+"valori, hostname o directory, può essere omesso, ma i due punti devono "
+"essere sempre presenti. I valori senza hostname o directory non sono "
+"consentiti."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"I profili sono selezionati automaticamente in base ai valori inseriti qui.\n"
+"I valori sono in formato <i>hostname:directory</i>. Uno dei due valori, "
+"hostname o directory, può essere omesso, ma i due punti devono essere sempre "
+"presenti. I valori senza hostname o directory non sono consentiti."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Corrisponde a"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Aggiungi"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Inserisci il valore username@hostname:directory"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Inserisci il valore hostname:directory"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Aggiungi una nuova corrispondenza"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Modifica il valore username@hostname:directory"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Modifica il valore hostname:directory"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Modifica la corrispondenza"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Elimina"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Espressione regolare"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Insensibile alle maiuscole/minuscole"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Modifica il collegamento personalizzato"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Applica"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Azione"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parametro"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Limita il numero di righe che il trigger deve elaborare a:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Modifica i trigger"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr "Riga %d: "
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminale"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr "Finestra"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr "Aiuto"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Preferenze di Terminix"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Globali"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Aspetto"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Modalità Quake (a scomparsa)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Segnalibri"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Tasti di scorciatoia"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profilo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Aggiungi un profilo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Elimina un profilo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profili"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profilo: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Clona"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Usa per i nuovi terminali"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Codifiche da mostrare nel menù:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Tasto di scorciatoia"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Abilita le scorciatoie da tastiera"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Sovrascrivi la scorciatoia esistente"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"La scorciatoia %s è già assegnata a %s.\n"
+"Vuoi riassegnarla a questa azione?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Attiva la trasparenza. È richiesto il riavvio"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr "Stile della finestra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normale"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr "Disabilita CSD"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr "Disabilita CSD, nascondi la barra degli strumenti"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr "Senza bordi"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr "La finestra richiede il riavvio"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Stile del titolo del terminale"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Piccolo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Varianti del tema"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Predefinito"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Chiaro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Scuro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Immagine di sfondo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Seleziona un'immagine"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Tutti i file immagine"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Azzera l'immagine di sfondo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Scalata"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "A mosaico"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centrata"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Estesa"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nome della sessione predefinita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Titolo dell'applicazione"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Usa un divisorio più largo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Posiziona il riquadro laterale sulla destra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Mostra il titolo del terminale anche se è l'unico"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Dimensione"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Altezza in percentuale"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Larghezza in percentuale"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Allineamento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Sinistra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Destra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Mostra il terminale in tutti gli spazi di lavoro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Suggerisci al Window Manager di disabilitare l'animazione"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Nascondi la finestra quando perde il focus"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Nascondi la barra del titolo della finestra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Visualizza il terminale sul monitor attivo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Visualizza il terminale su un monitor specifico"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Comportamento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Mostra una finestra di dialogo quando crei una nuova sessione"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Focus sul terminale quando il mouse è sopra di esso"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Nascondi automaticamente il puntatore del mouse quando digiti"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+"Chiudi il terminale cliccando con il tasto centrale del mouse sul titolo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+"Modifica l'ingrandimento del terminale usando il tasto «CTRL» e la rotella "
+"del mouse"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Chiudi la finestra alla chiusura dell'ultima sessione"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Invia una notifica al completamento di un processo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "A una nuova istanza"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nuova finestra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nuova sessione"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Dividi a destra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Dividi in basso"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Focus sulla finestra"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Appunti"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Usa sempre la finestra di dialogo avanzata per incollare"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Avverti quando si tenta di incollare un contenuto non sicuro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Sopprimi il primo carattere se è un commento o una dichiarazione di variabile"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Copia automaticamente il testo negli appunti quando lo selezioni"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr "Aggiungi segnalibro"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr "Modifica segnalibro"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr "Elimina segnalibro"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr "Deseleziona segnalibro"
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Titolo"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Non mostrare più questo messaggio"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Finestra (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sessione (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Chiudi l'applicazione"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Chiudi la finestra"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Chiudi la sessione"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Questo comando richiede l'accesso ai privilegi di Amministratore"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiare comandi da Internet può essere pericoloso "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Assicurati di comprendere cosa fa ciascuna parte di questo comando."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Trasforma"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Converti gli spazi in tabulazioni"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Converti i caratteri di fine riga CRLF e CR in LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Incolla avanzato"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Incolla"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Nome"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Nuovo"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Includi il carattere di ritorno a capo con la password"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Inserisci la password"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Password"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Conferma la password"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Aggiungi la password"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Modifica la password"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Opzioni di ricerca"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Trova successivo"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Trova precedente"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Sensibile alle maiuscole e minuscole"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Solo la parola intera"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Interpreta come una espressione regolare"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Riparti con la ricerca dall'inizio"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Chiudi"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Massimizza"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Disabilita la sincronizzazione dell'input per questo terminale"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Sola lettura"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Modifica il profilo"
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr "Cambia la codifica"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Abilita la sincronizzazione dell'input per questo terminale"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"La libreria %s non può essere caricata. La funzionalità di gestione delle "
+"password non è disponibile."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Libreria non caricata"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Cerca…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Password"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Aggiungi segnalibro..."
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Aggiungi segnalibro..."
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Salva l'output…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Azzera e pulisci"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Opzioni di disposizione…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Altro"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Aggiungi a destra"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Aggiungi in basso"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Ripristina"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Apri il collegamento"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Copia il collegamento"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Copia"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Seleziona tutto"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Sincronizza l'input"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+"L'espressione regolare '%s' del collegamento personalizzato presenta un "
+"errore, la ignoro"
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Si è verificato un errore imprevisto. Non è disponibile nessuna ulteriore "
+"informazione"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Si è verificato un errore imprevisto: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Salva l'output del terminale"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Tutti i file di testo"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Il processo figlio è terminato normalmente con lo stato %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Il processo figlio è stato interrotto dal segnale %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Il processo figlio è stato interrotto."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Rilancia"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Non incollare"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Incolla comunque"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Opzioni di disposizione"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Attiva"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Caricamento di sessione"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Le opzioni attive sono sempre in vigore e vengono applicate immediatamente.\n"
+"Le opzioni per il caricamento di una sessione si applicano solo quando si "
+"carica un file di sessione."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Visualizza il riquadro laterale delle sessioni"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Crea una nuova sessione"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Aggiungi un terminale a destra"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Aggiungi un terminale in basso"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Cerca nel terminale"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Cambia il nome della sessione"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Inserisci un nuovo nome per la sessione"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Apri…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Salva come…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nome…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Sincronizza input"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Ci sono multiple sessioni aperte. Le chiudo comunque?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Il File '%s' non esiste"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Carica la sessione"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Apri"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr "Impossibile caricare la sessione a causa di un errore imprevisto."
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Errore nel caricamento della sessione"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Salva la sessione"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Informazioni"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Esci"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Al-Xio Luzif\n"
+"boblaspugna\n"
+"Gabriele Lucci\n"
+"Karl Fiabeschi\n"
+"Luigi Maselli"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Riconoscimenti"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Imposta la directory di lavoro del terminale"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIRECTORY"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Imposta il profilo iniziale"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NOME_PROFILO"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Imposta il titolo del nuovo terminale"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITOLO"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Apri la sessione specificata"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NOME_SESSIONE"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Invia un'azione all'istanza corrente di Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NOME_AZIONE"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Esegui il parametro come un comando"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "COMANDO"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Massimizza la finestra del terminale"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Minimizza la finestra del terminale"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Finestra del terminale a schermo intero"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Focus sulla finestra esistente"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Avvia un'ulteriore istanza come un nuovo processo (Non raccomandato)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Imposta le dimensioni della finestra. Ad esempio: 80x24 o 80x24+200+200 "
+"(COLONNE+RIGHE+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIA"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Apre una finestra in modalità Quake (a scomparsa) o alterna la visibilità su "
+"una finestra già aperta in tale modalità"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Mostra Terminix e le versioni dei componenti da cui dipende"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Mostra la finestra con le preferenze di Terminix"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argomento nascosto dalla UUID del terminale"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINALE"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Sembra esserci un problema con la configurazione del terminale.\n"
+"Questo problema non è grave, ma correggerlo migliorerà la tua esperienza di "
+"uso.\n"
+"Clicca sul collegamento qui sotto per ulteriori informazioni:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "È stato rilevato un problema di configurazione"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Non mostrare più questo messaggio"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "File %s non è uno schema di colore JSON compatibile"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "La tavolozza richiede 16 colori"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Impossibile individuare il terminale rilasciato"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Impossibile individuare la sessione per il terminale rilasciato"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -216,75 +1594,41 @@ msgstr "GtkD per l'ottimo wrapper per le GTK"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org per un eccellente linguaggio, D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Titolo"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr "Titolo dell'icona"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Directory"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Nome dell'host"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Nome utente"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr "Colonne"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Righe"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Nome dell'applicazione"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Nome della sessione"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
 msgstr "Numero della sessione"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Impossibile individuare il terminale rilasciato"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Impossibile individuare la sessione per il terminale rilasciato"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Predefinito"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profilo"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nuova sessione"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -421,1417 +1765,6 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandese"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Opzioni di disposizione"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Attiva"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Badge"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Caricamento di sessione"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Le opzioni attive sono sempre in vigore e vengono applicate immediatamente.\n"
-"Le opzioni per il caricamento di una sessione si applicano solo quando si "
-"carica un file di sessione."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminale"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Chiudi"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Massimizza"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Disabilita la sincronizzazione dell'input per questo terminale"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Sola lettura"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Campanella del terminale"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Modifica il profilo"
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr "Cambia la codifica"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Abilita la sincronizzazione dell'input per questo terminale"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"La libreria %s non può essere caricata. La funzionalità di gestione delle "
-"password non è disponibile."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Libreria non caricata"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Salva l'output…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Azzera"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Azzera e pulisci"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profili"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Codifica"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Aggiungi segnalibro..."
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Seleziona segnalibro..."
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Segnalibri"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Cerca…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Opzioni di disposizione…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Aggiungi a destra"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Aggiungi in basso"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Ripristina"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Apri il collegamento"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Copia il collegamento"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Copia"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Incolla"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Seleziona tutto"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Appunti"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Sincronizza l'input"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-"L'espressione regolare '%s' del collegamento personalizzato presenta un "
-"errore, la ignoro"
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Si è verificato un errore imprevisto. Non è disponibile nessuna ulteriore "
-"informazione"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Si è verificato un errore imprevisto: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Salva l'output del terminale"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Salva"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Tutti i file di testo"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Tutti i file"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Il processo figlio è terminato normalmente con lo stato %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Il processo figlio è stato interrotto dal segnale %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Il processo figlio è stato interrotto."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Rilancia"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Non incollare"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Incolla comunque"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Opzioni di ricerca"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Trova successivo"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Trova precedente"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Sensibile alle maiuscole e minuscole"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Solo la parola intera"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Interpreta come una espressione regolare"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Riparti con la ricerca dall'inizio"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Questo comando richiede l'accesso ai privilegi di Amministratore"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiare comandi da Internet può essere pericoloso "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Assicurati di comprendere cosa fa ciascuna parte di questo comando."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Trasforma"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Converti gli spazi in tabulazioni"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Converti i caratteri di fine riga CRLF e CR in LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Incolla avanzato"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nuovo"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Modifica"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Elimina"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Includi il carattere di ritorno a capo con la password"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Inserisci la password"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Applica"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Password"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Conferma la password"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Aggiungi la password"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Modifica la password"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Non mostrare più questo messaggio"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Finestra (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sessione (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Chiudi l'applicazione"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Chiudi la finestra"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Chiudi la sessione"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nuova finestra"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Tasti di scorciatoia"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Informazioni"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Esci"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Riconoscimenti"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Imposta la directory di lavoro del terminale"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIRECTORY"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Imposta il profilo iniziale"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NOME_PROFILO"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Imposta il titolo del nuovo terminale"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITOLO"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Apri la sessione specificata"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NOME_SESSIONE"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Invia un'azione all'istanza corrente di Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NOME_AZIONE"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Esegui il parametro come un comando"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "COMANDO"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Massimizza la finestra del terminale"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Minimizza la finestra del terminale"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Finestra del terminale a schermo intero"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Focus sulla finestra esistente"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Avvia un'ulteriore istanza come un nuovo processo (Non raccomandato)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Imposta le dimensioni della finestra. Ad esempio: 80x24 o 80x24+200+200 "
-"(COLONNE+RIGHE+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIA"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Apre una finestra in modalità Quake (a scomparsa) o alterna la visibilità su "
-"una finestra già aperta in tale modalità"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Mostra Terminix e le versioni dei componenti da cui dipende"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Mostra la finestra con le preferenze di Terminix"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argomento nascosto dalla UUID del terminale"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINALE"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Sembra esserci un problema con la configurazione del terminale.\n"
-"Questo problema non è grave, ma correggerlo migliorerà la tua esperienza di "
-"uso.\n"
-"Clicca sul collegamento qui sotto per ulteriori informazioni:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "È stato rilevato un problema di configurazione"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Non mostrare più questo messaggio"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Visualizza il riquadro laterale delle sessioni"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Crea una nuova sessione"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Aggiungi un terminale a destra"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Aggiungi un terminale in basso"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Cerca nel terminale"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Cambia il nome della sessione"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Inserisci un nuovo nome per la sessione"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Apri…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Salva come…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nome…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Sincronizza input"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Ci sono multiple sessioni aperte. Le chiudo comunque?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Tutti i file JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Il File '%s' non esiste"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Carica la sessione"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Apri"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Impossibile caricare la sessione a causa di un errore imprevisto."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Errore nel caricamento della sessione"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Salva la sessione"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "File %s non è uno schema di colore JSON compatibile"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "La tavolozza richiede 16 colori"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr "Aggiungi segnalibro"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr "Modifica segnalibro"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr "Elimina segnalibro"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr "Deseleziona segnalibro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Preferenze di Terminix"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Globali"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Aspetto"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Modalità Quake (a scomparsa)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Aggiungi un profilo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Elimina un profilo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profilo: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Clona"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Usa per i nuovi terminali"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Codifiche da mostrare nel menù:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Abilitato"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Azione"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Tasto di scorciatoia"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Abilita le scorciatoie da tastiera"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Sovrascrivi la scorciatoia esistente"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"La scorciatoia %s è già assegnata a %s.\n"
-"Vuoi riassegnarla a questa azione?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Attiva la trasparenza. È richiesto il riavvio"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr "Stile della finestra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normale"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr "Disabilita CSD"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr "Disabilita CSD, nascondi la barra degli strumenti"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr "Senza bordi"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr "La finestra richiede il riavvio"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Stile del titolo del terminale"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Piccolo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Nessuno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Varianti del tema"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Chiaro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Scuro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Immagine di sfondo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Seleziona un'immagine"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Tutti i file immagine"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Azzera l'immagine di sfondo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Scalata"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "A mosaico"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centrata"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Estesa"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nome della sessione predefinita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Titolo dell'applicazione"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Usa un divisorio più largo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Posiziona il riquadro laterale sulla destra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Mostra il titolo del terminale anche se è l'unico"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Dimensione"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Altezza in percentuale"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Larghezza in percentuale"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Allineamento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Sinistra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Destra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Opzioni"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Mostra il terminale in tutti gli spazi di lavoro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Suggerisci al Window Manager di disabilitare l'animazione"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Nascondi la finestra quando perde il focus"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Nascondi la barra del titolo della finestra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Visualizza il terminale sul monitor attivo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Visualizza il terminale su un monitor specifico"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Comportamento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Mostra una finestra di dialogo quando crei una nuova sessione"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Focus sul terminale quando il mouse è sopra di esso"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Nascondi automaticamente il puntatore del mouse quando digiti"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-"Chiudi il terminale cliccando con il tasto centrale del mouse sul titolo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-"Modifica l'ingrandimento del terminale usando il tasto «CTRL» e la rotella "
-"del mouse"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Chiudi la finestra alla chiusura dell'ultima sessione"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Invia una notifica al completamento di un processo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "A una nuova istanza"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Dividi a destra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Dividi in basso"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Focus sulla finestra"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Usa sempre la finestra di dialogo avanzata per incollare"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Avverti quando si tenta di incollare un contenuto non sicuro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Sopprimi il primo carattere se è un commento o una dichiarazione di variabile"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Copia automaticamente il testo negli appunti quando lo selezioni"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Generale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Colore"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Scorrimento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibilità"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Avanzate"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nome del profilo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Dimensione del terminale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "colonne"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "righe"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Cursore"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Blocco"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Barra verticale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Trattino basso"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Modalità di lampeggio"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Impostazione di sistema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Attivo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Disattivo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Suono"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Icona e suono"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Titolo del terminale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Posizione del badge"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Nord-ovest"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Nord-est"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Sud-ovest"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Sud-est"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Aspetto del testo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Consenti il testo in grassetto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Riadatta il testo durante il ridimensionamento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Tipo di carattere personalizzato"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Scegli un tipo di carattere per il terminale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Schema di colore"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Personalizzato"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Esporta"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Tavolozza dei colori"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Utilizza i colori del tema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Trasparenza"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Offusca alla perdita del focus"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Testo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Sfondo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Seleziona il colore di primo piano del cursore"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Seleziona il colore di sfondo del cursore"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Evidenzia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Seleziona il colore di primo piano per le evidenziazioni"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Seleziona il colore di sfondo per le evidenziazioni"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Offusca"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Seleziona il colore di offuscamento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Seleziona il colore del badge"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Seleziona il colore di sfondo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Seleziona il colore di primo piano"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Primo piano"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Nero"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Rosso"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Verde"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Arancione"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Blu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Viola"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turchese"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Grigio"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Seleziona il colore %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Seleziona il colore %s chiaro"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Esporta lo schema di colore"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Mostra la barra di scorrimento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Scorri in presenza di output"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Scorri durante la battitura dei tasti"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Limita lo scorrimento all'indietro a:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Il tasto «BACKSPACE» genera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatico"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "CTRL-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Sequenza di escape"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Il tasto «Canc» genera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Caratteri a larghezza ambigua"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Stretto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Esteso"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Esegui il comando come una shell di login"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Esegui un comando personalizzato invece della shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Al termine del comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Chiudi il terminale"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Riavvia il comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Mantieni il terminale aperto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Collegamenti personalizzati"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Una lista di collegamenti personalizzati basati su espressioni regolari che "
-"possono essere cliccati nel terminale."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Trigger"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"I trigger sono espressioni regolari che vengono utilizzate per controllare "
-"il testo di output nel terminale. Quando viene rilevata una corrispondenza "
-"viene eseguita un azione predefinita."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Passaggio automatico di profilo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"I profili sono selezionati automaticamente in base ai valori inseriti qui.\n"
-"I valori sono in formato <i>username@hostname:directory</i>. Uno dei due "
-"valori, hostname o directory, può essere omesso, ma i due punti devono "
-"essere sempre presenti. I valori senza hostname o directory non sono "
-"consentiti."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"I profili sono selezionati automaticamente in base ai valori inseriti qui.\n"
-"I valori sono in formato <i>hostname:directory</i>. Uno dei due valori, "
-"hostname o directory, può essere omesso, ma i due punti devono essere sempre "
-"presenti. I valori senza hostname o directory non sono consentiti."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Corrisponde a"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Aggiungi"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Inserisci il valore username@hostname:directory"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Inserisci il valore hostname:directory"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Aggiungi una nuova corrispondenza"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Modifica il valore username@hostname:directory"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Modifica il valore hostname:directory"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Modifica la corrispondenza"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Espressione regolare"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Insensibile alle maiuscole/minuscole"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Modifica il collegamento personalizzato"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parametro"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Limita il numero di righe che il trigger deve elaborare a:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Modifica i trigger"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr "Riga %d: "
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr "Finestra"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr "Aiuto"
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1866,42 +1799,129 @@ msgstr ""
 "Non puoi usare la modalità Quake con le opzioni maximize, minimize, e "
 "geometry"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "Aggiorna Stato"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr "Errore durante la deserializzazione del segnalibro"
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "Esegui Comando"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr "Radice"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "Invia Notifica"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Impossibile caricare i preferiti a causa di un errore imprevisto"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "Aggiorna Titolo"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Cartella"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "Suona Campanella"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr "Percorso"
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "Invia Testo"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Connessione remota"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "Inserisci Password"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Seleziona cartella"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "Aggiorna Badge"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Seleziona cartella"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Pulisci cartella"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Aggiungi segnalibro"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Modifica segnalibro"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Seleziona percorso"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Protocollo di rete"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Host"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Nome utente"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Parametri"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Seleziona segnalibro"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "disabilitato"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Copia)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"La tua versione delle GTK è troppo vecchia. Sono necessarie almeno le GTK %d."
+"%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Si è verificata un'eccezione imprevista"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Errore: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Versioni"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Versione di Terminix: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Versione della libreria VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Versione delle GTK: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Caratteristiche speciali di Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Notifiche abilitate=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Trigger abilitati=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Badge abilitati=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"
@@ -2444,6 +2464,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix è stato testato su GNOME e Unity."
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Seleziona segnalibro..."
 
 #~ msgid "The expression %s is not a valid regex"
 #~ msgstr "%s non è una espressione regolare valida"

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-01-08 03:36+0000\n"
 "Last-Translator: ふうせん Fu-sen. | BALLOON a.k.a.  <balloonakafusen@gmail."
 "com>\n"
@@ -19,179 +19,1564 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.11-dev\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "UpdateState"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "ExecuteCommand"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "SendNotification"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "UpdateTitle"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "PlayBell"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "SendText"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "InsertPassword"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "UpdateBadge"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "GTK のバージョンは古すぎます。 GTK %d.%d.%d 以上が必要です！"
+msgid "%s (Copy)"
+msgstr "%s (コピー)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "予期しない例外が発生しました"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "エラー: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "バージョン"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Terminix バージョン: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "VTE バージョン: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "GTK バージョン: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Terminix の特長"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "通知を有効にしました=％b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "トリガーを有効にしました=％b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "バッジを有効にしました=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "無効"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:99
 #, fuzzy
-msgid "Select Folder"
-msgstr "%s の色を選択して下さい"
+msgid "General"
+msgstr "一般"
 
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "%s の色を選択して下さい"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "名前"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "すべて選択"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "コマンド"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:418
+#: source/gx/terminix/prefeditor/profileeditor.d:101
 #, fuzzy
-msgid "Parameters"
-msgstr "パラメーター"
+msgid "Color"
+msgstr "カラー"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "スクロール"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "互換性"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
 #, fuzzy
-msgid "Select Bookmark"
-msgstr "バッジの色を選択して下さい"
+msgid "Advanced"
+msgstr "高度"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "プロファイル名"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "ターミナルのサイズ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "横の文字数"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "縦の文字数"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "リセット"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "カーソル"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "ブロック"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+#, fuzzy
+msgid "IBeam"
+msgstr "エの形状"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "下線"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "点滅モード"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "システム"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "オン"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "オフ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "ターミナルベル"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "なし"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "音"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "アイコン"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "アイコン・音"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "ターミナルのタイトル"
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "バッジ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "バッジの位置"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Northwest"
+msgstr "左上"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+#, fuzzy
+msgid "Northeast"
+msgstr "右上"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+#, fuzzy
+msgid "Southwest"
+msgstr "左下"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+#, fuzzy
+msgid "Southeast"
+msgstr "右下"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "テキストの外観"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "強調テキストを適用"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+#, fuzzy
+msgid "Rewrap on resize"
+msgstr "サイズを変更して折り返す"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "カスタムフォント"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "ターミナルフォントを選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "カラースキーマー"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "カスタム"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "エクスポート"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "配色パレット"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "オプション"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "前景色・背景色にテーマカラーを使用する"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+#, fuzzy
+msgid "Transparency"
+msgstr "透明度"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "画面を暗くしてフォーカスしない"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "テキスト"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "背景"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "カーソルの前景色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "カーソルの背景色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "ハイライト"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "ハイライトの前景色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "ハイライトの背景色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "画面の暗転"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "暗転を行う色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "バッジの色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "背景色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "前景色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "前景"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "黒"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "赤"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "緑"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "橙"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "青"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "紫"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "水色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "灰色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "%s の色を選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "%s のライトカラーを選択して下さい"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "カラースキームをエクスポート"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "保存"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "すべての JSON ファイル"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "すべてのファイル"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "スクロールバーを表示"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "出力をスクロールする"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "キーストロークをスクロールする"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+#, fuzzy
+msgid "Limit scrollback to:"
+msgstr "スクロールログの上限:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+#, fuzzy
+msgid "Backspace key generates"
+msgstr "Back Space キーの動作"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "自動"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+#, fuzzy
+msgid "Escape sequence"
+msgstr "Escape シーケンス"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+#, fuzzy
+msgid "Delete key generates"
+msgstr "Delete キーの動作"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "エンコード"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+#, fuzzy
+msgid "Ambiguous-width characters"
+msgstr "あいまいな文字"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "狭"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "広"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "シェルログイン時に実行するコマンド"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "シェルの代わりにカスタムコマンドを実行する"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+#, fuzzy
+msgid "When command exits"
+msgstr "コマンド終了時の動作"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "ターミナルを終了する"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "コマンドを再度開始する"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "開いているターミナルをそのままにする"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "カスタムリンク"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"正規表現の定義に基づきターミナルでクリックできるユーザ定義リンクの一覧です。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "編集"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+#, fuzzy
+msgid "Triggers"
+msgstr "トリガー"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+#, fuzzy
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"トリガーはターミナルの出力テキストを確認するために使用される正規表現です。 検"
+"出一致すると設定アクションを実行します。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "自動プロファイル切り替え"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"プロファイルはここに入力された値に基づいて自動的に選択されます。\n"
+"値は <i>ユーザー名@ホスト名:ディレクトリ</i> 形式で入力します。 ホスト名また"
+"はディレクトリは省略できますが、コロンは必要です。 ホスト名もディレクトリもな"
+"いエントリは許可されません。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"プロファイルはここに入力された値に基づいて自動的に選択されます。\n"
+"値は <i>ホスト名:ディレクトリ</i> の形式で入力します。 ホスト名またはディレク"
+"トリは省略できますが、コロンは必要です。 ホスト名もディレクトリもないエントリ"
+"は許可されません。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "一致"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "追加"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "一致させる ユーザー名@ホスト名:ディレクトリ を入力"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "一致させる ホスト名@ディレクトリ を入力"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "新たな一致条件を追加"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "一致させる ユーザー名@ホスト名:ディレクトリ の編集"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "一致させる ホスト名:ディレクトリ の編集"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "一致条件の編集"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "削除"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Regex"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "大文字・小文字を区別しない"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "カスタムリンクの編集"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "適用"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "アクション"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "パラメーター"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "トリガー処理の制限行数:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "トリガーの編集"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "ターミナル"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "ウインドウ"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Terminix 設定"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "グローバル"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "外観"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "振動"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "ショートカット"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "プロファイル"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "プロファイルの追加"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "プロファイルの削除"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "設定"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "プロファイル"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "プロファイル: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "複製"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "新しいターミナルを使用"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "メニュー表示のエンコード:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "有効"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "ショートカットキー"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "ショートカットを有効にする"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "既存のショートカットを上書きする"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"ショートカット %s はすでに %s で割り当てられています。\n"
+"他アクションのショートカットを無効にして、代わりにこれを割り当てますか？"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "透明度を有効にする 再起動が必要"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "ウインドウ (%s)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "通常"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "無効"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "ターミナルタイトルの形式"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "小さい"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "テーマの状態"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "デフォルト"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "明るい"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "暗い"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "背景画像"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "画像を選択"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "すべての画像ファイル"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "背景画像をリセット"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "スケール"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "タイル"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "中央"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "ストレッジ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "デフォルトセッションの名称"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "アプリケーションタイトル"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "分割に広いハンドルを使用する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "サイドバーを右へ置く"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "唯一のターミナルであってもターミナルのタイトルを表示する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "サイズ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "縦のパーセント"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "横のパーセント"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "配置"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "左"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "右"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "すべてのワークスペースにターミナルを表示する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "アニメーションを無効にするウィンドウマネージャのヒントを設定する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "フォーカスが失われた時にウィンドウを非表示にする"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "ウィンドウのタイトルバーを隠す"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "有効なモニタにターミナルを表示する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "特定のモニタに表示する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "動作"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "新しいセッションを作成した時のプロンプト"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "マウスが上を移動するときにターミナルへフォーカスする"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "入力時にマウスポインタを自動的に隠す"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "タイトルで中マウスボタンをクリックして端末を閉じる"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "<Control> キー＋ホイールでターミナルを拡大・縮小する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "最後のセッションが閉じられた時にウィンドウを閉じる"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "プロセス完了時にデスクトップ通知を送信する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+#, fuzzy
+msgid "On new instance"
+msgstr "新しいインスタンスについて"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "新しいウインドウ"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "新しいセッション"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "右に分割"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "下に分割"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "ウインドウのフォーカス"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "クリップボード"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "常に高度な貼り付けダイアログを使用する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "安全でない貼り付けを試みるときに警告する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "コメントまたは変数宣言の場合、貼り付けの頭文字を削除する"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "選択時にテキストをクリップボードへ自動的にコピーする"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "タイトル"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "再度表示しない"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "ウインドウ (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "セッション (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "アプリケーションを閉じる"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "ウインドウを閉じる"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "セッションを閉じる"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "このコマンドはコンピュータへの管理者アクセスを要求しています"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "インターネットからコマンドのコピーは危険です。 "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "このコマンドの各部が何をするのかを理解してください。"
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "変換"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "スペースをタブへ変換"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "CRLF および CR を LF へ変換"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "高度な貼り付け"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "貼り付け"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "名前"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+#, fuzzy
+msgid "New"
+msgstr "新規"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "改行文字にパスワードを含める"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "パスワードを挿入する"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "パスワード"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "確認パスワード"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "パスワードを追加"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "パスワードの編集"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "検索オプション"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "次を検索"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "前を検索"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "一致する条件"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "単語全体を検出"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "正規表現で検出"
+
+#: source/gx/terminix/terminal/search.d:191
+#, fuzzy
+msgid "Wrap around"
+msgstr "改行の処理"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "閉じる"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+#, fuzzy
+msgid "Disable input synchronization for this terminal"
+msgstr "このターミナルの入力同期を無効にする"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "読み込みのみ"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "プロファイルの編集"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "エンコード"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "このターミナルの入力同期を有効にする"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"ライブラリー %s をロードできませんでした。パスワード機能は使用できません。"
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "ライブラリーを読み込めません"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "検索…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "パスワード"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "バッジの色を選択して下さい"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "出力の保存…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "リセット・クリアー"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "レイアウトオプション…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "その他"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "右に追加"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "下に追加"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+#, fuzzy
+msgid "Restore"
+msgstr "復元"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "リンクを開く"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "リンクアドレスをコピー"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "コピー"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "すべて選択"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "同期入力"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "予期しないエラーが発生しました。追加情報はありません"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "予期しないエラーが発生しました: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "ターミナル出力の保存"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "すべてのテキストファイル"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "子プロセス %d は正常の状態で終了しました"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "子プロセス %d はシグナルによって中止されました。"
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "子プロセスは中止しました。"
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "再起動"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "貼り付けない"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "常に貼り付け"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "レイアウトオプション"
+
+#: source/gx/terminix/terminal/layout.d:45
+#, fuzzy
+msgid "Active"
+msgstr "アクティブ"
+
+#: source/gx/terminix/terminal/layout.d:69
+#, fuzzy
+msgid "Session Load"
+msgstr "セッションを読み込む"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"アクティブなオプションは常に有効であり、すぐに適用されます。\n"
+"セッションロードオプションはセッションファイルをロードするときにのみ適用され"
+"ます。"
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "セッションサイドバーを表示"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "新しいセッションを生成"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "右にターミナルを追加"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "下にターミナルを追加"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "ターミナルのテキストを検索"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "セッション名を変更"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "セッションの新しい名称を入力して下さい"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "開く…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "名前をつけて保存…"
+
+#: source/gx/terminix/appwindow.d:648
+#, fuzzy
+msgid "Name…"
+msgstr "名前…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "同期入力"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "複数のセッションが開いています。閉じてよろしいですか？"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "ファイル名 '%s' が見つかりません"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "セッションの読み込み"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "開く"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "予期しないエラーのためセッションを読み込めませんでした。"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr ""
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "セッション読み込みエラー"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "セッションを保存"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+#, fuzzy
+msgid "About"
+msgstr "情報"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "終了"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "ふうせん Fu-sen. | BALLOON a.k.a."
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "開発者"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "ターミナルの作業ディレクトリを設定"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIRECTORY"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "開始時のプロファイルを設定"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "新しいターミナルのタイトルを設定"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITLE"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "指定したセッションを開く"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "現在の Terminix インスタンスにアクションを送信"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "パラメータをコマンドとして実行"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "COMMAND"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "ターミナルウインドウを最大化"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "ターミナルウインドウを最小化"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "ターミナルウインドウを全画面表示にする"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "既存のウィンドウにフォーカスする"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "追加インスタンスを新しいプロセスとして開始する (非推奨)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "ウインドウサイズの設定; 例:  80x24 または 80x24+200+200 (横x縦+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRY"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
 msgstr ""
+"震動モードでウィンドウを開くまたは既存ウインドウを震動モードへ切り替える"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Terminix および依存コンポーネントのバージョンを表示"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Terminix 設定ダイアログを直接表示する"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "端末 UUID を渡すための隠し引数"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"ターミナルの設定に問題があるようです。\n"
+"この問題は深刻ではありませんが、修正すると動作が向上します。\n"
+"詳細は次のリンクをクリックしてください:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "構成の問題が検出されました"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "このメッセージを再度表示しない"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "ファイル %s はカラースキームに準拠した JSON ファイルではありません"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "配色パレットは 16 色必須です"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "ドロップされたターミナルを見つけることができませんでした"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "ドロップされたターミネルのセッションを見つけることができませんでした"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -220,80 +1605,46 @@ msgstr "GtkD は優れた GTK ラッパーを提供します"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org による優れた言語、D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "タイトル"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "アプリケーションタイトル"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "横の文字数"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "アプリケーション"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "セッションを読み込む"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "セッション"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "ドロップされたターミナルを見つけることができませんでした"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "ドロップされたターミネルのセッションを見つけることができませんでした"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "デフォルト"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "プロファイル"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "新しいセッション"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -430,1434 +1781,6 @@ msgstr "ベトナム語"
 msgid "Thai"
 msgstr "タイ語"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "レイアウトオプション"
-
-#: source/gx/terminix/terminal/layout.d:45
-#, fuzzy
-msgid "Active"
-msgstr "アクティブ"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "バッジ"
-
-#: source/gx/terminix/terminal/layout.d:69
-#, fuzzy
-msgid "Session Load"
-msgstr "セッションを読み込む"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"アクティブなオプションは常に有効であり、すぐに適用されます。\n"
-"セッションロードオプションはセッションファイルをロードするときにのみ適用され"
-"ます。"
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "ターミナル"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "閉じる"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-#, fuzzy
-msgid "Disable input synchronization for this terminal"
-msgstr "このターミナルの入力同期を無効にする"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "読み込みのみ"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "ターミナルベル"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "プロファイルの編集"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "エンコード"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "このターミナルの入力同期を有効にする"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"ライブラリー %s をロードできませんでした。パスワード機能は使用できません。"
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "ライブラリーを読み込めません"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "出力の保存…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "リセット"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "リセット・クリアー"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "プロファイル"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "エンコード"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "バッジの色を選択して下さい"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "検索…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "レイアウトオプション…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "右に追加"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "下に追加"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-#, fuzzy
-msgid "Restore"
-msgstr "復元"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "リンクを開く"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "リンクアドレスをコピー"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "コピー"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "貼り付け"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "すべて選択"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "クリップボード"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "同期入力"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "予期しないエラーが発生しました。追加情報はありません"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "予期しないエラーが発生しました: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "ターミナル出力の保存"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "保存"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "すべてのテキストファイル"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "すべてのファイル"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "子プロセス %d は正常の状態で終了しました"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "子プロセス %d はシグナルによって中止されました。"
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "子プロセスは中止しました。"
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "再起動"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "貼り付けない"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "常に貼り付け"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "検索オプション"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "次を検索"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "前を検索"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "一致する条件"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "単語全体を検出"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "正規表現で検出"
-
-#: source/gx/terminix/terminal/search.d:191
-#, fuzzy
-msgid "Wrap around"
-msgstr "改行の処理"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "このコマンドはコンピュータへの管理者アクセスを要求しています"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "インターネットからコマンドのコピーは危険です。 "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "このコマンドの各部が何をするのかを理解してください。"
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "変換"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "スペースをタブへ変換"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "CRLF および CR を LF へ変換"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "高度な貼り付け"
-
-#: source/gx/terminix/terminal/password.d:157
-#, fuzzy
-msgid "New"
-msgstr "新規"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "編集"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "削除"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "改行文字にパスワードを含める"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "パスワードを挿入する"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "適用"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "パスワード"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "確認パスワード"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "パスワードを追加"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "パスワードの編集"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "再度表示しない"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "ウインドウ (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "セッション (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "アプリケーションを閉じる"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "ウインドウを閉じる"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "セッションを閉じる"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "新しいウインドウ"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "設定"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "ショートカット"
-
-#: source/gx/terminix/application.d:228
-#, fuzzy
-msgid "About"
-msgstr "情報"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "終了"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "開発者"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "ターミナルの作業ディレクトリを設定"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIRECTORY"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "開始時のプロファイルを設定"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "新しいターミナルのタイトルを設定"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITLE"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "指定したセッションを開く"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "現在の Terminix インスタンスにアクションを送信"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "パラメータをコマンドとして実行"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "COMMAND"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "ターミナルウインドウを最大化"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "ターミナルウインドウを最小化"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "ターミナルウインドウを全画面表示にする"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "既存のウィンドウにフォーカスする"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "追加インスタンスを新しいプロセスとして開始する (非推奨)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "ウインドウサイズの設定; 例:  80x24 または 80x24+200+200 (横x縦+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRY"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"震動モードでウィンドウを開くまたは既存ウインドウを震動モードへ切り替える"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Terminix および依存コンポーネントのバージョンを表示"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Terminix 設定ダイアログを直接表示する"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "端末 UUID を渡すための隠し引数"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"ターミナルの設定に問題があるようです。\n"
-"この問題は深刻ではありませんが、修正すると動作が向上します。\n"
-"詳細は次のリンクをクリックしてください:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "構成の問題が検出されました"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "このメッセージを再度表示しない"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "セッションサイドバーを表示"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "新しいセッションを生成"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "右にターミナルを追加"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "下にターミナルを追加"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "ターミナルのテキストを検索"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "セッション名を変更"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "セッションの新しい名称を入力して下さい"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "開く…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "名前をつけて保存…"
-
-#: source/gx/terminix/appwindow.d:648
-#, fuzzy
-msgid "Name…"
-msgstr "名前…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "同期入力"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "複数のセッションが開いています。閉じてよろしいですか？"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "すべての JSON ファイル"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "ファイル名 '%s' が見つかりません"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "セッションの読み込み"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "開く"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "予期しないエラーのためセッションを読み込めませんでした。"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "セッション読み込みエラー"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "セッションを保存"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "ファイル %s はカラースキームに準拠した JSON ファイルではありません"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "配色パレットは 16 色必須です"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Terminix 設定"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "グローバル"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "外観"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "振動"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "プロファイルの追加"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "プロファイルの削除"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "プロファイル: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "複製"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "新しいターミナルを使用"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "メニュー表示のエンコード:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "有効"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "アクション"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "ショートカットキー"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "ショートカットを有効にする"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "既存のショートカットを上書きする"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"ショートカット %s はすでに %s で割り当てられています。\n"
-"他アクションのショートカットを無効にして、代わりにこれを割り当てますか？"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "透明度を有効にする 再起動が必要"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "ウインドウ (%s)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "通常"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "無効"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "ターミナルタイトルの形式"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "小さい"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "なし"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "テーマの状態"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "明るい"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "暗い"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "背景画像"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "画像を選択"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "すべての画像ファイル"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "背景画像をリセット"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "スケール"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "タイル"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "中央"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "ストレッジ"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "デフォルトセッションの名称"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "アプリケーションタイトル"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "分割に広いハンドルを使用する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "サイドバーを右へ置く"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "唯一のターミナルであってもターミナルのタイトルを表示する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "サイズ"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "縦のパーセント"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "横のパーセント"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "配置"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "左"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "右"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "オプション"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "すべてのワークスペースにターミナルを表示する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "アニメーションを無効にするウィンドウマネージャのヒントを設定する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "フォーカスが失われた時にウィンドウを非表示にする"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "ウィンドウのタイトルバーを隠す"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "有効なモニタにターミナルを表示する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "特定のモニタに表示する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "動作"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "新しいセッションを作成した時のプロンプト"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "マウスが上を移動するときにターミナルへフォーカスする"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "入力時にマウスポインタを自動的に隠す"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "タイトルで中マウスボタンをクリックして端末を閉じる"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "<Control> キー＋ホイールでターミナルを拡大・縮小する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "最後のセッションが閉じられた時にウィンドウを閉じる"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "プロセス完了時にデスクトップ通知を送信する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-#, fuzzy
-msgid "On new instance"
-msgstr "新しいインスタンスについて"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "右に分割"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "下に分割"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "ウインドウのフォーカス"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "常に高度な貼り付けダイアログを使用する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "安全でない貼り付けを試みるときに警告する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "コメントまたは変数宣言の場合、貼り付けの頭文字を削除する"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "選択時にテキストをクリップボードへ自動的にコピーする"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-#, fuzzy
-msgid "General"
-msgstr "一般"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-#, fuzzy
-msgid "Color"
-msgstr "カラー"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "スクロール"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "互換性"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-#, fuzzy
-msgid "Advanced"
-msgstr "高度"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "プロファイル名"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "ターミナルのサイズ"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "横の文字数"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "縦の文字数"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "カーソル"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "ブロック"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-#, fuzzy
-msgid "IBeam"
-msgstr "エの形状"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "下線"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "点滅モード"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "システム"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "オン"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "オフ"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "音"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "アイコン・音"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "ターミナルのタイトル"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "バッジの位置"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Northwest"
-msgstr "左上"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Northeast"
-msgstr "右上"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southwest"
-msgstr "左下"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "右下"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "テキストの外観"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "強調テキストを適用"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-#, fuzzy
-msgid "Rewrap on resize"
-msgstr "サイズを変更して折り返す"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "カスタムフォント"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "ターミナルフォントを選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "カラースキーマー"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "カスタム"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "エクスポート"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "配色パレット"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "前景色・背景色にテーマカラーを使用する"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-#, fuzzy
-msgid "Transparency"
-msgstr "透明度"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "画面を暗くしてフォーカスしない"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "テキスト"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "背景"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "カーソルの前景色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "カーソルの背景色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "ハイライト"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "ハイライトの前景色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "ハイライトの背景色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "画面の暗転"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "暗転を行う色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "バッジの色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "背景色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "前景色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "前景"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "黒"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "赤"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "緑"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "橙"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "青"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "紫"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "水色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "灰色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "%s の色を選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "%s のライトカラーを選択して下さい"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "カラースキームをエクスポート"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "スクロールバーを表示"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "出力をスクロールする"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "キーストロークをスクロールする"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-#, fuzzy
-msgid "Limit scrollback to:"
-msgstr "スクロールログの上限:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-#, fuzzy
-msgid "Backspace key generates"
-msgstr "Back Space キーの動作"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "自動"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-#, fuzzy
-msgid "Escape sequence"
-msgstr "Escape シーケンス"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-#, fuzzy
-msgid "Delete key generates"
-msgstr "Delete キーの動作"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-#, fuzzy
-msgid "Ambiguous-width characters"
-msgstr "あいまいな文字"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "狭"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "広"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "シェルログイン時に実行するコマンド"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "シェルの代わりにカスタムコマンドを実行する"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-#, fuzzy
-msgid "When command exits"
-msgstr "コマンド終了時の動作"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "ターミナルを終了する"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "コマンドを再度開始する"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "開いているターミナルをそのままにする"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "カスタムリンク"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"正規表現の定義に基づきターミナルでクリックできるユーザ定義リンクの一覧です。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-#, fuzzy
-msgid "Triggers"
-msgstr "トリガー"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-#, fuzzy
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"トリガーはターミナルの出力テキストを確認するために使用される正規表現です。 検"
-"出一致すると設定アクションを実行します。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "自動プロファイル切り替え"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"プロファイルはここに入力された値に基づいて自動的に選択されます。\n"
-"値は <i>ユーザー名@ホスト名:ディレクトリ</i> 形式で入力します。 ホスト名また"
-"はディレクトリは省略できますが、コロンは必要です。 ホスト名もディレクトリもな"
-"いエントリは許可されません。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"プロファイルはここに入力された値に基づいて自動的に選択されます。\n"
-"値は <i>ホスト名:ディレクトリ</i> の形式で入力します。 ホスト名またはディレク"
-"トリは省略できますが、コロンは必要です。 ホスト名もディレクトリもないエントリ"
-"は許可されません。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "一致"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "追加"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "一致させる ユーザー名@ホスト名:ディレクトリ を入力"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "一致させる ホスト名@ディレクトリ を入力"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "新たな一致条件を追加"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "一致させる ユーザー名@ホスト名:ディレクトリ の編集"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "一致させる ホスト名:ディレクトリ の編集"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "一致条件の編集"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Regex"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "大文字・小文字を区別しない"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "カスタムリンクの編集"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "パラメーター"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "トリガー処理の制限行数:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "トリガーの編集"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "ウインドウ"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1894,42 +1817,133 @@ msgstr ""
 "震動モードでは最大化、最小化、フルスクリーン、ジオメトリのパラメータを使用す"
 "る事ができません"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "ExecuteCommand"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:586
+#, fuzzy
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "予期しないエラーのためセッションを読み込めませんでした。"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "UpdateTitle"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "SendText"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "InsertPassword"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "%s の色を選択して下さい"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "UpdateBadge"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "%s の色を選択して下さい"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "すべて選択"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "パラメーター"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "バッジの色を選択して下さい"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "無効"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (コピー)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "GTK のバージョンは古すぎます。 GTK %d.%d.%d 以上が必要です！"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "予期しない例外が発生しました"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "エラー: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "バージョン"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Terminix バージョン: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "VTE バージョン: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "GTK バージョン: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Terminix の特長"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "通知を有効にしました=％b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "トリガーを有効にしました=％b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "バッジを有効にしました=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-08-22 06:24+0000\n"
 "Last-Translator: Youngbin Han <sukso96100@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/terminix/"
@@ -15,181 +15,1568 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
-"GTK 버전이 너무 오래 되었습니다, 적어도 GTK %d.%d.%d 버전이 필요합니다!"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "예상하지 못한 예외 발생"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "오류: "
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "페르시아어"
+msgid "ExecuteCommand"
+msgstr "명령어"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "제목"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "텍스트"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "제목"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "%s에서 터미널 열기"
+msgid "%s (Copy)"
+msgstr "복사"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "%s에서 터미널 열기"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "일반"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "설정 열기"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "비활성화됨"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "%s색 선택"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "%s색 선택"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "확인"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "취소"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "이름"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "모두 선택"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "명령어"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "색상"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "스크롤링"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "호환성"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "고급"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "%s색 선택"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "프로파일 이름"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "터미널 크기"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "행"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "열"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "초기화"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "커서"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "블록"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "I빔"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "밑줄"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "깜빡임 모드"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "시스템"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "켬"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "끔"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "터미널 벨"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "없음"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "소리"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "아이콘"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "아이콘 및 소리"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "터미널 제목"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Southeast"
+msgstr "남유럽어"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "텍스트 모양새"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "굵은 글씨 허용"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "크기 조절시 자동으로 줄바꿈 하기"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "사용자 정의 글꼴"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "터미널 글꼴 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "색상 스키마"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "사용자 정의"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "색상 팔레트"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "옵션"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "전경/배경 에 대해 테마 색상 사용"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "투명도"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "포커스 해제시 어두운 색상"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "텍스트"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "배경"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "커서 전경 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "커서 배경 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "강조"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "강조 전경 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "강조 배경 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "어두운 색상"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "어두운 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "%s색 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "배경 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "전경 색상 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "전경"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "검정"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "빨강"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "녹색"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "주황"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "파랑"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "보라"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "청록"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "회색"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "%s색 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "밝은 %s색 선택"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "색상 스키마"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "저장"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "취소"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "모든 JSON 파일"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "모든 파일"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "스크롤바 보이기"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "출력시 스크롤하기"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "키 누를 때 스크롤하기"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "스크롤 제한:"
+
+# Terminix gettext pot file
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Backspace 키 누를 때 생성할 것"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "자동"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "이스케이프 시퀀스"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Delete 키 누를 때 생성할 것"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "인코딩"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "모호한 폭의 문자"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "좁음"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "넓음"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "로그인 셸로 명령어 실행"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "내 셸 대신 사용자 정의 명령어 실행"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "명령어가 종료될 때"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "터미널 나가기"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "명령어 다시 시작"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "터미널 열림 유지"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "사용자 정의 링크"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"정규표현식 정의에 기반하여 터미널에서 누를 수 있는 사용자 정의 링크 목록."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "편집"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "프로파일 자동 변경"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
+"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
+"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
+"리 둘다 없는 입력은 허용되지 않습니다."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
+"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
+"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
+"리 둘다 없는 입력은 허용되지 않습니다."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "일치값"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "추가"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "새 일치값 추가"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "일치값 수정"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "삭제"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "정규표현식"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "대소문자 구분 한함"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "사용자 정의 링크 편집"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "적용"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "동작"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "프로파일 편집"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "터미널"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "창"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "설정 열기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "전역"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "모양새"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "바로 가기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "프로파일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "프로파일 편집"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "새 프로파일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "기본 설정"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "프로파일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "프로파일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "터미널 초기화 하기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "메뉴에 보일 인코딩:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "활성화됨"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "단축키"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "바로 가기 활성화"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "이미 있는 바로가기 덮어쓰기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"바로가기 %s 는 이미 %s 로 지정되어 있습니다.\n"
+"다른 동작을 위해 바로가기를 비활성화 하고 여기에 지정할까요?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "투명도 활성화 하기(다시 시작 필요함)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "창"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "보통"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "비활성화됨"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "터미널 제목 스타일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "작음"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "테마 종류"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "기본값"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "밝음"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "어두움"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "배경 이미지"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "이미지 선택"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "모든 이미지 파일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "배경 이미지 초기화"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "크기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "타일"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "가운데"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "늘리기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "세션 이름 편집"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "응용프로그램"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "스플라이터에 대해 넓은 핸들 사용하기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "새 터미널 제목 설정"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "밝음"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "새 터미널 제목 설정"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "터미널 내용 저장"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "행동"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "새 세션을 만들 때 세션 설정 입력받기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "마우스가 위에서 움직일 때 터미널에 포커스 하기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "타이핑 할 때 마우스 포인터 자동으로 숨기기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "프로세스가 완료될때 데스크톱 알림 보내기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "새 인스턴스 생성시"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "새 창"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "새 세션"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "오른쪽으로 분할"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "아래로 분할"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "창에 포커스"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "클립보드"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "위험한 붙여넣기를 할 때 경고하기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "붙여넣기 한 것이 주석 또는 변수 선언문일 경우 첫 문자 삭제하기"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "선택할 때 텍스트를 자동으로 클립보드로 복사하기"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "제목"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "이 메시지 다시 보지 않기"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "창"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "세션"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "응용프로그램"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "창에 포커스"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "새 세션"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "확인"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "고급"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "붙여넣기"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "이름"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "새로 만들기"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "검색 옵션"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "다음 찾기"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "이전 찾기"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "일치 경우"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "전체 단어 일치만"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "정규 표현식으로 일치"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "주변 감싸기"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "닫기"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "최대화"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "읽기전용"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "프로파일 편집"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "인코딩"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "이 터미널에 대해 입력 동기화 활성화 하기"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "찾기…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "%s색 선택"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "출력 저장…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "초기화 하고 지우기"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "레이아웃 옵션…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "기타"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "오른쪽에 추가"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "아래에 추가"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "복원"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "링크 열기"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "링크 주소 복사"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "복사"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "모두 선택"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "입력 동기화"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "예상하지 못한 오류가 발생했습니다. %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "터미널 출력 저장"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "모든 텍스트 파일"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다 %d"
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "자식 프로세스가 중지되었습니다."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "다시 시작"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "붙여넣지 마세요"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "어떻게든 붙여넣기"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "레이아웃 옵션"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "동작"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "세션"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"활성 옵션은 항상 영향을 주며 바로 적용됩니다.\n"
+"세션 불러오기 옵션은 세션 파일을 불러올 때만 적용됩니다."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "세션 사이드바 보기"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "새 세션 만들기"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "오른쪽에 터미널 추가"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "아래에 터미널 추가"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "터미널에서 텍스트 찾기"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "세션 이름 바꾸기"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "새 세션 이름 입력"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "열기…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "다른 이름으로 저장…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "이름…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "입력 동기화"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "파일 이름 '%s'이(가) 없습니다"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "세션 불러오기"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "열기"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "세션 불러오기 오류"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "세션 저장"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "정보"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "끝내기"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Youngbin Han\n"
+"revizes"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "크레딧"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "터미널 작업 디렉터리 설정"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "디렉토리"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "시작 프로파일 설정"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "새 터미널 제목 설정"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
 msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "특정 세션 열기"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "현재 Terminix 인스턴스로 동작 보내기"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "전달된 명령어 실행"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "터미널 창 최대화"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "터미널 창 최대화"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "터미널 창을 전체화면으로"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "기존 창에 포커스 두기"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "새 프로세스로 추가적인 인스턴스 시작(권장하지 않음)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "창 크기를 정하세요; 예시: 80x24, 또는 80x24+200+200 (행x열+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"터미널 설정에 이슈가 있는 것으로 보입니다.\n"
+"이 이슈는 심각하지 않습니다. 그러나 고친다면 사용 경험이 향상됩니다.\n"
+"자세한 정보는 아래 링크를 누르세요."
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "설정 이슈 감지됨"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "이 메시지 다시 보지 않기"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "파일 %s은(는) 색상 스키마 호환 JSON 파일이 아닙니다"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "색상표에 16 가지 색상이 필요합니다"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "중단된 터미널을 위치시킬 수 없습니다"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "중단된 터미널을 위한 세션을 위치시킬 수 없습니다"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -217,80 +1604,46 @@ msgstr "GtkD - 훌룡한 GTK 래퍼 제공"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org - 훌룡한 언어, D 제공"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "제목"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "응용프로그램"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "행"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "응용프로그램"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "세션"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "세션"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "중단된 터미널을 위치시킬 수 없습니다"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "중단된 터미널을 위한 세션을 위치시킬 수 없습니다"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "기본값"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "프로파일"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "새 세션"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -430,1433 +1783,6 @@ msgstr "베트남어"
 msgid "Thai"
 msgstr "태국어"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "레이아웃 옵션"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "동작"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "세션"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"활성 옵션은 항상 영향을 주며 바로 적용됩니다.\n"
-"세션 불러오기 옵션은 세션 파일을 불러올 때만 적용됩니다."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "터미널"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "닫기"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "최대화"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "이 터미널에 대해 입력 동기화 비활성화 하기"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "읽기전용"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "터미널 벨"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "프로파일 편집"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "인코딩"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "이 터미널에 대해 입력 동기화 활성화 하기"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "출력 저장…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "초기화"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "초기화 하고 지우기"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "프로파일"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "인코딩"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "%s색 선택"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "찾기…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "레이아웃 옵션…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "오른쪽에 추가"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "아래에 추가"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "복원"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "링크 열기"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "링크 주소 복사"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "복사"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "붙여넣기"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "모두 선택"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "클립보드"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "입력 동기화"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"예상하지 못한 오류가 발생했습니다. 이용 가능한 추가적인 정보가 없습니다"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "예상하지 못한 오류가 발생했습니다. %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "터미널 출력 저장"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "저장"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "모든 텍스트 파일"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "모든 파일"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "자식 프로세스가 다음과 같은 상태로 정상적으로 종료되었습니다. %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "자식 프로세스가 다음과 같은 신호에 의해 중지되었습니다 %d"
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "자식 프로세스가 중지되었습니다."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "다시 시작"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "붙여넣지 마세요"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "어떻게든 붙여넣기"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "검색 옵션"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "다음 찾기"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "이전 찾기"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "일치 경우"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "전체 단어 일치만"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "정규 표현식으로 일치"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "주변 감싸기"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "이 명령어가 컴퓨터로의 관리자 액세스를 요청합니다"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "인터넷에서 명령어를 복사하는 것은 위험할 수 있습니다. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "이 명령어의 각 부분이 무엇을 하는지 분명히 이해하세요."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "고급"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "새로 만들기"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "편집"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "삭제"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "적용"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "이 메시지 다시 보지 않기"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "창"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "세션"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "응용프로그램"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "창에 포커스"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "새 세션"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "새 창"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "기본 설정"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "바로 가기"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "정보"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "끝내기"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "크레딧"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "터미널 작업 디렉터리 설정"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "디렉토리"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "시작 프로파일 설정"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "새 터미널 제목 설정"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "특정 세션 열기"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "현재 Terminix 인스턴스로 동작 보내기"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "전달된 명령어 실행"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "터미널 창 최대화"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "터미널 창 최대화"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "터미널 창을 전체화면으로"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "기존 창에 포커스 두기"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "새 프로세스로 추가적인 인스턴스 시작(권장하지 않음)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "창 크기를 정하세요; 예시: 80x24, 또는 80x24+200+200 (행x열+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "터미널 UUID를 전달하기 위한 숨겨진 독립변수"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"터미널 설정에 이슈가 있는 것으로 보입니다.\n"
-"이 이슈는 심각하지 않습니다. 그러나 고친다면 사용 경험이 향상됩니다.\n"
-"자세한 정보는 아래 링크를 누르세요."
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "설정 이슈 감지됨"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "이 메시지 다시 보지 않기"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "세션 사이드바 보기"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "새 세션 만들기"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "오른쪽에 터미널 추가"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "아래에 터미널 추가"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "터미널에서 텍스트 찾기"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "세션 이름 바꾸기"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "새 세션 이름 입력"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "열기…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "다른 이름으로 저장…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "이름…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "입력 동기화"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "프로세스가 여전히 실행중입니다. 어떻게든 닫을까요?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "모든 JSON 파일"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "파일 이름 '%s'이(가) 없습니다"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "세션 불러오기"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "열기"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "세션 불러오기 오류"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "세션 저장"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "파일 %s은(는) 색상 스키마 호환 JSON 파일이 아닙니다"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "색상표에 16 가지 색상이 필요합니다"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "설정 열기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "전역"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "모양새"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "프로파일 편집"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "새 프로파일"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "프로파일"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "터미널 초기화 하기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "메뉴에 보일 인코딩:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "활성화됨"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "동작"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "단축키"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "바로 가기 활성화"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "이미 있는 바로가기 덮어쓰기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"바로가기 %s 는 이미 %s 로 지정되어 있습니다.\n"
-"다른 동작을 위해 바로가기를 비활성화 하고 여기에 지정할까요?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "투명도 활성화 하기(다시 시작 필요함)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "창"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "보통"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "비활성화됨"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "터미널 제목 스타일"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "작음"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "없음"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "테마 종류"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "밝음"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "어두움"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "배경 이미지"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "이미지 선택"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "모든 이미지 파일"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "배경 이미지 초기화"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "크기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "타일"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "가운데"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "늘리기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "세션 이름 편집"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "응용프로그램"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "스플라이터에 대해 넓은 핸들 사용하기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "새 터미널 제목 설정"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "밝음"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "옵션"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "새 터미널 제목 설정"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "터미널 내용 저장"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "행동"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "새 세션을 만들 때 세션 설정 입력받기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "마우스가 위에서 움직일 때 터미널에 포커스 하기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "타이핑 할 때 마우스 포인터 자동으로 숨기기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "프로세스가 완료될때 데스크톱 알림 보내기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "새 인스턴스 생성시"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "오른쪽으로 분할"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "아래로 분할"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "창에 포커스"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "위험한 붙여넣기를 할 때 경고하기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "붙여넣기 한 것이 주석 또는 변수 선언문일 경우 첫 문자 삭제하기"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "선택할 때 텍스트를 자동으로 클립보드로 복사하기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "일반"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "색상"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "스크롤링"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "호환성"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "고급"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "프로파일 이름"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "터미널 크기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "행"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "열"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "커서"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "블록"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "I빔"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "밑줄"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "깜빡임 모드"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "시스템"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "켬"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "끔"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "소리"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "아이콘 및 소리"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "터미널 제목"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "남유럽어"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "텍스트 모양새"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "굵은 글씨 허용"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "크기 조절시 자동으로 줄바꿈 하기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "사용자 정의 글꼴"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "터미널 글꼴 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "색상 스키마"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "사용자 정의"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "색상 팔레트"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "전경/배경 에 대해 테마 색상 사용"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "투명도"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "포커스 해제시 어두운 색상"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "텍스트"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "배경"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "커서 전경 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "커서 배경 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "강조"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "강조 전경 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "강조 배경 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "어두운 색상"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "어두운 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "%s색 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "배경 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "전경 색상 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "전경"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "검정"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "빨강"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "녹색"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "주황"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "파랑"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "보라"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "청록"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "회색"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "%s색 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "밝은 %s색 선택"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "색상 스키마"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "스크롤바 보이기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "출력시 스크롤하기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "키 누를 때 스크롤하기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "스크롤 제한:"
-
-# Terminix gettext pot file
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Backspace 키 누를 때 생성할 것"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "자동"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "이스케이프 시퀀스"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Delete 키 누를 때 생성할 것"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "모호한 폭의 문자"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "좁음"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "넓음"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "로그인 셸로 명령어 실행"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "내 셸 대신 사용자 정의 명령어 실행"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "명령어가 종료될 때"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "터미널 나가기"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "명령어 다시 시작"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "터미널 열림 유지"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "사용자 정의 링크"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"정규표현식 정의에 기반하여 터미널에서 누를 수 있는 사용자 정의 링크 목록."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "프로파일 자동 변경"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
-"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
-"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
-"리 둘다 없는 입력은 허용되지 않습니다."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"여기서 입력한 값에 기반하여 프로파일이 자동으로 선택됩니다.\n"
-"<i>호스트이름:디렉터리</i>형식을 사용하여 값이 입력됩니다. 호스트이름과 디렉"
-"터리 중 하나만 있어도 되나, 쌍점은 반드시 있어야 합니다. 호스트이름과 디렉터"
-"리 둘다 없는 입력은 허용되지 않습니다."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "일치값"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "추가"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식의 일치값을 입력하세요"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "새 일치값 추가"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "호스트이름:디렉터리 형식으로 일치값을 수정합니다"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "일치값 수정"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "정규표현식"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "대소문자 구분 한함"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "사용자 정의 링크 편집"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "프로파일 편집"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "창"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1889,46 +1815,135 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "명령어"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "제목"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "예상하지 못한 오류로 인해 세션을 불러올 수 없습니다."
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "텍스트"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "제목"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "%s색 선택"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "%s색 선택"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "모두 선택"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "%s색 선택"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "비활성화됨"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"GTK 버전이 너무 오래 되었습니다, 적어도 GTK %d.%d.%d 버전이 필요합니다!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "예상하지 못한 예외 발생"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "오류: "
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "페르시아어"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "복사"
+msgid "Terminix version: %s"
+msgstr "%s에서 터미널 열기"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "%s에서 터미널 열기"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "설정 열기"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-07-30 19:47+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/terminix/"
@@ -19,172 +19,1510 @@ msgstr ""
 "%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgid "%s (Copy)"
 msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
 msgstr ""
 
-#: source/app.d:128
-msgid "Error: "
-msgstr ""
-
-#: source/app.d:138
-msgid "Versions"
-msgstr ""
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr ""
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr ""
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr ""
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Suderinamumas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Profilio pavadinimas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Terminalo dydis"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Atstatyti"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Žymeklis"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Dvitėjinė sija"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Pabraukimas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Mirksėjimo veiksena"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr ""
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Spalvų rinkinys"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Spalvų paletė"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Parametrai"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Fonas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Spalvų rinkinys"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Naujas profilis"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "Naujas profilis"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Profilio pavadinimas"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+msgid "Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:736
+msgid "Other"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr ""
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr ""
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr ""
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Failas %s nėra su JSON failu suderinamas spalvų rinkinys"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Spalvų rinkinio paletė reikalauja 16 spalvų"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
 msgstr ""
 
 #: source/gx/terminix/constants.d:60
@@ -210,74 +1548,40 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr ""
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr ""
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr ""
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr ""
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
-msgstr ""
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr ""
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
 msgstr ""
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
@@ -415,1383 +1719,6 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Atstatyti"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr ""
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr ""
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr ""
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr ""
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr ""
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr ""
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Failas %s nėra su JSON failu suderinamas spalvų rinkinys"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Spalvų rinkinio paletė reikalauja 16 spalvų"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Naujas profilis"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "Naujas profilis"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Profilio pavadinimas"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Parametrai"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Suderinamumas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Profilio pavadinimas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Terminalo dydis"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Žymeklis"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Dvitėjinė sija"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Pabraukimas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Mirksėjimo veiksena"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Spalvų rinkinys"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Spalvų paletė"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Fonas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Spalvų rinkinys"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1822,41 +1749,126 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr ""
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr ""
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr ""
+
+#: source/app.d:128
+msgid "Error: "
+msgstr ""
+
+#: source/app.d:138
+msgid "Versions"
+msgstr ""
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr ""
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr ""
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr ""
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
 msgstr ""
 
 #: data/nautilus/open-terminix.py:108

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-06 11:05+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
-"Language-Team: Dutch "
-"<https://hosted.weblate.org/projects/terminix/translations/nl/>\n"
+"Language-Team: Dutch <https://hosted.weblate.org/projects/terminix/"
+"translations/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,177 +18,1549 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.11\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "StatusBijwerken"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "CommandoUitvoeren"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "MeldingVersturen"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "TitelBijwerken"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "BelAfspelen"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "TekstVersturen"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "WachtwoordInvoeren"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "Badge bijwerken"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"Uw GTK-versie is verouderd; u moet op zijn minst beschikken over versie %d."
-"%d.%d!"
+msgid "%s (Copy)"
+msgstr "%s (Kopiëren)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Er is een onverwachte fout opgetreden"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Algemeen"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Fout: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Versies"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Terminix-versie: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "VTE-versie: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "GTK-versie: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Terminix Speciale Mogelijkheden"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Meldingen ingeschakeld=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Triggers ingeschakeld=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Badges ingeschakeld=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "uitgeschakeld"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Selecteer map"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Selecteer map"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Map legen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Bladwijzer toevoegen"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Bladwijzer bewerken"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Oké"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Annuleren"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Naam"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr "Pad"
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Selecteer pad"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Opdracht"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Protocol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Kleur"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Host"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Scrollen"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Gebruiker"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibiliteit"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Parameters"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Geavanceerd"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Selecteer bladwijzer"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Profielnaam"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Terminalgrootte"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "kolommen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "rijen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Herstellen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Blok"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Verticale streep"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Onderliggende streep"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Knippermodus"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Systeem"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Ingeschakeld"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Uitgeschakeld"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Terminalbel"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Geen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Geluid"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Pictogram"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr "Fout tijdens deserialiseren van bladwijzer"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Pictogram en geluid"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Terminaltitel"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Logo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Logo-positie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Noordwest"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Noordoost"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Zuidwest"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Zuidoost"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Tekstuiterlijk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Vetgedrukte tekst toestaan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Tekstterugloop passend maken bij herschalen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Aangepast lettertype"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Kies een terminal-lettertype"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Kleurenschema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Aangepast"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exporteren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Kleurenpalet"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Opties"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Themakleuren gebruiken voor voorgrond/achtergrond"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Doorzichtigheid"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Ongefocusde verduistering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Tekst"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Achtergrond"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Selecteer voorgrondkleur van cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Selecteer achtergrondkleur van cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Markeren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Selecteer voorgrondkleur van markering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Selecteer achtergrondkleur van markering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Verduisteren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Selecteer verduisteringskleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Selecteer badgekleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Selecteer achtergrondkleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Selecteer voorgrondkleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Voorgrond"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Zwart"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Rood"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Groen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Oranje"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Blauw"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Paars"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turkoois"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Grijs"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Selecteer %s kleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Selecteer %s lichte kleur"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Kleurenschema exporteren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Opslaan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Alle JSON-bestanden"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Alle bestanden"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Scrollbalk weergeven"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Scrollen bij uitvoer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Scrollen bij toetsaanslag"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Scrolluitvoer beperken tot:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Backspace-toets genereert"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Escape-volgorde"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Delete-toets genereert"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Tekstcodering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Tekens met eenduidige breedte"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Smal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Breed"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Opdracht uitvoeren als inlog-shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Een aangepast commando uitvoeren in plaats van mijn shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Als de opdracht is afgerond"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Terminal afsluiten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Opdracht herstarten"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Terminalvenster openhouden"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Aangepaste links"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
 msgstr ""
-"De bladwijzers kunnen niet worden geladen omdat er een onverwachte fout is "
-"opgetreden"
+"Een gebruikers-gedefinieerde lijst van links die kunnen worden aangeklikt in "
+"de terminal gebaseerd op reguliere expressies."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Map"
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Bewerken"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Op afstand"
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Triggers"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Triggers zijn reguliere expressies die worden gebruikt om de uitvoertekst in "
+"de terminal te controleren. Als een overeenkomst is aangetroffen zal de "
+"ingestelde actie worden uitgevoerd."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Automatische profieloverschakeling"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
+"waarden.\n"
+"Waarden moeten worden ingevoerd in de notatie <i>gebruikersnaam@hostnaam:"
+"map</i>. De hostnaam of map kan leeg worden gelaten maar de dubbele punt "
+"moet ten alle tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als "
+"de map is niet toegestaan."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
+"waarden.\n"
+"Waarden moeten worden ingevoerd in de notatie <i>hostnaam:map</i>. De "
+"hostnaam of map kan leeg worden gelaten maar de dubbele punt moet ten alle "
+"tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als de map is niet "
+"toegestaan."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Overeenkomen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Toevoegen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Voer de overeen te komen gebruikersnaam@hostnaam:map in"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Voer de overeen te komen hostnaam:map in"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Nieuw overeenkomst toevoegen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Bewerk de overeen te komen gebruikersnaam@hostnaam:map"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Bewerk de overeen te komen hostnaam:map"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Overeenkomst bewerken"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Regex"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Hoofdletterongevoelig"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Aangepaste links bewerken"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Toevoegen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Actie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parameter"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Aantal regels voor triggerdoorvoering beperken tot:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Triggers bewerken"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr "Rij %d: "
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr "Venster"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr "Hulp"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Terminix-voorkeuren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Globaal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Uiterlijk"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Bladwijzers"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Sneltoetsen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profiel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Profiel toevoegen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Profiel verwijderen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profielen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profiel: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Dupliceren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "G"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Tekstcoderingen die moeten worden weergegeven in het menu:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Sneltoets"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Sneltoetsen inschakelen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Bestaande sneltoets overschrijven"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"De snelkoppeling %s is al toegewezen aan %s.\n"
+"Wilt u de sneltoets van de andere actie uitschakelen en toewijzen aan deze "
+"actie?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Doorzichtigheid inschakelen; herstart vereist"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr "Vensterstijl"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normaal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr "CSD uitschakelen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr "CSD uitschakelen, werkbalk verbergen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr "Randloos"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr "Vensterherstart vereist"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Titelstijl van terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Klein"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Themastijl"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Standaard"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Licht"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Donker"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Achtergrondafbeelding"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Afbeelding selecteren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Alle afbeeldingsbestanden"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Achtergrondafbeelding verwijderen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Schalen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Tegelen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centreren"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Uitrekken"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Standaard sessienaam"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Applicatietitel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Brede handgreep gebruiken voor splitsingen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Zijbalk aan de rechterkant plaatsen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Terminaltitel weergeven, zelfs als het de enige terminal is"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Grootte"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Hoogtepercentage"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Breedtepercentage"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Uitlijning"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Links"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Rechts"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Terminal weergeven op alle werkbladen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Hint instellen voor vensterbeheerder om animaties uit te schakelen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Venster sluiten bij verliezen van focus"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Venstertitelbalk verbergen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Terminal weergeven op actief beeldscherm"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Weergeven op specifiek beeldscherm"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Gedrag"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Vragen bij creëren van nieuwe sessie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Focus een terminal wanneer de muis eroverheen zweeft"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Cursor verbergen tijdens typen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Terminal sluiten door met de middelste muisknop te klikken op de titel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Zoomen in terminalvenster middels <Control> en scrollwiel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Venster sluiten wanneer de laatste sessie wordt afgesloten"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Bureaubladmelding weergeven bij afronden van proces"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Bij nieuw proces"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nieuw venster"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nieuwe sessie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Splitsen naar rechts"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Splitsen naar onderen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Venster focussen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Klembord"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Altijd geavanceerd plakken gebruiken"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Waarschuwen bij plakken van onveilige opdracht"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "Eerste teken weglaten bij plakken van een comment of variabel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Geselecteerde tekst automatisch kopiëren naar het klembord"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr "Bladwijzer toevoegen"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr "Bladwijzer bewerken"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr "Bladwijzer verwijderen"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr "Bladwijzer de-selecteren"
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Dit bericht niet meer weergeven"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Venster (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sessie (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Applicatie sluiten"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Venster sluiten"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Sessie sluiten"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Oké"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Deze opdracht vraagt om administrator-toegang tot uw computer"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Het kopiëren van opdrachten vanaf het internet kan gevaarlijk zijn. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Zorg ervoor dat u begrijpt wat alle delen van deze opdracht uitvoeren."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformeren"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Spaties omzetten naar tabs"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "CRLF en CR converteren naar LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Geavanceerd plakken"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Plakken"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Naam"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Nieuw"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Wederkerend teken opnemen met wachtwoord"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Wachtwoord invoeren"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Wachtwoord"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Wachtwoord bevestigen"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Wachtwoord toevoegen"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Wachtwoord bewerken"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Zoekopties"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Volgende zoeken"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Vorige zoeken"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Hoofdlettergevoelig"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Alleen gehele woorden"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Alleen reguliere expressies"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Tekstomloop"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Sluiten"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximaliseren"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Invoer-synchronisatie uitschakelen voor dit terminalvenster"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Alleen-lezen"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Profiel bewerken"
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr "Coderingen bewerken"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Invoer-synchronisatie inschakelen voor dit terminalvenster"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Het laden van de  %s-bibliotheek is mislukt; de wachtwoordfunctionaliteit is "
+"niet beschikbaar."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Bibliotheek is niet geladen"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Zoeken…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Wachtwoord"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Bladwijzer toevoegen..."
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Bladwijzer toevoegen..."
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Uitvoer opslaan…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Terugzetten en wissen"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Indelingsopties…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Overig"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Rechts toevoegen"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Onder toevoegen"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Herstellen"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Link openen"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Linkadres kopiëren"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Kopiëren"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Alles selecteren"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Invoer synchroniseren"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr "De aangepaste linkregex '%s' bevat een fout en wordt genegeerd"
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+"Er is een onverwachte fout opgetreden; geen verdere informatie beschikbaar"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Er is een onverwachte fout opgetreden: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Terminaluitvoer opslaan"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Alle tekstbestanden"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Het dochterproces is normaal afgerond met de status %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Het dochterproces is afgebroken door signaal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Het dochterproces is afgebroken."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Herstarten"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Niet plakken"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Tóch plakken"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Indelingsopties"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Actief"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Laden van sessie"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Actieve opties zijn altijd actief en worden onmiddelijk toegepast.\n"
+"Laden van sessie-opties worden alleen toegepast bij het laden van een "
+"sessiebestand."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Sessie-zijbalk weergeven"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Nieuwe sessie creëren"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Terminal rechts toevoegen"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Terminal onder toevoegen"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Naar tekst zoeken in de terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Sessienaam wijzigen"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Voer een nieuwe sessienaam in"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Openen…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Opslaan als…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Naam…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Invoer synchroniseren"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Dit venster bevat actieve processen. Wilt u het venster tóch sluiten?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "De bestandsnaam '%s' bestaat niet"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Sessie laden"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Openen"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr ""
+"De sessie kan niet worden geladen omdat er een onverwachte fout is "
+"opgetreden."
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Er is een fout opgetreden tijdens het laden van de sessie"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Sessie opslaan"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Over"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Afsluiten"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Heimen Stoffels"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Met dank aan"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Stel de terminal-werkmap in"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "MAP"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Stel het startprofiel in"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "PROFIEL_NAAM"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Stel de nieuwe terminaltitel in"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITEL"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Open de opgegeven sessie"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "SESSIE_NAAM"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Verstuur een actie naar het huidige Terminix-proces"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ACTIE_NAAM"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Parameter uitvoeren als opdracht"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "OPDRACHT"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximaliseer het terminalvenster"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Terminalvenster minimaliseren"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Volledige scherm-modus"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Focus het huidige venster"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Nieuwe vensters starten als nieuw proces (niet aanbevolen)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Stel de venstergrootte in; bijv.: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "AFMETINGEN"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Opent een venster in quake-modus of weergeeft/verwerpt een actief quake-"
+"venster"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Terminix-versie en vereiste componenten-versies weergeven"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Terminix-voorkeurenvenster direct weergeven"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Verborgen argument om door te geven aan de terminal UUID"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Er lijkt een probleem te zijn met de configuratie van de terminal. Het "
+"probleem\n"
+"is niet ernstig maar het oplossen ervan zal uw terminal-ervaring verbeteren. "
+"Voor\n"
+"meer informatie, klik op de onderstaande link:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Configuratieprobleem ontdekt"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Dit bericht niet meer weergeven"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Het bestand %s is geen JSON-compatibel kleurenschemabestand"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Het kleurenschemapalet vereist 16 kleuren"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Er is een probleem opgetreden bij het vinden van de gedaalde terminal"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr ""
+"Er is een probleem opgetreden bij het vinden van de sessie van de gedaalde "
+"terminal"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -216,77 +1588,41 @@ msgstr "GtkD voor het beschikbaar stellen van een geweldige GTK-wrapper"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org voor de geweldige D-taal"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr "Pictogramtitel"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Map"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Hostnaam"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr "Kolommen"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Rijen"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Applicatienaam"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Sessienaam"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
 msgstr "Sessienummer"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Er is een probleem opgetreden bij het vinden van de gedaalde terminal"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-"Er is een probleem opgetreden bij het vinden van de sessie van de gedaalde "
-"terminal"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Standaard"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profiel"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nieuwe sessie"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -423,1416 +1759,6 @@ msgstr "Vietnamees"
 msgid "Thai"
 msgstr "Thais"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Indelingsopties"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Actief"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Logo"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Laden van sessie"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Actieve opties zijn altijd actief en worden onmiddelijk toegepast.\n"
-"Laden van sessie-opties worden alleen toegepast bij het laden van een "
-"sessiebestand."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Sluiten"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximaliseren"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Invoer-synchronisatie uitschakelen voor dit terminalvenster"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Alleen-lezen"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Terminalbel"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Profiel bewerken"
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr "Coderingen bewerken"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Invoer-synchronisatie inschakelen voor dit terminalvenster"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Het laden van de  %s-bibliotheek is mislukt; de wachtwoordfunctionaliteit is "
-"niet beschikbaar."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Bibliotheek is niet geladen"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Uitvoer opslaan…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Herstellen"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Terugzetten en wissen"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profielen"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Tekstcodering"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Bladwijzer toevoegen..."
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Bladwijzer selecteren..."
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Bladwijzers"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Zoeken…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Indelingsopties…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Rechts toevoegen"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Onder toevoegen"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Herstellen"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Link openen"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Linkadres kopiëren"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Kopiëren"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Plakken"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Alles selecteren"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Klembord"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Invoer synchroniseren"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr "De aangepaste linkregex '%s' bevat een fout en wordt genegeerd"
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-"Er is een onverwachte fout opgetreden; geen verdere informatie beschikbaar"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Er is een onverwachte fout opgetreden: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Terminaluitvoer opslaan"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Opslaan"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Alle tekstbestanden"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Alle bestanden"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Het dochterproces is normaal afgerond met de status %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Het dochterproces is afgebroken door signaal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Het dochterproces is afgebroken."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Herstarten"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Niet plakken"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Tóch plakken"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Zoekopties"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Volgende zoeken"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Vorige zoeken"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Hoofdlettergevoelig"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Alleen gehele woorden"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Alleen reguliere expressies"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Tekstomloop"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Deze opdracht vraagt om administrator-toegang tot uw computer"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Het kopiëren van opdrachten vanaf het internet kan gevaarlijk zijn. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Zorg ervoor dat u begrijpt wat alle delen van deze opdracht uitvoeren."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformeren"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Spaties omzetten naar tabs"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "CRLF en CR converteren naar LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Geavanceerd plakken"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nieuw"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Bewerken"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Verwijderen"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Wederkerend teken opnemen met wachtwoord"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Wachtwoord invoeren"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Toevoegen"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Wachtwoord"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Wachtwoord bevestigen"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Wachtwoord toevoegen"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Wachtwoord bewerken"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Dit bericht niet meer weergeven"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Venster (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sessie (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Applicatie sluiten"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Venster sluiten"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Sessie sluiten"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nieuw venster"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Voorkeuren"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Sneltoetsen"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Over"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Afsluiten"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Met dank aan"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Stel de terminal-werkmap in"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "MAP"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Stel het startprofiel in"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "PROFIEL_NAAM"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Stel de nieuwe terminaltitel in"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITEL"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Open de opgegeven sessie"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "SESSIE_NAAM"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Verstuur een actie naar het huidige Terminix-proces"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ACTIE_NAAM"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Parameter uitvoeren als opdracht"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "OPDRACHT"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximaliseer het terminalvenster"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Terminalvenster minimaliseren"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Volledige scherm-modus"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Focus het huidige venster"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Nieuwe vensters starten als nieuw proces (niet aanbevolen)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Stel de venstergrootte in; bijv.: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "AFMETINGEN"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Opent een venster in quake-modus of weergeeft/verwerpt een actief quake-"
-"venster"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Terminix-versie en vereiste componenten-versies weergeven"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Terminix-voorkeurenvenster direct weergeven"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Verborgen argument om door te geven aan de terminal UUID"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Er lijkt een probleem te zijn met de configuratie van de terminal. Het "
-"probleem\n"
-"is niet ernstig maar het oplossen ervan zal uw terminal-ervaring verbeteren. "
-"Voor\n"
-"meer informatie, klik op de onderstaande link:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Configuratieprobleem ontdekt"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Dit bericht niet meer weergeven"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Sessie-zijbalk weergeven"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Nieuwe sessie creëren"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Terminal rechts toevoegen"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Terminal onder toevoegen"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Naar tekst zoeken in de terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Sessienaam wijzigen"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Voer een nieuwe sessienaam in"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Openen…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Opslaan als…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Naam…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Invoer synchroniseren"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Dit venster bevat actieve processen. Wilt u het venster tóch sluiten?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Alle JSON-bestanden"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "De bestandsnaam '%s' bestaat niet"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Sessie laden"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Openen"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr ""
-"De sessie kan niet worden geladen omdat er een onverwachte fout is "
-"opgetreden."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Er is een fout opgetreden tijdens het laden van de sessie"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Sessie opslaan"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Het bestand %s is geen JSON-compatibel kleurenschemabestand"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Het kleurenschemapalet vereist 16 kleuren"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr "Bladwijzer toevoegen"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr "Bladwijzer bewerken"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr "Bladwijzer verwijderen"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr "Bladwijzer de-selecteren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Terminix-voorkeuren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Globaal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Uiterlijk"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Profiel toevoegen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Profiel verwijderen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profiel: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Dupliceren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "G"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Tekstcoderingen die moeten worden weergegeven in het menu:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Ingeschakeld"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Actie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Sneltoets"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Sneltoetsen inschakelen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Bestaande sneltoets overschrijven"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"De snelkoppeling %s is al toegewezen aan %s.\n"
-"Wilt u de sneltoets van de andere actie uitschakelen en toewijzen aan deze "
-"actie?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Doorzichtigheid inschakelen; herstart vereist"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr "Vensterstijl"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normaal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr "CSD uitschakelen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr "CSD uitschakelen, werkbalk verbergen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr "Randloos"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr "Vensterherstart vereist"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Titelstijl van terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Klein"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Geen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Themastijl"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Licht"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Donker"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Achtergrondafbeelding"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Afbeelding selecteren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Alle afbeeldingsbestanden"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Achtergrondafbeelding verwijderen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Schalen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Tegelen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centreren"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Uitrekken"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Standaard sessienaam"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Applicatietitel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Brede handgreep gebruiken voor splitsingen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Zijbalk aan de rechterkant plaatsen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Terminaltitel weergeven, zelfs als het de enige terminal is"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Grootte"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Hoogtepercentage"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Breedtepercentage"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Uitlijning"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Links"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Rechts"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Opties"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Terminal weergeven op alle werkbladen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Hint instellen voor vensterbeheerder om animaties uit te schakelen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Venster sluiten bij verliezen van focus"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Venstertitelbalk verbergen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Terminal weergeven op actief beeldscherm"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Weergeven op specifiek beeldscherm"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Gedrag"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Vragen bij creëren van nieuwe sessie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Focus een terminal wanneer de muis eroverheen zweeft"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Cursor verbergen tijdens typen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Terminal sluiten door met de middelste muisknop te klikken op de titel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Zoomen in terminalvenster middels <Control> en scrollwiel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Venster sluiten wanneer de laatste sessie wordt afgesloten"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Bureaubladmelding weergeven bij afronden van proces"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Bij nieuw proces"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Splitsen naar rechts"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Splitsen naar onderen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Venster focussen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Altijd geavanceerd plakken gebruiken"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Waarschuwen bij plakken van onveilige opdracht"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "Eerste teken weglaten bij plakken van een comment of variabel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Geselecteerde tekst automatisch kopiëren naar het klembord"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Algemeen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Kleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Scrollen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibiliteit"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Geavanceerd"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Profielnaam"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Terminalgrootte"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "kolommen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "rijen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Blok"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Verticale streep"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Onderliggende streep"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Knippermodus"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Systeem"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Ingeschakeld"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Uitgeschakeld"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Geluid"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Pictogram en geluid"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Terminaltitel"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Logo-positie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Noordwest"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Noordoost"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Zuidwest"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Zuidoost"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Tekstuiterlijk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Vetgedrukte tekst toestaan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Tekstterugloop passend maken bij herschalen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Aangepast lettertype"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Kies een terminal-lettertype"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Kleurenschema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Aangepast"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exporteren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Kleurenpalet"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Themakleuren gebruiken voor voorgrond/achtergrond"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Doorzichtigheid"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Ongefocusde verduistering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Tekst"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Achtergrond"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Selecteer voorgrondkleur van cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Selecteer achtergrondkleur van cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Markeren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Selecteer voorgrondkleur van markering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Selecteer achtergrondkleur van markering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Verduisteren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Selecteer verduisteringskleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Selecteer badgekleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Selecteer achtergrondkleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Selecteer voorgrondkleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Voorgrond"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Zwart"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Rood"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Groen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Oranje"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Blauw"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Paars"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turkoois"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Grijs"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Selecteer %s kleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Selecteer %s lichte kleur"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Kleurenschema exporteren"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Scrollbalk weergeven"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Scrollen bij uitvoer"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Scrollen bij toetsaanslag"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Scrolluitvoer beperken tot:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Backspace-toets genereert"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatisch"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Escape-volgorde"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Delete-toets genereert"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Tekens met eenduidige breedte"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Smal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Breed"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Opdracht uitvoeren als inlog-shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Een aangepast commando uitvoeren in plaats van mijn shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Als de opdracht is afgerond"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Terminal afsluiten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Opdracht herstarten"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Terminalvenster openhouden"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Aangepaste links"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Een gebruikers-gedefinieerde lijst van links die kunnen worden aangeklikt in "
-"de terminal gebaseerd op reguliere expressies."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Triggers"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Triggers zijn reguliere expressies die worden gebruikt om de uitvoertekst in "
-"de terminal te controleren. Als een overeenkomst is aangetroffen zal de "
-"ingestelde actie worden uitgevoerd."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Automatische profieloverschakeling"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
-"waarden.\n"
-"Waarden moeten worden ingevoerd in de notatie <i>gebruikersnaam@hostnaam:"
-"map</i>. De hostnaam of map kan leeg worden gelaten maar de dubbele punt "
-"moet ten alle tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als "
-"de map is niet toegestaan."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profielen worden automatisch geselecteerd op basis van de hier ingevoerde "
-"waarden.\n"
-"Waarden moeten worden ingevoerd in de notatie <i>hostnaam:map</i>. De "
-"hostnaam of map kan leeg worden gelaten maar de dubbele punt moet ten alle "
-"tijde aanwezig zijn. Het leeglaten van zowels de hostnaam als de map is niet "
-"toegestaan."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Overeenkomen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Toevoegen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Voer de overeen te komen gebruikersnaam@hostnaam:map in"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Voer de overeen te komen hostnaam:map in"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Nieuw overeenkomst toevoegen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Bewerk de overeen te komen gebruikersnaam@hostnaam:map"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Bewerk de overeen te komen hostnaam:map"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Overeenkomst bewerken"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Regex"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Hoofdletterongevoelig"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Aangepaste links bewerken"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parameter"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Aantal regels voor triggerdoorvoering beperken tot:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Triggers bewerken"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr "Rij %d: "
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr "Venster"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr "Hulp"
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1867,42 +1793,131 @@ msgstr ""
 "U kunt de quake-modus niet gebruiken met de parameters voor maximaliseren, "
 "minimaliseren of afmetingen"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "StatusBijwerken"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr "Fout tijdens deserialiseren van bladwijzer"
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "CommandoUitvoeren"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr "Root"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "MeldingVersturen"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr ""
+"De bladwijzers kunnen niet worden geladen omdat er een onverwachte fout is "
+"opgetreden"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "TitelBijwerken"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Map"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "BelAfspelen"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr "Pad"
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "TekstVersturen"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Op afstand"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "WachtwoordInvoeren"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Selecteer map"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "Badge bijwerken"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Selecteer map"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Map legen"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Bladwijzer toevoegen"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Bladwijzer bewerken"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Selecteer pad"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Protocol"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Host"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Gebruiker"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Parameters"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Selecteer bladwijzer"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "uitgeschakeld"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Kopiëren)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"Uw GTK-versie is verouderd; u moet op zijn minst beschikken over versie %d."
+"%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Er is een onverwachte fout opgetreden"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Fout: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Versies"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Terminix-versie: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "VTE-versie: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "GTK-versie: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Terminix Speciale Mogelijkheden"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Meldingen ingeschakeld=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Triggers ingeschakeld=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Badges ingeschakeld=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"
@@ -2452,6 +2467,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix is getest onder GNOME en Unity."
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Bladwijzer selecteren..."
 
 #~ msgid "The expression %s is not a valid regex"
 #~ msgstr "De expressie %s is een ongeldige regex"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.4.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-01-14 11:37+0100\n"
 "Last-Translator: Piotr Sokół <psokol.l10n@gmail.com>\n"
 "Language-Team: polski <>\n"
@@ -17,181 +17,1553 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"Zainstalowana wersja GTK jest przestarzała. Wymagana jest co najmniej wersja "
-"GTK %d.%d.%d!"
-
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Wystąpił nieoczekiwany błąd"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "Błąd: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Wersje"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Wersja Terminix: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Wersja: VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Wersja GTK: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Specjalne funkcje Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Powiadomienia włączone=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Wyzwalacze włączone=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
 
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "wyłączone"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Select Folder"
-msgstr "Wybór koloru: %s"
+msgid "ExecuteCommand"
+msgstr "Polecenie"
 
-#: source/gx/terminix/bookmark/bmeditor.d:74
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
 #, fuzzy
-msgid "Select folder"
-msgstr "Wybór koloru: %s"
+msgid "UpdateTitle"
+msgstr "Tytuł"
 
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Zatwierdź"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Nazwa"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
+#: source/gx/terminix/preferences.d:217
 #, fuzzy
-msgid "Select Path"
-msgstr "Zaznaczenie wszystkiego"
+msgid "SendText"
+msgstr "Tekst"
 
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "Tytuł"
+
+#: source/gx/terminix/preferences.d:326
+#, c-format
+msgid "%s (Copy)"
+msgstr "%s (kopia)"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Ogólne"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Polecenie"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Kolory"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Przewijanie"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Zgodność"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Parametr"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Zaawansowane"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Wybór koloru: %s"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nazwa profilu"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Rozmiar terminala"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "kolumn"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "wierszy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Przywróć"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Kursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Blokowy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Linia pionowa"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Podkreślenie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Tryb migania"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Systemowy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Włączony"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Wyłączony"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Dzwonek terminala"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Brak"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Dźwięk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Ikona"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Ikona i dźwięk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Tytuł terminala"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Southeast"
+msgstr "Południowoeuropejskie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Wygląd tekstu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Zezwolenie na pogrubiony tekst"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Zawijanie podczas zmiany rozmiaru"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Własna czcionka"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Wybór czcionki terminala"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "Identyfikator: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Zestaw kolorów"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Własny"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Eksportuj"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Paleta kolorów"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Opcje"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Kolory stylu dla tła i pierwszego planu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Przezroczystość"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Przyciemnienie nieaktywnych"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Tekst"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Tło"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Wybór koloru pierwszego planu kursora"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Wybór koloru tła kursora"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Zaznaczenie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Wybór koloru pierwszego planu zaznaczenia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Wybór koloru tła zaznaczenia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Przyciemnienie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Wybór koloru przyciemnienia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Wybór koloru: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Wybór koloru tła"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Wybór koloru pierwszego planu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Pierwszy plan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Czarny"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Czerwony"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Zielony"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Pomarańczowy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Niebieski"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Fioletowy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turkusowy"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Szary"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Wybór koloru: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Wybór jasnego koloru: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Zestaw kolorów"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Zapisz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Wszystkie pliki JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Wszystkie pliki"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Pasek przewijania"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Przewijanie po wypisaniu na wyjście"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Przewijanie po naciśnięciu klawisza"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Wielkość buforu przewijania:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Działanie klawisza Backspace"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatycznie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "Znak DEL kodu ASCII"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Sekwencja sterująca"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "Znak wymazania TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Działanie klawisza Delete"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Kodowanie znaków"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Znaki o zmiennej szerokości"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Wąskie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Szerokie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Uruchamianie w roli powłoki startowej"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Uruchamianie własnego polecenia zamiast powłoki"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Działanie zakończenia polecenia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Zakończenie działania terminala"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Ponowne uruchomienie polecenia"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Pozostawienia terminala otwartego"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Własne odnośniki"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Poniższa lista zawiera odnośniki zdefiniowane przez użytkownika na podstawie "
+"wyrażeń regularnych, które można kliknąć w terminalu."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Zmodyfikuj"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Wyzwalacze"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Wyzwalacze są wyrażeniami regularnymi porównywanymi ze standardowym wyjściem "
+"terminala. Wykrycie dopasowania powoduje wykonanie skonfigurowanej czynności."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Automatyczne przełączanie profilów"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profile są automatycznie wybierane na podstawie wprowadzonych poniżej "
+"wartości.\n"
+"Wartości te należy wprowadzać w formacie <i>nazwa_komputera:katalog</i>. "
+"Można pominąć nazwę komputera lub ścieżkę katalogu ale należy zachować znak "
+"dwukropka. Niedozwolone są dopasowania pomijające nazwę komputera wraz ze "
+"ścieżką katalogu."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Dopasowanie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Dodaj"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Dodawanie dopasowania"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Modyfikowanie dopasowania"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Usuń"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Wyrażenie regularne"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Nieważna wielkość liter"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Modyfikowanie własnych odnośników"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Zastosuj"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Działanie"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parametr"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Zmodyfikuj wyzwalacz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "Okno"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Preferencje Terminix"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Ogólne"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Wygląd"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Tryb Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Skróty klawiszowe"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Dodaje profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Usuwa profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profile"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profil: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Powiel"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Użyj dla nowych terminali"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Kodowania znaków wyświetlane w menu:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Włączony"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Klawisz skrótu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Włączenie skrótów klawiszowych"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Zastępowanie istniejącego skrótu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Skrót %s jest już przypisany do czynności %s.\n"
+"Wyłączyć skrót dla innej czynności i przypisać go do bieżącej?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Włączenie przezroczystości wymaga ponownego uruchomienia programu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Okno (%s)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Zwykły"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "wyłączone"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Pasek tytułu terminala"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Mały"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Styl"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Domyślny"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Jasny"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Ciemny"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Obraz tła"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Wybór obrazu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Wszystkie pliki obrazów"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Czyści obraz tła"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Przeskalowany"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Rozmieszczony sąsiadująco"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Środek"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Rozciągnięty"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nazwa domyślnej sesji"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Tytuł programu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Szerokie uchwyty elementów rozdzielających"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Pasek boczny po prawej stronie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Pasek tytułu tylko jednego terminala "
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Rozmiar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Wysokość %"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Szerokość %"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Wyrównanie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Lewo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Prawo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Terminal widoczny na wszystkich obszarach roboczych"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Wyłączenie animacji w menedżerze okien"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Ukrycie okna po utraceniu uaktywnienia"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Ukrycie paska tytułowego okna"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Terminal widoczny na aktualnym ekranie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Widoczny na określonym ekranie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Zachowanie"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Dialog tworzenia nowej sesji"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Uaktywnianie terminala przenosząc nad niego wskaźnik myszy"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Ukrywanie wskaźnika myszy podczas pisania"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+"Zamykanie terminala kliknięciem środkowego przycisku myszy na pasku tytułu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Przybliżanie widoku za pomocą klawisza <Control> i kółka myszy"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Zamknięcie okna po zakończeniu ostatniej sesji"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Powiadamianie o zakończonych procesach"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Działanie nowego wystąpienia"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nowe okno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nowa sesja"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Podzielenie w prawo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Podzielenie w dół"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Uaktywnienie okna"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Schowek"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Używanie okna zaawansowanego wklejania"
+
+# Notatki:
+# Dodaj notatkę
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Ostrzeganie o potencjalnie niebezpiecznej zawartości"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "Usuwanie pierwszego znaku komentarza lub deklaracji zmiennej"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Kopiowanie tekstu po jego zaznaczeniu"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Tytuł"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Pomijanie wyświetlania tego ponownie"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Okno (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sesja (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "Program"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "Uaktywnienie okna"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "Nowa sesja"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Zatwierdź"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+"Wklejanie do terminala poleceń opublikowanych w sieci może być "
+"niebezpieczne. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+"Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Przekształcenia"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Skonwertowanie spacji na tabulatory"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Skonwertowanie CRLF i CR na LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Zaawansowanie wklejanie"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Wklej"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Nazwa"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "Identyfikator"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Nowy"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Wprowadzanie hasła"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Hasło"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Potwierdzenie hasła"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Dodawanie hasła"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Modyfikowanie hasła"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Wyświetla opcje wyszukiwania"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Wyszukuje następne wystąpienie"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Wyszukuje poprzednie wystąpienie"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Uwzględnianie wielkości liter"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Dopasowanie tylko całych słów"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Dopasowanie do wyrażenia regularnego"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Przeszukanie od początku po osiągnięciu końca"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Zamknij"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Zmaksymalizuj"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Tylko do odczytu"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Zmodyfikuj profil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Kodowanie znaków"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Nie można wczytać biblioteki %s. Przechowywanie haseł jest niedostępne."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Nie wczytano biblioteki"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Wyszukaj…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Hasło"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Wybór koloru: %s"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Zapisz zawartość…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Przywróć i wyczyść"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Opcje układu…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Inne"
+
+#: source/gx/terminix/terminal/terminal.d:745
+#, fuzzy
+msgid "Add Right"
+msgstr "Podzielenie w prawo"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Przywróć"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Otwórz odnośnik"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Skopiuj adres odnośnika"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Skopiuj"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Zaznacz wszystko"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Synchronizowanie wprowadzania"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Wystąpił nieoczekiwany błąd: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Zapisywanie zawartości terminala"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Wszystkie pliki tekstowe"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Zakończono proces podrzędny w zwykły sposób, ze stanem %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Przerwano proces podrzędny sygnałem %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Przerwano proces podrzędny."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Uruchom ponownie"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Nie wklejaj"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Wklej mimo to"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Opcje układu"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Bieżące"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Wczytywanie sesji"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Bieżące opcje działają cały czas i są wprowadzane natychmiastowo.\n"
+"Opcje wczytywania sesji są wprowadzane tylko podczas wczytywania pliku sesji."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Wyświetla pasek boczny sesji"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Tworzy nową sesję"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Dodaje terminal po prawej"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Dodaje terminal u dołu"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Wyszukuje tekst w terminalu"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Zmiana nazwy sesji"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Proszę wprowadzić nazwę sesji"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Otwórz…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Zapisz jako…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nadaj nazwę…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Synchronizowanie"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Jest wiele otwartych sesji. Zakończyć działanie?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Plik „%s” nie istnieje"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Wczytywanie sesji"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Otwórz"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr ""
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Błąd wczytywania sesji"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Zapisywanie sesji"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "O programie"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Zakończ"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Piotr Sokół"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Zasługi"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Ustala katalog roboczy terminala"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "KATALOG"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Używa zdefiniowanego profilu"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NAZWA_PROFILU"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Ustala tytuł nowego terminala"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TYTUŁ"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Otwiera określoną sesję"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NAZWA_SESJI"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NAZWA_CZYNNOŚCI"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Wykonuje polecenie określone w parametrze"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "POLECENIE"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maksymalizuje rozmiar okna"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Minimalizuje okno"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Przełącza tryb pełnego ekranu"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Uaktywnia otwarte okno"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Uruchamia dodatkowe wystąpienie jako nowy proces (nie polecane)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
+"Ustala rozmiar okna; np.: 80x24 lub 80x24+200+200 (KOLUMNYxWIERSZE+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIA"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Otwiera okno w trybie quake lub przełącza widoczność okna otwartego w trybie "
+"quake"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Wypisuje numery wersji programu i zależnych składników"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Wyświetla okno preferencji programu"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_TERMINALA"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Natrafiono na problem z konfiguracją terminala.\n"
+"Błąd nie jest poważny, ale naprawienie go ułatwi pracę z programem.\n"
+"Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Wykryto błąd konfiguracji"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Plik %s nie jest zgodny z formatem pliku JSON zestawu kolorów"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Paleta zestawu kolorów wymaga 16 kolorów"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Nie można odnaleźć porzuconego terminala"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Nie można odnaleźć sesji porzuconego terminala"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -217,80 +1589,46 @@ msgstr "GtkD za udostępnienie świetnego interfejsu GTK"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org za doskonały język programowania, D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Tytuł"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Tytuł programu"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Identyfikator"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "kolumn"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Program"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Wczytywanie sesji"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Sesja"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Nie można odnaleźć porzuconego terminala"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Nie można odnaleźć sesji porzuconego terminala"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Domyślny"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nowa sesja"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -427,1419 +1765,6 @@ msgstr "Wietnamskie"
 msgid "Thai"
 msgstr "Tajskie"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Opcje układu"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Bieżące"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Wczytywanie sesji"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Bieżące opcje działają cały czas i są wprowadzane natychmiastowo.\n"
-"Opcje wczytywania sesji są wprowadzane tylko podczas wczytywania pliku sesji."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Zamknij"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Zmaksymalizuj"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Tylko do odczytu"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Dzwonek terminala"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Zmodyfikuj profil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Kodowanie znaków"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Przełącza synchronizowanie wprowadzania dla tego terminala"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Nie można wczytać biblioteki %s. Przechowywanie haseł jest niedostępne."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Nie wczytano biblioteki"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Zapisz zawartość…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Przywróć"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Przywróć i wyczyść"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profile"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Kodowanie znaków"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Wybór koloru: %s"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Wyszukaj…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Opcje układu…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-#, fuzzy
-msgid "Add Right"
-msgstr "Podzielenie w prawo"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Przywróć"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Otwórz odnośnik"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Skopiuj adres odnośnika"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Skopiuj"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Wklej"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Zaznacz wszystko"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Schowek"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Synchronizowanie wprowadzania"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Wystąpił nieoczekiwany błąd. Brak dodatkowych informacji."
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Wystąpił nieoczekiwany błąd: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Zapisywanie zawartości terminala"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Zapisz"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Wszystkie pliki tekstowe"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Wszystkie pliki"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Zakończono proces podrzędny w zwykły sposób, ze stanem %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Przerwano proces podrzędny sygnałem %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Przerwano proces podrzędny."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Uruchom ponownie"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Nie wklejaj"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Wklej mimo to"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Wyświetla opcje wyszukiwania"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Wyszukuje następne wystąpienie"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Wyszukuje poprzednie wystąpienie"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Uwzględnianie wielkości liter"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Dopasowanie tylko całych słów"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Dopasowanie do wyrażenia regularnego"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Przeszukanie od początku po osiągnięciu końca"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "To polecenie prosi o uwierzytelnienie dostępu do komputera"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-"Wklejanie do terminala poleceń opublikowanych w sieci może być "
-"niebezpieczne. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-"Proszę upewnić się, że zrozumiany jest każdy element składni polecenia."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Przekształcenia"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Skonwertowanie spacji na tabulatory"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Skonwertowanie CRLF i CR na LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Zaawansowanie wklejanie"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Nowy"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Zmodyfikuj"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Usuń"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Wprowadzanie hasła"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Zastosuj"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Hasło"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Potwierdzenie hasła"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Dodawanie hasła"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Modyfikowanie hasła"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Pomijanie wyświetlania tego ponownie"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Okno (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sesja (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "Program"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "Uaktywnienie okna"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "Nowa sesja"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nowe okno"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Skróty klawiszowe"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "O programie"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Zakończ"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Zasługi"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Ustala katalog roboczy terminala"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "KATALOG"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Używa zdefiniowanego profilu"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NAZWA_PROFILU"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Ustala tytuł nowego terminala"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TYTUŁ"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Otwiera określoną sesję"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NAZWA_SESJI"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Wykonuje czynność w bieżącym wystąpieniu programu"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NAZWA_CZYNNOŚCI"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Wykonuje polecenie określone w parametrze"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "POLECENIE"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maksymalizuje rozmiar okna"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Minimalizuje okno"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Przełącza tryb pełnego ekranu"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Uaktywnia otwarte okno"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Uruchamia dodatkowe wystąpienie jako nowy proces (nie polecane)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Ustala rozmiar okna; np.: 80x24 lub 80x24+200+200 (KOLUMNYxWIERSZE+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIA"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Otwiera okno w trybie quake lub przełącza widoczność okna otwartego w trybie "
-"quake"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Wypisuje numery wersji programu i zależnych składników"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Wyświetla okno preferencji programu"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Określa ukryty parametr przekazujący identyfikator terminala"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_TERMINALA"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Natrafiono na problem z konfiguracją terminala.\n"
-"Błąd nie jest poważny, ale naprawienie go ułatwi pracę z programem.\n"
-"Proszę kliknąć na poniższy odnośnik w celu uzyskania dodatkowych informacji:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Wykryto błąd konfiguracji"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Pomijanie wyświetlania tej informacji w przyszłości"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Wyświetla pasek boczny sesji"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Tworzy nową sesję"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Dodaje terminal po prawej"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Dodaje terminal u dołu"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Wyszukuje tekst w terminalu"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Zmiana nazwy sesji"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Proszę wprowadzić nazwę sesji"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Otwórz…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Zapisz jako…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nadaj nazwę…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Synchronizowanie"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Jest wiele otwartych sesji. Zakończyć działanie?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Wszystkie pliki JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Plik „%s” nie istnieje"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Wczytywanie sesji"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Otwórz"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Błąd wczytywania sesji"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Zapisywanie sesji"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Plik %s nie jest zgodny z formatem pliku JSON zestawu kolorów"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Paleta zestawu kolorów wymaga 16 kolorów"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Preferencje Terminix"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Ogólne"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Wygląd"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Tryb Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Dodaje profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Usuwa profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profil: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Powiel"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Użyj dla nowych terminali"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Kodowania znaków wyświetlane w menu:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Włączony"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Działanie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Klawisz skrótu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Włączenie skrótów klawiszowych"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Zastępowanie istniejącego skrótu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Skrót %s jest już przypisany do czynności %s.\n"
-"Wyłączyć skrót dla innej czynności i przypisać go do bieżącej?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Włączenie przezroczystości wymaga ponownego uruchomienia programu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Okno (%s)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Zwykły"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "wyłączone"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Pasek tytułu terminala"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Mały"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Brak"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Styl"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Jasny"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Ciemny"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Obraz tła"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Wybór obrazu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Wszystkie pliki obrazów"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Czyści obraz tła"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Przeskalowany"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Rozmieszczony sąsiadująco"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Środek"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Rozciągnięty"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nazwa domyślnej sesji"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Tytuł programu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Szerokie uchwyty elementów rozdzielających"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Pasek boczny po prawej stronie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Pasek tytułu tylko jednego terminala "
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Rozmiar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Wysokość %"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Szerokość %"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Wyrównanie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Lewo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Prawo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Opcje"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Terminal widoczny na wszystkich obszarach roboczych"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Wyłączenie animacji w menedżerze okien"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Ukrycie okna po utraceniu uaktywnienia"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Ukrycie paska tytułowego okna"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Terminal widoczny na aktualnym ekranie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Widoczny na określonym ekranie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Zachowanie"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Dialog tworzenia nowej sesji"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Uaktywnianie terminala przenosząc nad niego wskaźnik myszy"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Ukrywanie wskaźnika myszy podczas pisania"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-"Zamykanie terminala kliknięciem środkowego przycisku myszy na pasku tytułu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Przybliżanie widoku za pomocą klawisza <Control> i kółka myszy"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Zamknięcie okna po zakończeniu ostatniej sesji"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Powiadamianie o zakończonych procesach"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Działanie nowego wystąpienia"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Podzielenie w prawo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Podzielenie w dół"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Uaktywnienie okna"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Używanie okna zaawansowanego wklejania"
-
-# Notatki:
-# Dodaj notatkę
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Ostrzeganie o potencjalnie niebezpiecznej zawartości"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "Usuwanie pierwszego znaku komentarza lub deklaracji zmiennej"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Kopiowanie tekstu po jego zaznaczeniu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Ogólne"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Kolory"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Przewijanie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Zgodność"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Zaawansowane"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nazwa profilu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Rozmiar terminala"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "kolumn"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "wierszy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Kursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Blokowy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Linia pionowa"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Podkreślenie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Tryb migania"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Systemowy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Włączony"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Wyłączony"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Dźwięk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Ikona i dźwięk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Tytuł terminala"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "Południowoeuropejskie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Wygląd tekstu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Zezwolenie na pogrubiony tekst"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Zawijanie podczas zmiany rozmiaru"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Własna czcionka"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Wybór czcionki terminala"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "Identyfikator: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Zestaw kolorów"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Własny"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Eksportuj"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Paleta kolorów"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Kolory stylu dla tła i pierwszego planu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Przezroczystość"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Przyciemnienie nieaktywnych"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Tekst"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Tło"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Wybór koloru pierwszego planu kursora"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Wybór koloru tła kursora"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Zaznaczenie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Wybór koloru pierwszego planu zaznaczenia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Wybór koloru tła zaznaczenia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Przyciemnienie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Wybór koloru przyciemnienia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Wybór koloru: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Wybór koloru tła"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Wybór koloru pierwszego planu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Pierwszy plan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Czarny"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Czerwony"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Zielony"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Pomarańczowy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Niebieski"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Fioletowy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turkusowy"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Szary"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Wybór koloru: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Wybór jasnego koloru: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Zestaw kolorów"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Pasek przewijania"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Przewijanie po wypisaniu na wyjście"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Przewijanie po naciśnięciu klawisza"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Wielkość buforu przewijania:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Działanie klawisza Backspace"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatycznie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "Znak DEL kodu ASCII"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Sekwencja sterująca"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "Znak wymazania TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Działanie klawisza Delete"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Znaki o zmiennej szerokości"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Wąskie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Szerokie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Uruchamianie w roli powłoki startowej"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Uruchamianie własnego polecenia zamiast powłoki"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Działanie zakończenia polecenia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Zakończenie działania terminala"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Ponowne uruchomienie polecenia"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Pozostawienia terminala otwartego"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Własne odnośniki"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Poniższa lista zawiera odnośniki zdefiniowane przez użytkownika na podstawie "
-"wyrażeń regularnych, które można kliknąć w terminalu."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Wyzwalacze"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Wyzwalacze są wyrażeniami regularnymi porównywanymi ze standardowym wyjściem "
-"terminala. Wykrycie dopasowania powoduje wykonanie skonfigurowanej czynności."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Automatyczne przełączanie profilów"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profile są automatycznie wybierane na podstawie wprowadzonych poniżej "
-"wartości.\n"
-"Wartości te należy wprowadzać w formacie <i>nazwa_komputera:katalog</i>. "
-"Można pominąć nazwę komputera lub ścieżkę katalogu ale należy zachować znak "
-"dwukropka. Niedozwolone są dopasowania pomijające nazwę komputera wraz ze "
-"ścieżką katalogu."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Dopasowanie"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Dodaj"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Dodawanie dopasowania"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Proszę wprowadzić wzór nazwa_komputera:katalog do dopasowania:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Modyfikowanie dopasowania"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Wyrażenie regularne"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Nieważna wielkość liter"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Modyfikowanie własnych odnośników"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parametr"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Zmodyfikuj wyzwalacz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Okno"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1872,46 +1797,135 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Polecenie"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "Tytuł"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Nie można wczytać sesji z powodu nieoczekiwanego błędu."
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "Tekst"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "Tytuł"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "Wybór koloru: %s"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Wybór koloru: %s"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Zaznaczenie wszystkiego"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "Parametr"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Wybór koloru: %s"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "wyłączone"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (kopia)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"Zainstalowana wersja GTK jest przestarzała. Wymagana jest co najmniej wersja "
+"GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Wystąpił nieoczekiwany błąd"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Błąd: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Wersje"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Wersja Terminix: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Wersja: VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Wersja GTK: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Specjalne funkcje Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Powiadomienia włączone=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Wyzwalacze włączone=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,11 +3,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-08 18:05+0000\n"
 "Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
-"Language-Team: Portuguese (Brazil) "
-"<https://hosted.weblate.org/projects/terminix/translations/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"terminix/translations/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,174 +15,1548 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.12-dev\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "AtualizarEstado"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "ExecutarComando"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "EnviarNotificação"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "AtualizarTítulo"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "SinalizarAtenção"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "EnviarTexto"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "InserirSenha"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "AtualizarDistintivo"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"Sua versão do GTK é muito antiga, você precisa pelo menos do GTK %d.%d.%d!"
+msgid "%s (Copy)"
+msgstr "%s (Cópia)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Ocorreu uma exceção inesperada"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Geral"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Erro: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Versões"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Versão do Terminix: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Versão do VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Versão do GTK: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Funcionalidades especiais do Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Notificações habilitadas=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Acionadores habilitados=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Distintivos habilitados=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "desabilitado"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Selecionar pasta"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Selecionar pasta"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Limpar pasta"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Adicionar favorito"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Editar favorito"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Nome"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr "Caminho"
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Selecionar caminho"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Comando"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Protocolo"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Cor"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Host"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Rolagem"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Usuário"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibilidade"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Parâmetros"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Avançado"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Selecionar favorito"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nome do perfil"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Tamanho do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "colunas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "linhas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Redefinir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Bloco"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Barra vertical"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Sublinhado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Piscar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Configuração do sistema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Ligado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Desligado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Sinal de atenção"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Nenhum"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Som"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Ícone"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr "Erro ao carregar favorito"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Ícone e Som"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr "Raiz"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Título do terminal"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
-msgstr "Não foi possível carregar favoritos devido a um erro inesperado"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Distintivo"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Pasta"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Posição do distintivo"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Remoto"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Noroeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Nordeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Sudoeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Sudeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Aparência do texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Permitir negrito"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Reajustar ao redimensionar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Fonte personalizada"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Escolher fonte do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Esquema de cores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Personalizado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exportar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Paleta de cores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Opções"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Utilizar cores de sistema para texto/fundo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparência"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Escurecer quando fora de foco"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Fundo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Selecionar cor principal do cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Selecionar cor de fundo do cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Seleção"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Selecionar cor de texto selecionado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Selecionar cor de fundo selecionado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Escurecimento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Selecionar cor de escurecimento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Selecionar cor do distintivo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Selecionar cor de fundo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Selecionar cor do texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Preto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Vermelho"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Verde"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Laranja"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Azul"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Roxo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turquesa"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Cinza"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Selecionar cor %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Selecionar cor %s clara"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Exportar esquema de cores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Salvar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Todos os arquivos JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Todos os arquivos"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Mostrar barra de rolagem"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Rolar na saída"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Rolar ao digitar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Limite de rolagem:"
+
+# Terminix gettext pot file
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Tecla Backspace gera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automático"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Sequência de escape"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Tecla Delete gera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Codificação"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Caracteres de largura ambígua"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Estreitar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Alargar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Executar comando como um shell de login"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Executar um comando personalizado ao invés do meu shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Após termino do comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Sair do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Reiniciar o comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Manter o terminal aberto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Links personalizados"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Uma lista de links definidos pelo usuário que podem ser clicados no terminal "
+"com base em definições de expressões regulares."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Editar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Acionadores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Acionadores são expressões regulares comparadas com o texto de saída do "
+"terminal. Quando correspondências são detectadas, a ação configurada é "
+"executada."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Seleção automática de perfil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
+"Entradas usam o formato <i>usuário@nome-do-host:diretório</i>. O nome de "
+"host ou diretório podem ser omitidos, mas não ambos, e o caractere dois "
+"pontos precisa ser mantido."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
+"Entradas usam o formato <i>nome da máquina:diretório</i>. O nome da máquina "
+"ou diretório podem ser omitidos, mas não ambos, as entradas sem nome da "
+"máquina ou diretório não são permitidas."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Correspondências"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Adicionar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Digite um padrão no formato usuário@nome-do-host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Digite um padrão de nome do host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Adicionar novo padrão de correspondência"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Editar padrão no formato usuário@nome-do-host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Editar padrão de nome do host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Editar padrão de correspondência"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Excluir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Expressão regular"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Não diferenciar maiúsculas e minúsculas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Editar links personalizados"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Aplicar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Ação"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parâmetro"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Limitar número de linhas processadas para detectar acionadores a:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Editar acionadores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr "Linha %d: "
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr "Janela"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr "Ajuda"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Preferências do Terminix"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Global"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Aparência"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Modo Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Favoritos"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Atalhos do teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Novo perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Excluir perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferências"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Perfis"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Perfil: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Clonar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Aplicar em novos terminais"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Codificações exibidas no menu:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Tecla de atalho"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Habilitar atalhos do teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Sobrescrever atalho existente"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"O atalho %s já está atribuído para %s.\n"
+"Desabilitar a ação existente e substituí-la pela nova?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Habilitar transparência, requer re-início"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr "Estilo de janela"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr "Desabilitar CSD"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr "Desabilitar CSD, ocultar barra de ferramentas"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr "Sem bordas"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr "Necessário reiniciar janela"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Estilo do título do terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Pequeno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Variante do tema"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Padrão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Claro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Escuro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Imagem de fundo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Selecionar imagem"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Todos os arquivos de imagem"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Reinicializar imagem de fundo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Preencher"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Lado a lado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Estender"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nome da sessão padrão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Título da aplicação"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Utilizar uma borda larga para os divisores"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Mostrar barra lateral na direita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Mostrar o título do terminal mesmo que seja o único"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Tamanho"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Proporção de altura"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Proporção de largura"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Alinhamento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Esquerda"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Direita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Mostrar o terminal em todos os espaços de trabalho"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Definir dica para o gerenciador de janelas desativar a animação"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Esconder janela ao retirar foco"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Ocultar a barra de título da janela"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Exibir terminal apenas no monitor ativo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Exibir terminal no monitor"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Comportamento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Alertar ao criar uma nova sessão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Ativar terminal quando o cursor é colocado sobre ele"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Ocultar automaticamente o ponteiro ao digitar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Fechar terminal com clique do meio no título"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Aumentar ou diminuir zoom usando <Control> e rolagem do mouse"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Fechar janela ao encerrar a última sessão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Enviar notificação para a área de trabalho quando o processo terminar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Ao iniciar nova instância"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nova janela"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nova sessão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Dividir à direita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Dividir abaixo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Ativar janela existente"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Sempre usar o diálogo de colagem avançada"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Alertar ao tentar colar comando inseguro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Retira o primeiro caractere da colagem se comentário ou declaração de "
+"variável"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Copiar texto automaticamente ao selecionar"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr "Adicionar favorito"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr "Editar favorito"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr "Excluir favorito"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr "Desfazer seleção de favorito"
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Título"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Não exibir esta mensagem novamente"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Janela (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sessão (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Fechar aplicação"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Fechar janela"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Fechar sessão"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Este comando requer acesso de administrador ao seu computador"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiar comandos da Internet pode ser perigoso. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Assegure-se de que entende o que cada parte desse comando faz."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformar"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Converter espaços em tabulações"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Converter CRLF e CR em LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Colagem avançada"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Colar"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Nome"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Novo"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Incluir quebra de linha com senha"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Inserir Senha"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Senha"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Confirmar senha"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Adicionar senha"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Editar senha"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Opções de pesquisa"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Localizar a próxima ocorrência"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Localizar a ocorrência anterior"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Diferenciar maiúsculas/minúsculas"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Coincidir somente palavra inteira"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Coincidir como expressão regular"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Voltar ao início"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Fechar"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximizar"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Desabilitar sincronização de entrada neste terminal"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Somente leitura"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr "Editar codificações"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Habilitar sincronização de entrada neste terminal"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"A biblioteca %s não pôde ser carregada, a funcionalidade de senha ficará "
+"indisponível."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Biblioteca não carregada"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Localizar…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Senha"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Adicionar favorito…"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Adicionar favorito…"
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Salvar saída…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Redefinir e limpar"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Opções de layout…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Outro"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Adicionar terminal à direita"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Adicionar terminal abaixo"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Restaurar"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Abrir link"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Copiar endereço do link"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Copiar"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Selecionar tudo"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr "Expressão regular de link personalizado '%s' tem um erro, ignorando"
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Ocorreu um erro inesperado: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Salvar saída do terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Todos os arquivos de texto"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "O processo filho encerrou normalmente com o estado %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "O processo filho foi abortado pelo sinal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "O processo filho foi abortado."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Recarregar"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Não colar"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Colar mesmo assim"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Opções de layout"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Ativo"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Ao carregar sessão"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Ativo: mudanças nessas opções são aplicadas imediatamente.\n"
+"Ao carregar sessão: mudanças nessas opções são aplicadas ao carregar um "
+"arquivo de sessão."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Visualizar barra lateral de sessões"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Criar uma nova sessão"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Adicionar terminal à direita"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Adicionar terminal abaixo"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Localizar texto no terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Renomear sessão"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Digite um novo nome para a sessão"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Abrir…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Salvar como…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nome…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Múltiplas sessões estão em uso. Fechar mesmo assim?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "O arquivo '%s' não existe"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Carregar sessão"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Abrir"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Erro ao carregar sessão"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Salvar sessão"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Sobre"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Sair"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Daniel Miranda\n"
+"Davi da Silva Böger\n"
+"Fábio Nogueira"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Créditos"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Definir o diretório de trabalho para o terminal"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIRETÓRIO"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Definir o perfil inicial"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NOME_DO_PERFIL"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Definir título do novo terminal"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TÍTULO"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Abrir a sessão especificada"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NOME_DA_SESSÃO"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Enviar uma ação para a instância atual do Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NOME_DA_AÇÃO"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Executar o parâmetro como comando"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "COMANDO"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximizar a janela do terminal"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Minimizar a janela do terminal"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Alternar a janela do terminal para tela cheia"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Ativar a janela existente"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Iniciar instância adicional em novo processo (não recomendado)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Definir o tamanho da janela; por exemplo: 80x24 ou 80x24+200+200 "
+"(COLUNASxLINHAS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIA"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Abre nova janela, ou alterna visibilidade de janela existente (modo Quake)"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Mostrar versão do Terminix e de componentes dependentes"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Mostrar o diálogo de preferências do Terminix diretamente"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argumento oculto para fornecer o UUID do terminal"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_DO_TERMINAL"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Parece haver um problema com a configuração do terminal.\n"
+"O problema não é grave, mas corrigi-lo irá melhorar a sua experiência.\n"
+"Clique no link a seguir para mais informações:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Problema de configuração detectado"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Não exibir esta mensagem novamente"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "A paleta do esquema de cores requer 16 cores"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Não foi possível localizar o terminal soltado"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Não foi possível localizar a sessão do terminal soltado"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -211,75 +1585,41 @@ msgstr "GtkD por fornecer uma excelente biblioteca de integração com GTK"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org pela excelente linguagem de programação D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Título"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr "Título do ícone"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Diretório"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Hostname"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr "Colunas"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Linhas"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Nome da aplicação"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Nome da sessão"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
 msgstr "Número da sessão"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Não foi possível localizar o terminal soltado"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Não foi possível localizar a sessão do terminal soltado"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Padrão"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Perfil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nova sessão"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -419,1414 +1759,6 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandês"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Opções de layout"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Ativo"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Distintivo"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Ao carregar sessão"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Ativo: mudanças nessas opções são aplicadas imediatamente.\n"
-"Ao carregar sessão: mudanças nessas opções são aplicadas ao carregar um "
-"arquivo de sessão."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Fechar"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximizar"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Desabilitar sincronização de entrada neste terminal"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Somente leitura"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Sinal de atenção"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr "Editar codificações"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Habilitar sincronização de entrada neste terminal"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"A biblioteca %s não pôde ser carregada, a funcionalidade de senha ficará "
-"indisponível."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Biblioteca não carregada"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Salvar saída…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Redefinir"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Redefinir e limpar"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Perfis"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Codificação"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Adicionar favorito…"
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Selecionar favorito…"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Favoritos"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Localizar…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Opções de layout…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Adicionar terminal à direita"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Restaurar"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Abrir link"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Copiar endereço do link"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Copiar"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Colar"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Selecionar tudo"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Área de transferência"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr "Expressão regular de link personalizado '%s' tem um erro, ignorando"
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Ocorreu um erro inesperado: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Salvar saída do terminal"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Salvar"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Todos os arquivos de texto"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Todos os arquivos"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "O processo filho encerrou normalmente com o estado %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "O processo filho foi abortado pelo sinal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "O processo filho foi abortado."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Recarregar"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Não colar"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Colar mesmo assim"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Opções de pesquisa"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Localizar a próxima ocorrência"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Localizar a ocorrência anterior"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Diferenciar maiúsculas/minúsculas"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Coincidir somente palavra inteira"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Coincidir como expressão regular"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Voltar ao início"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Este comando requer acesso de administrador ao seu computador"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiar comandos da Internet pode ser perigoso. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Assegure-se de que entende o que cada parte desse comando faz."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformar"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Converter espaços em tabulações"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Converter CRLF e CR em LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Colagem avançada"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Novo"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Editar"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Excluir"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Incluir quebra de linha com senha"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Inserir Senha"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Aplicar"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Senha"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Confirmar senha"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Adicionar senha"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Editar senha"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Janela (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sessão (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Fechar aplicação"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Fechar janela"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Fechar sessão"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nova janela"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferências"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Atalhos do teclado"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Sobre"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Sair"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Créditos"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Definir o diretório de trabalho para o terminal"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIRETÓRIO"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Definir o perfil inicial"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NOME_DO_PERFIL"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Definir título do novo terminal"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TÍTULO"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Abrir a sessão especificada"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NOME_DA_SESSÃO"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Enviar uma ação para a instância atual do Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NOME_DA_AÇÃO"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Executar o parâmetro como comando"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "COMANDO"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximizar a janela do terminal"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Minimizar a janela do terminal"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Alternar a janela do terminal para tela cheia"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Ativar a janela existente"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Iniciar instância adicional em novo processo (não recomendado)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Definir o tamanho da janela; por exemplo: 80x24 ou 80x24+200+200 "
-"(COLUNASxLINHAS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIA"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Abre nova janela, ou alterna visibilidade de janela existente (modo Quake)"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Mostrar versão do Terminix e de componentes dependentes"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Mostrar o diálogo de preferências do Terminix diretamente"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argumento oculto para fornecer o UUID do terminal"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_DO_TERMINAL"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Parece haver um problema com a configuração do terminal.\n"
-"O problema não é grave, mas corrigi-lo irá melhorar a sua experiência.\n"
-"Clique no link a seguir para mais informações:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Problema de configuração detectado"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Visualizar barra lateral de sessões"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Criar uma nova sessão"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Adicionar terminal à direita"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Localizar texto no terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Renomear sessão"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Digite um novo nome para a sessão"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Abrir…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Salvar como…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nome…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Múltiplas sessões estão em uso. Fechar mesmo assim?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Todos os arquivos JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "O arquivo '%s' não existe"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Carregar sessão"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Abrir"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Erro ao carregar sessão"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Salvar sessão"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "A paleta do esquema de cores requer 16 cores"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr "Adicionar favorito"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr "Editar favorito"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr "Excluir favorito"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr "Desfazer seleção de favorito"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Preferências do Terminix"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Global"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Aparência"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Modo Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Novo perfil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Excluir perfil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Perfil: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Clonar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Aplicar em novos terminais"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Codificações exibidas no menu:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Habilitado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Ação"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Tecla de atalho"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Habilitar atalhos do teclado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Sobrescrever atalho existente"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"O atalho %s já está atribuído para %s.\n"
-"Desabilitar a ação existente e substituí-la pela nova?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Habilitar transparência, requer re-início"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr "Estilo de janela"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr "Desabilitar CSD"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr "Desabilitar CSD, ocultar barra de ferramentas"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr "Sem bordas"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr "Necessário reiniciar janela"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Estilo do título do terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Pequeno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Nenhum"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Variante do tema"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Claro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Escuro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Imagem de fundo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Selecionar imagem"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Todos os arquivos de imagem"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Reinicializar imagem de fundo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Preencher"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Lado a lado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Estender"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nome da sessão padrão"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Título da aplicação"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Utilizar uma borda larga para os divisores"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Mostrar barra lateral na direita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Mostrar o título do terminal mesmo que seja o único"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Tamanho"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Proporção de altura"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Proporção de largura"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Alinhamento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Esquerda"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Direita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Opções"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Mostrar o terminal em todos os espaços de trabalho"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Definir dica para o gerenciador de janelas desativar a animação"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Esconder janela ao retirar foco"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Ocultar a barra de título da janela"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Exibir terminal apenas no monitor ativo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Exibir terminal no monitor"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Comportamento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Alertar ao criar uma nova sessão"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Ativar terminal quando o cursor é colocado sobre ele"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Ocultar automaticamente o ponteiro ao digitar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Fechar terminal com clique do meio no título"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Aumentar ou diminuir zoom usando <Control> e rolagem do mouse"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Fechar janela ao encerrar a última sessão"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Enviar notificação para a área de trabalho quando o processo terminar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Ao iniciar nova instância"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Dividir à direita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Dividir abaixo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Ativar janela existente"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Sempre usar o diálogo de colagem avançada"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Alertar ao tentar colar comando inseguro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Retira o primeiro caractere da colagem se comentário ou declaração de "
-"variável"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Copiar texto automaticamente ao selecionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Geral"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Cor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Rolagem"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibilidade"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Avançado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nome do perfil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Tamanho do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "colunas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "linhas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Bloco"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Barra vertical"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Sublinhado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Piscar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Configuração do sistema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Ligado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Desligado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Som"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Ícone e Som"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Título do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Posição do distintivo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Noroeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Nordeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Sudoeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Sudeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Aparência do texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Permitir negrito"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Reajustar ao redimensionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Fonte personalizada"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Escolher fonte do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Esquema de cores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Personalizado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exportar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Paleta de cores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Utilizar cores de sistema para texto/fundo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparência"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Escurecer quando fora de foco"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Fundo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Selecionar cor principal do cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Selecionar cor de fundo do cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Seleção"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Selecionar cor de texto selecionado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Selecionar cor de fundo selecionado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Escurecimento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Selecionar cor de escurecimento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Selecionar cor do distintivo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Selecionar cor de fundo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Selecionar cor do texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Preto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Vermelho"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Verde"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Laranja"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Azul"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Roxo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turquesa"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Cinza"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Selecionar cor %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Selecionar cor %s clara"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Exportar esquema de cores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Mostrar barra de rolagem"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Rolar na saída"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Rolar ao digitar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Limite de rolagem:"
-
-# Terminix gettext pot file
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Tecla Backspace gera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automático"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Sequência de escape"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Tecla Delete gera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Caracteres de largura ambígua"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Estreitar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Alargar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Executar comando como um shell de login"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Executar um comando personalizado ao invés do meu shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Após termino do comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Sair do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Reiniciar o comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Manter o terminal aberto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Links personalizados"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Uma lista de links definidos pelo usuário que podem ser clicados no terminal "
-"com base em definições de expressões regulares."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Acionadores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Acionadores são expressões regulares comparadas com o texto de saída do "
-"terminal. Quando correspondências são detectadas, a ação configurada é "
-"executada."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Seleção automática de perfil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>usuário@nome-do-host:diretório</i>. O nome de "
-"host ou diretório podem ser omitidos, mas não ambos, e o caractere dois "
-"pontos precisa ser mantido."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>nome da máquina:diretório</i>. O nome da máquina "
-"ou diretório podem ser omitidos, mas não ambos, as entradas sem nome da "
-"máquina ou diretório não são permitidas."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Correspondências"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Adicionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Digite um padrão no formato usuário@nome-do-host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Digite um padrão de nome do host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Adicionar novo padrão de correspondência"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Editar padrão no formato usuário@nome-do-host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Editar padrão de nome do host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Editar padrão de correspondência"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Expressão regular"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Não diferenciar maiúsculas e minúsculas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Editar links personalizados"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parâmetro"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Limitar número de linhas processadas para detectar acionadores a:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Editar acionadores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr "Linha %d: "
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr "Janela"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr "Ajuda"
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1861,42 +1793,128 @@ msgstr ""
 "Você não pode usar os parâmetros maximizar, tela cheia ou geometria no modo "
 "Quake"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "AtualizarEstado"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr "Erro ao carregar favorito"
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "ExecutarComando"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr "Raiz"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "EnviarNotificação"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Não foi possível carregar favoritos devido a um erro inesperado"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "AtualizarTítulo"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Pasta"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "SinalizarAtenção"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr "Caminho"
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "EnviarTexto"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Remoto"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "InserirSenha"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Selecionar pasta"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "AtualizarDistintivo"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Selecionar pasta"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Limpar pasta"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Adicionar favorito"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Editar favorito"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Selecionar caminho"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Host"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Usuário"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Parâmetros"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Selecionar favorito"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "desabilitado"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Cópia)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"Sua versão do GTK é muito antiga, você precisa pelo menos do GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Ocorreu uma exceção inesperada"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Erro: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Versões"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Versão do Terminix: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Versão do VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Versão do GTK: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Funcionalidades especiais do Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Notificações habilitadas=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Acionadores habilitados=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Distintivos habilitados=%b"
 
 # ******************
 # Nautilus extension
@@ -2454,6 +2472,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "O Terminix foi testado nos ambientes GNOME e Unity."
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Selecionar favorito…"
 
 #~ msgid "The expression %s is not a valid regex"
 #~ msgstr "A expressão %s não é uma expressão regular válida"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-01-23 15:11+0000\n"
 "Last-Translator: Daniel Pinto <danielpinto8zz6@gmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
@@ -17,180 +17,1548 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.11-dev\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "AtualizarEstado"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "ExecutarComando"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "EnviarNotificação"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "AtualizarTítulo"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "SinalizarAtenção"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "EnviarTexto"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "InserirSenha"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "AtualizarDistintivo"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr ""
-"A sua versão do GTK é muito antiga, você precisa pelo menos do GTK %d.%d.%d!"
+msgid "%s (Copy)"
+msgstr "%s (Cópia)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Ocorreu uma exceção inesperada"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Geral"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Erro: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Versões"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Versão do Terminix: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Versão do VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Versão do GTK: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Funcionalidades especiais do Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Notificações ativadas=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Ativadores ativados=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Distintivos ativados=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "desativado"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Selecionar cor %s"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Selecionar cor %s"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Nome"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Selecionar tudo"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Comando"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Cor"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Rolagem"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Compatibilidade"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Parâmetro"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Avançado"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Selecionar cor do distintivo"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Nome do perfil"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Tamanho do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "colunas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "linhas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Redefinir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Bloco"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "Barra vertical"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Sublinhado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Piscar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Configuração do sistema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Ligado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Desligado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Sinal de atenção"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Nenhum"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Som"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Ícone"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Ícone e Som"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Título do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Distintivo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Posição do distintivo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Noroeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Nordeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Sudoeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Sudeste"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Aparência do texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Permitir negrito"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Reajustar ao redimensionar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Fonte personalizada"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Escolher fonte do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Esquema de cores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Personalizado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Exportar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Paleta de cores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Opções"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Utilizar cores de sistema para texto/fundo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparência"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Escurecer quando fora de foco"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Fundo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Selecionar cor principal do cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Selecionar cor de fundo do cursor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Seleção"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Selecionar cor de texto selecionado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Selecionar cor de fundo selecionado"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Escurecimento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Selecionar cor de escurecimento"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Selecionar cor do distintivo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Selecionar cor de fundo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Selecionar cor do texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Texto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Preto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Vermelho"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Verde"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Laranja"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Azul"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Roxo"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turquesa"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Cinza"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Selecionar cor %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Selecionar cor %s clara"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Exportar esquema de cores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Salvar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Todos os arquivos JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Todos os arquivos"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Mostrar barra de rolagem"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Rolar na saída"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Rolar ao digitar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Limite de rolagem:"
+
+# Terminix gettext pot file
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Tecla Backspace gera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automático"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Sequência de escape"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Tecla Delete gera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Codificação"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Caracteres de largura ambígua"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Estreitar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Alargar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Executar comando como um shell de login"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Executar um comando personalizado ao invés do meu shell"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Após termino do comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Sair do terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Reiniciar o comando"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Manter o terminal aberto"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Links personalizados"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Uma lista de links definidos pelo usuário que podem ser clicados no terminal "
+"com base em definições de expressões regulares."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Editar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Acionadores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Acionadores são expressões regulares comparadas com o texto de saída do "
+"terminal. Quando correspondências são detectadas, a ação configurada é "
+"executada."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Seleção automática de perfil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
+"Entradas usam o formato <i>usuário@nome-do-host:diretório</i>. O nome de "
+"host ou diretório podem ser omitidos, mas não ambos, e o caractere dois "
+"pontos precisa ser mantido."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
+"Entradas usam o formato <i>nome da máquina:diretório</i>. O nome da máquina "
+"ou diretório podem ser omitidos, mas não ambos, as entradas sem nome da "
+"máquina ou diretório não são permitidas."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Correspondências"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Adicionar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Digite um padrão no formato usuário@nome-do-host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Digite um padrão de nome do host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Adicionar novo padrão de correspondência"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Editar padrão no formato usuário@nome-do-host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Editar padrão de nome do host:diretório"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Editar padrão de correspondência"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Apagar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Expressão regular"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Não diferenciar maiúsculas e minúsculas"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Editar links personalizados"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Aplicar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Ação"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parâmetro"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Limitar número de linhas processadas para detectar acionadores a:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Editar acionadores"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/titleeditor.d:108
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Window"
+msgstr "Janela"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Preferências do Terminix"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Global"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Aparência"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Modo Quake"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Atalhos do teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Novo perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Apagar perfil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Preferências"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Perfis"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Perfil: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Clonar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Aplicar em novos terminais"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Codificações exibidas no menu:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Ativado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Tecla de atalho"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Ativar atalhos do teclado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Sobrescrever atalho existente"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"O atalho %s já está atribuído para %s.\n"
+"Desativar a ação existente e substituí-la pela nova?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Ativar transparência, requer re-início"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Janela (%s)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "desativado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Estilo do título do terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Pequeno"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Variante do tema"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Padrão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Claro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Escuro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Imagem de fundo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Selecionar imagem"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Todos os arquivos de imagem"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Reiniciar imagem de fundo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Preencher"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Lado a lado"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Estender"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Nome da sessão padrão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Título da aplicação"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Utilizar uma borda larga para os divisores"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Mostrar barra lateral na direita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Mostrar o título do terminal mesmo que seja o único"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Tamanho"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Proporção de altura"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Proporção de largura"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Alinhamento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Esquerda"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Direita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Mostrar o terminal em todos os espaços de trabalho"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Definir dica para o gerenciador de janelas desativar a animação"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Esconder janela ao retirar foco"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Ocultar a barra de título da janela"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Mostrar o terminal apenas no monitor ativo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Mostrar o terminal no monitor"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Comportamento"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Alertar ao criar uma nova sessão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Ativar terminal quando o cursor é colocado sobre ele"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Ocultar automaticamente o ponteiro ao digitar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Fechar terminal com clique do meio no título"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Aumentar ou diminuir zoom usando <Control> e rolagem do mouse"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Fechar janela ao encerrar a última sessão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Enviar notificação para a área de trabalho quando o processo terminar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Ao iniciar nova instância"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nova janela"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Nova sessão"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Dividir à direita"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Dividir abaixo"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Ativar janela existente"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Sempre usar o diálogo de colagem avançada"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Alertar ao tentar colar comando inseguro"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Retira o primeiro caractere da colagem se comentário ou declaração de "
+"variável"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Copiar texto automaticamente ao selecionar"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Título"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Não exibir esta mensagem novamente"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Janela (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Sessão (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Fechar aplicação"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Fechar janela"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Fechar sessão"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Este comando requer acesso de administrador ao seu computador"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Copiar comandos da Internet pode ser perigoso. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Assegure-se de que entende o que cada parte desse comando faz."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Transformar"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Converter espaços em tabulações"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Converter CRLF e CR em LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Colagem avançada"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Colar"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Nome"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Novo"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Incluir quebra de linha com senha"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Inserir Senha"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Senha"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Confirmar senha"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Adicionar senha"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Editar senha"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Opções de pesquisa"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Localizar a próxima ocorrência"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Localizar a ocorrência anterior"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Diferenciar maiúsculas/minúsculas"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Coincidir somente palavra inteira"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Coincidir como expressão regular"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Voltar ao início"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Fechar"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximizar"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Desabilitar sincronização de entrada neste terminal"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Somente leitura"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Editar perfil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Codificação"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Habilitar sincronização de entrada neste terminal"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"A biblioteca %s não pôde ser carregada, a funcionalidade de senha ficará "
+"indisponível."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Biblioteca não carregada"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Localizar…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Senha"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Selecionar cor do distintivo"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Salvar saída…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Redefinir e limpar"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Opções de layout…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Outro"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Adicionar terminal à direita"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Adicionar terminal abaixo"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Restaurar"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Abrir link"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Copiar endereço do link"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Copiar"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Selecionar tudo"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Ocorreu um erro inesperado: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Salvar saída do terminal"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Todos os arquivos de texto"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "O processo filho encerrou normalmente com o estado %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "O processo filho foi abortado pelo sinal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "O processo filho foi abortado."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Recarregar"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Não colar"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Colar mesmo assim"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Opções de layout"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Ativo"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Ao carregar sessão"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Ativo: mudanças nessas opções são aplicadas imediatamente.\n"
+"Ao carregar sessão: mudanças nessas opções são aplicadas ao carregar um "
+"arquivo de sessão."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Visualizar barra lateral de sessões"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Criar uma nova sessão"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Adicionar terminal à direita"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Adicionar terminal abaixo"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Localizar texto no terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Renomear sessão"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Digite um novo nome para a sessão"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Abrir…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Salvar como…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Nome…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Sincronizar entrada"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Múltiplas sessões estão em uso. Fechar mesmo assim?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "O arquivo '%s' não existe"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Carregar sessão"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Abrir"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr ""
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Erro ao carregar sessão"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Salvar sessão"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Sobre"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Sair"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Daniel Pinto"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Créditos"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Definir o diretório de trabalho para o terminal"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIRETÓRIO"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Definir o perfil inicial"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "NOME_DO_PERFIL"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Definir título do novo terminal"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TÍTULO"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Abrir a sessão especificada"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "NOME_DA_SESSÃO"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Enviar uma ação para a instância atual do Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "NOME_DA_AÇÃO"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Executar o parâmetro como comando"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "COMANDO"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximizar a janela do terminal"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Minimizar a janela do terminal"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Alternar a janela do terminal para tela cheia"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Ativar a janela existente"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Iniciar instância adicional em novo processo (não recomendado)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
+"Definir o tamanho da janela; por exemplo: 80x24 ou 80x24+200+200 "
+"(COLUNASxLINHAS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRIA"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Abre nova janela, ou alterna visibilidade de janela existente (modo Quake)"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Mostrar versão do Terminix e de componentes dependentes"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Mostrar o diálogo de preferências do Terminix diretamente"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Argumento oculto para fornecer o UUID do terminal"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID_DO_TERMINAL"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Parece haver um problema com a configuração do terminal.\n"
+"O problema não é grave, mas corrigi-lo irá melhorar a sua experiência.\n"
+"Clique no link a seguir para mais informações:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Problema de configuração detectado"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Não exibir esta mensagem novamente"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "A paleta do esquema de cores requer 16 cores"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Não foi possível localizar o terminal soltado"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Não foi possível localizar a sessão do terminal soltado"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -220,80 +1588,46 @@ msgstr "GtkD por fornecer uma excelente biblioteca de integração com GTK"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org pela excelente linguagem de programação D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Título"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Título da aplicação"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "colunas"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Aplicação"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Ao carregar sessão"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Sessão"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Não foi possível localizar o terminal soltado"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Não foi possível localizar a sessão do terminal soltado"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Padrão"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Perfil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Nova sessão"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -432,1418 +1766,6 @@ msgstr "Vietnamita"
 msgid "Thai"
 msgstr "Tailandês"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Opções de layout"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Ativo"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Distintivo"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Ao carregar sessão"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Ativo: mudanças nessas opções são aplicadas imediatamente.\n"
-"Ao carregar sessão: mudanças nessas opções são aplicadas ao carregar um "
-"arquivo de sessão."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Fechar"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximizar"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Desabilitar sincronização de entrada neste terminal"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Somente leitura"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Sinal de atenção"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Editar perfil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Codificação"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Habilitar sincronização de entrada neste terminal"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"A biblioteca %s não pôde ser carregada, a funcionalidade de senha ficará "
-"indisponível."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Biblioteca não carregada"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Salvar saída…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Redefinir"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Redefinir e limpar"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Perfis"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Codificação"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Selecionar cor do distintivo"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Localizar…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Opções de layout…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Adicionar terminal à direita"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Restaurar"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Abrir link"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Copiar endereço do link"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Copiar"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Colar"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Selecionar tudo"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Área de transferência"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Ocorreu um erro inesperado, nenhuma informação adicional disponível"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Ocorreu um erro inesperado: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Salvar saída do terminal"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Salvar"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Todos os arquivos de texto"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Todos os arquivos"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "O processo filho encerrou normalmente com o estado %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "O processo filho foi abortado pelo sinal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "O processo filho foi abortado."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Recarregar"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Não colar"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Colar mesmo assim"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Opções de pesquisa"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Localizar a próxima ocorrência"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Localizar a ocorrência anterior"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Diferenciar maiúsculas/minúsculas"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Coincidir somente palavra inteira"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Coincidir como expressão regular"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Voltar ao início"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Este comando requer acesso de administrador ao seu computador"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Copiar comandos da Internet pode ser perigoso. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Assegure-se de que entende o que cada parte desse comando faz."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Transformar"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Converter espaços em tabulações"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Converter CRLF e CR em LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Colagem avançada"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Novo"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Editar"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Apagar"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Incluir quebra de linha com senha"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Inserir Senha"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Aplicar"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Senha"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Confirmar senha"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Adicionar senha"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Editar senha"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Janela (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Sessão (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Fechar aplicação"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Fechar janela"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Fechar sessão"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nova janela"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Preferências"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Atalhos do teclado"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Sobre"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Sair"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Créditos"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Definir o diretório de trabalho para o terminal"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIRETÓRIO"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Definir o perfil inicial"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "NOME_DO_PERFIL"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Definir título do novo terminal"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TÍTULO"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Abrir a sessão especificada"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "NOME_DA_SESSÃO"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Enviar uma ação para a instância atual do Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "NOME_DA_AÇÃO"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Executar o parâmetro como comando"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "COMANDO"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximizar a janela do terminal"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Minimizar a janela do terminal"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Alternar a janela do terminal para tela cheia"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Ativar a janela existente"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Iniciar instância adicional em novo processo (não recomendado)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Definir o tamanho da janela; por exemplo: 80x24 ou 80x24+200+200 "
-"(COLUNASxLINHAS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRIA"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Abre nova janela, ou alterna visibilidade de janela existente (modo Quake)"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Mostrar versão do Terminix e de componentes dependentes"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Mostrar o diálogo de preferências do Terminix diretamente"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Argumento oculto para fornecer o UUID do terminal"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID_DO_TERMINAL"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Parece haver um problema com a configuração do terminal.\n"
-"O problema não é grave, mas corrigi-lo irá melhorar a sua experiência.\n"
-"Clique no link a seguir para mais informações:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Problema de configuração detectado"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Não exibir esta mensagem novamente"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Visualizar barra lateral de sessões"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Criar uma nova sessão"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Adicionar terminal à direita"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Adicionar terminal abaixo"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Localizar texto no terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Renomear sessão"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Digite um novo nome para a sessão"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Abrir…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Salvar como…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Nome…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Sincronizar entrada"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Múltiplas sessões estão em uso. Fechar mesmo assim?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Todos os arquivos JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "O arquivo '%s' não existe"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Carregar sessão"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Abrir"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Erro ao carregar sessão"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Salvar sessão"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "O arquivo %s não é um arquivo JSON compatível com o esquema de cores"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "A paleta do esquema de cores requer 16 cores"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Preferências do Terminix"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Global"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Aparência"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Modo Quake"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Novo perfil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Apagar perfil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Perfil: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Clonar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Aplicar em novos terminais"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Codificações exibidas no menu:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Ativado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Ação"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Tecla de atalho"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Ativar atalhos do teclado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Sobrescrever atalho existente"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"O atalho %s já está atribuído para %s.\n"
-"Desativar a ação existente e substituí-la pela nova?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Ativar transparência, requer re-início"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Janela (%s)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "desativado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Estilo do título do terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Pequeno"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Nenhum"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Variante do tema"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Claro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Escuro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Imagem de fundo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Selecionar imagem"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Todos os arquivos de imagem"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Reiniciar imagem de fundo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Preencher"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Lado a lado"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Estender"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Nome da sessão padrão"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Título da aplicação"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Utilizar uma borda larga para os divisores"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Mostrar barra lateral na direita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Mostrar o título do terminal mesmo que seja o único"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Tamanho"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Proporção de altura"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Proporção de largura"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Alinhamento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Esquerda"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Direita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Opções"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Mostrar o terminal em todos os espaços de trabalho"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Definir dica para o gerenciador de janelas desativar a animação"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Esconder janela ao retirar foco"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Ocultar a barra de título da janela"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Mostrar o terminal apenas no monitor ativo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Mostrar o terminal no monitor"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Comportamento"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Alertar ao criar uma nova sessão"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Ativar terminal quando o cursor é colocado sobre ele"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Ocultar automaticamente o ponteiro ao digitar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Fechar terminal com clique do meio no título"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Aumentar ou diminuir zoom usando <Control> e rolagem do mouse"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Fechar janela ao encerrar a última sessão"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Enviar notificação para a área de trabalho quando o processo terminar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Ao iniciar nova instância"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Dividir à direita"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Dividir abaixo"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Ativar janela existente"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Sempre usar o diálogo de colagem avançada"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Alertar ao tentar colar comando inseguro"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Retira o primeiro caractere da colagem se comentário ou declaração de "
-"variável"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Copiar texto automaticamente ao selecionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Geral"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Cor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Rolagem"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Compatibilidade"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Avançado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Nome do perfil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Tamanho do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "colunas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "linhas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Bloco"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "Barra vertical"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Sublinhado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Piscar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Configuração do sistema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Ligado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Desligado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Som"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Ícone e Som"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Título do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Posição do distintivo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Noroeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Nordeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Sudoeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Sudeste"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Aparência do texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Permitir negrito"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Reajustar ao redimensionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Fonte personalizada"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Escolher fonte do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Esquema de cores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Personalizado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Exportar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Paleta de cores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Utilizar cores de sistema para texto/fundo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparência"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Escurecer quando fora de foco"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Fundo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Selecionar cor principal do cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Selecionar cor de fundo do cursor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Seleção"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Selecionar cor de texto selecionado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Selecionar cor de fundo selecionado"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Escurecimento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Selecionar cor de escurecimento"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Selecionar cor do distintivo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Selecionar cor de fundo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Selecionar cor do texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Texto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Preto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Vermelho"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Verde"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Laranja"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Azul"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Roxo"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turquesa"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Cinza"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Selecionar cor %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Selecionar cor %s clara"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Exportar esquema de cores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Mostrar barra de rolagem"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Rolar na saída"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Rolar ao digitar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Limite de rolagem:"
-
-# Terminix gettext pot file
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Tecla Backspace gera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automático"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Sequência de escape"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Tecla Delete gera"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Caracteres de largura ambígua"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Estreitar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Alargar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Executar comando como um shell de login"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Executar um comando personalizado ao invés do meu shell"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Após termino do comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Sair do terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Reiniciar o comando"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Manter o terminal aberto"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Links personalizados"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Uma lista de links definidos pelo usuário que podem ser clicados no terminal "
-"com base em definições de expressões regulares."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Acionadores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Acionadores são expressões regulares comparadas com o texto de saída do "
-"terminal. Quando correspondências são detectadas, a ação configurada é "
-"executada."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Seleção automática de perfil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>usuário@nome-do-host:diretório</i>. O nome de "
-"host ou diretório podem ser omitidos, mas não ambos, e o caractere dois "
-"pontos precisa ser mantido."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Perfis são selecionados automaticamente com base nas entradas criadas aqui.\n"
-"Entradas usam o formato <i>nome da máquina:diretório</i>. O nome da máquina "
-"ou diretório podem ser omitidos, mas não ambos, as entradas sem nome da "
-"máquina ou diretório não são permitidas."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Correspondências"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Adicionar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Digite um padrão no formato usuário@nome-do-host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Digite um padrão de nome do host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Adicionar novo padrão de correspondência"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Editar padrão no formato usuário@nome-do-host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Editar padrão de nome do host:diretório"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Editar padrão de correspondência"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Expressão regular"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Não diferenciar maiúsculas e minúsculas"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Editar links personalizados"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parâmetro"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Limitar número de linhas processadas para detectar acionadores a:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Editar acionadores"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Janela"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1879,42 +1801,134 @@ msgstr ""
 "Você não pode usar o modo Quake com os parâmetros maximizar, tela cheia ou "
 "geometria"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "AtualizarEstado"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "ExecutarComando"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "EnviarNotificação"
+#: source/gx/terminix/bookmark/manager.d:586
+#, fuzzy
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Não foi possível carregar a sessão devido a um erro inesperado."
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "AtualizarTítulo"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "SinalizarAtenção"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "EnviarTexto"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "InserirSenha"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "Selecionar cor %s"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "AtualizarDistintivo"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Selecionar cor %s"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Selecionar tudo"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "Parâmetro"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Selecionar cor do distintivo"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "desativado"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Cópia)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+"A sua versão do GTK é muito antiga, você precisa pelo menos do GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Ocorreu uma exceção inesperada"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Erro: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Versões"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Versão do Terminix: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Versão do VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Versão do GTK: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Funcionalidades especiais do Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Notificações ativadas=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Ativadores ativados=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Distintivos ativados=%b"
 
 # ******************
 # Nautilus extension

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,186 +8,1560 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-02-06 12:47+0000\n"
 "Last-Translator: Igor <f2404@yandex.ru>\n"
-"Language-Team: Russian "
-"<https://hosted.weblate.org/projects/terminix/translations/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/terminix/"
+"translations/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.11\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "Обновить состояние"
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "Выполнить команду"
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr "Отправить уведомление"
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "Обновить заголовок"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "Проиграть звук"
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "Отправить текст"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "Вставить пароль"
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "Обновить значок"
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "Ваша версия GTK устарела, вам нужна как минимум GTK %d.%d.%d!"
+msgid "%s (Copy)"
+msgstr "%s (Скопировать)"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Произошло неожиданное исключение"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Общие"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Ошибка: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Версии"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Версия Terminix: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "Версия VTE: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "Версия GTK: %d.%d.%d"
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr "Особые возможности Terminix"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Нотификации включены=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Триггеры включены=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr "Значки включены=%b"
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "выключен"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr "Выбрать папку"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr "Выбрать папку"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr "Очистить папку"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr "Добавить закладку"
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr "Редактировать закладку"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Хорошо"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Отменить"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Имя"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr "Путь"
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr "Выбрать путь"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Команда"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr "Протокол"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Цвета"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr "Хост"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Прокрутка"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr "Пользователь"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Совместимость"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr "Параметры"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Расширенные"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
-msgstr "Выбрать закладку"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Имя профиля"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Размер терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "столбцов"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "строк"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Сброс"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Курсор"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Блок"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "I-образный"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Подчёркивание"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Режим мерцания"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Система"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Вкл"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Выкл"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Подавать гудок"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Отсутствует"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Звук"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Значок"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
-msgstr "Ошибка десериализации закладки"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Значок и звук"
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr "Корень"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Заголовок терминала"
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
-msgstr "Не удалось загрузить закладки из-за неожиданной ошибки"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Знак"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
-msgstr "Папка"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Позиция знака"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
-msgstr "Удалённый"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Северо-запад"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Северо-восток"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Юго-запад"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Юго-восток"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Оформление текста"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Разрешить полужирный текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Переносить при изменении размера"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Пользовательский шрифт"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Выбрать шрифт терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "Идентификатор: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Цветовая схема"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Пользовательская"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Экспорт"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Цветовая палитра"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Настройки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Использовать цвета темы для основного и фонового цветов"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Прозрачность"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Фокусировка неактивного состояния"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Фон"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Выбрать основной цвет курсора терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Выбрать цвет фона курсора терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Подсветка"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Выбрать основной цвет подсветки терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Выбрать цвет фона подсветки терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Неактивное состояние"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Выбрать цвет неактивного состояния терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Выбрать цвет значка"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Выбрать цвет фона"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Выбрать основной цвет"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Передний план"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Чёрный"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Красный"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Зелёный"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Оранжевый"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Синий"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Фиолетовый"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Бирюзовый"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Серый"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Выбрать %s цвет"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Выбрать светло-%s цвет"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Экспорт цветовой схемы"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Сохранить"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Отменить"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Все JSON файлы"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Все файлы"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Показать полосу прокрутки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Прокручивать при выводе"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Прокручивать при нажатии клавиши"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Ограничить прокрутку:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Клавиша «Backspace» генерирует"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Автоматически"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Управляющая последовательность"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Клавиша «Delete» генерирует"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Кодировка"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Символы неоднозначной ширины"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Узкие"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Широкие"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Запускать команду как оболочку входа"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Запускать другую команду вместо моей оболочки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "При завершении команды"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Выйти из терминала"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Перезапустить команду"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Держать терминал открытым"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Пользовательские ссылки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"Список определённых пользователем ссылок на основе регулярных выражений, "
+"которые можно нажать в терминале."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Изменить"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Триггеры"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Триггеры - это регулярные выражения, с которыми сравнивается текст в "
+"терминале. Как только найдётся совпадение, будет выполнено настроенное "
+"действие."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Автоматическое переключение профиля"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Профили автоматически выбираются на основании значений, введённых здесь.\n"
+"Значения вводятся в формате <i>hostname:directory</i>. Либо имя хоста, либо "
+"каталог могут быть пропущены, но знак двоеточия должен присутствовать. "
+"Записи без имени хоста и каталога не допускаются."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Профили автоматически выбираются на основании значений, введённых здесь.\n"
+"Значения вводятся в формате <i>hostname:directory</i>. Либо имя хоста, либо "
+"каталог могут быть пропущены, но знак двоеточия должен присутствовать. "
+"Записи без имени хоста и каталога не допускаются."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Совпадения"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Добавить"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Введите пользователь@хост:каталог для совпадения"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Введите хост:каталог для совпадения"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Добавить новое совпадение"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Редактировать пользователь@хост:каталог для совпадения"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Редактировать хост:каталог для совпадения"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Редактировать совпадение"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Удалить"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Регулярное выражение"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Без учета регистра"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Редактировать пользовательские ссылки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Применить"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Действие"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Параметр"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Ограничить количество строк для обработки запуска до:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Редактировать триггеры"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr "Строка %d: "
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Терминал"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr "Окно"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr "Помощь"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Параметры Terminix"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Основные"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Оформление"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Выпадающий режим"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr "Закладки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Комбинации клавиш"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Профиль"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Добавить профиль"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Удалить профиль"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Параметры"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Профили"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Профиль: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Клонировать"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Использовать для новых терминалов"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Кодировки, доступные в меню:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Включено"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Комбинация клавиш"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Включить комбинации клавиш"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Перепись существующей комбинации клавиш"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Комбинация клавиш %s уже назначена для %s.\n"
+"Отключить комбинацию клавиш для других действий и назначить здесь вместо "
+"этого?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Включение прозрачности требует перезагрузки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr "Стиль окна"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Обычный"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr "Отключить CSD"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr "Отключить CSD, спрятать панель инструментов"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr "Не показывать границы"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr "Требуется перезапуск окна"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Стиль заголовока терминала"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Мелкий"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Вариант темы"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "По умолчанию"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Светлый"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Тёмный"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Фоновое изображение"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Выбор изображения"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Все файлы изображений"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Сброс фонового изображения"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Маштабировать"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Повторять"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "По центру"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Растянуть"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Имя сессии по умолчанию"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Заголовок приложения"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Использовать широкие отступы"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Разместить боковую панель справа"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Показывать название терминала, даже если это единственный терминал"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Размер"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Высота в процентах"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Ширина в процентах"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Выравнивание"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Слева"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Справа"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Показывать терминал на всех рабочих пространствах"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Установить свойство менеджера окон для отключения анимации"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Прятать окно при потере фокуса"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Прятать заголовок окна"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Отображать терминал на активном мониторе"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Отображать на указанном мониторе"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Поведение"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Подсказка при создании нового сеанса"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Фокусировать терминал, когда мышь над ним"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Скрывать указатель мыши при наборе"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Закрывать терминал нажатием средней кнопки мыши по заголовку"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Изменять масштаб с помощью <Control> и колёсика прокрутки мыши"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Закрыть окно, когда последняя сессия закрыта"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Посылать извещение при окончании процесса"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Открывать новые терминалы"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Новое окно"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Новый сеанс"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Разделить справа"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Разделить снизу"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Показать текущее окно"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Буфер обмена"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Всегда использовать расширенный диалог вставки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Предупреждать при попытке небезопасной вставки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Обрезать первый символ вставки, если это комментарий или определение "
+"переменной"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Автоматически копировать текст в буфер обмена при выделении"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr "Добавить закладку"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr "Редактировать закладку"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr "Удалить закладку"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr "Снять отметку с закладки"
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Заголовок"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Не показывать это снова"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Окно (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Сеанс (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Закрыть приложение"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Закрыть окно"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Завершить сеанс"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Хорошо"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Эта команда запрашивает административный доступ к вашему компьютеру"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Копирование команд из интернета может быть опасным. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Убедитесь, что вы понимаете, что делает каждая часть этой команды."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Преображение"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Преобразование пробелов в табы"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Преобразование CRLF и CR в LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Расширенная вставка"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Вставить"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Имя"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Новый"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Вставить символы перевода строки с паролем"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Вставить пароль"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Пароль"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Подтвердить пароль"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Добавить пароль"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Изменить пароль"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Параметры поиска"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Найти следующее"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Найти предыдущее"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Учитывать регистр"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Только полные слова"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "По регулярному выражению"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Автоматически переходить к началу"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Закрыть"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Развернуть"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Выключить синхронизацию ввода для этого терминала"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Только чтение"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Редактировать профиль"
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr "Редактировать кодировки"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Включить синхронизацию ввода для этого терминала"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Невозможно загрузить библиотеку %s, функциональность паролей недоступна."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Библиотека не загружается"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Найти…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Пароль"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Добавить закладку..."
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr "Добавить закладку..."
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Сохранить содержимое…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Сброс и очистка"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Параметры оформления…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Другие"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Добавить справа"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Добавить снизу"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Восстановить"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Открыть ссылку"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Копировать адрес ссылки"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Копировать"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Выбрать всё"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Синхронизировать ввод"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+"Пользовательское регулярное выражение \"%s\" содержит ошибку, игнорируем"
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Произошла неожиданная ошибка, дополнительная информация отсутствует"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Произошла неожиданная ошибка: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Сохранить содержимое терминала"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Все текстовые файлы"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Дочерний процесс завершился нормально со статусом %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Дочерний процесс был прерван сигналом %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Дочерний процесс был прерван."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Перезапустить"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Не вставлять"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Все равно вставить"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Параметры оформления"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Активный"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Загрузка сеанса"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Активные варианты всегда являются действующими и вступают в силу "
+"немедленно.\n"
+"Опции загрузки сеанса применяются только при загрузке файла сеанса."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Показать сеанс в боковой панели"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Создать новый сеанс"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Добавить терминал справа"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Добавить терминал вниз"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Найти текст в терминале"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Смена названия сеанса"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Введите новое имя сеанса"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Открыть…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Сохранить как…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Имя…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Синхронизировать ввод"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Открыто несколько сессий. Все равно закрыть?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Имя файла '%s' не существует"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Загрузить сеанс"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Открыть"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr "Не удалось загрузить сеанс из-за неожиданной ошибки."
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Ошибка загрузки сеанса"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Сохранить сеанс"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "О программе"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Завершить"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Grigorii Horos\n"
+"f2404\n"
+"Igor Dyatlov\n"
+"Ivan Ivanov\n"
+"Tigro"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Признательности"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Установить рабочий каталог терминала"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "КАТАЛОГ"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Установить стартовый профиль"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "ИМЯ-ПРОФИЛЯ"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Установить название нового терминала"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "ЗАГОЛОВОК"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Открыть указанную сессию"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "ИМЯ-СЕАНСА"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Отправить действие в текущий экземпляр Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ИМЯ-ДЕЙСТВИЯ"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Выполнить параметр как команду"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "КОМАНДА"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Развернуть окно терминала"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Свернуть окно терминала"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Полноэкранный режим окна терминала"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Сделать активным существующее окно"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+"Запустить дополнительный экземпляр в качестве нового процесса (Не "
+"рекомендуется)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Установить размер окна; например: 80x24 или 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "ГЕОМЕТРИЯ"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Открывает новое или показывает/скрывает существующее окно в выпадающем режиме"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Показать версии Terminix и компонентов"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr "Показать только диалог настроек Terminix"
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Скрытый аргумент для передачи UUID терминала"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "UUID-ТЕРМИНАЛА"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Похоже, есть проблема с конфигурацией терминала.\n"
+"Эта проблема не является серьёзной, но её исправление улучшит эксплуатацию "
+"приложения.\n"
+"Нажмите на ссылку ниже для получения дополнительной информации:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Найдена ошибка конфигурации"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Больше не показывать это сообщение"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Файл %s не является цветовой схемой совместимой с файлом формата JSON"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Палитра цветовой схемы требует 16 цветов"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Не удалось обнаружить потерянный терминал"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Не удалось найти потерянный сеанс для терминала"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -215,75 +1589,41 @@ msgstr "GtkD за предоставление такой превосходно
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org за такой превосходный язык как D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Заголовок"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr "Заголовок значка"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr "Каталог"
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr "Имя хоста"
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr "Столбцы"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr "Строки"
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr "Название приложения"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr "Название сеанса"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
 msgstr "Номер сеанса"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Не удалось обнаружить потерянный терминал"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Не удалось найти потерянный сеанс для терминала"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "По умолчанию"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Профиль"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Новый сеанс"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -420,1411 +1760,6 @@ msgstr "Вьетнамская"
 msgid "Thai"
 msgstr "Тайская"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Параметры оформления"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Активный"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Знак"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Загрузка сеанса"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Активные варианты всегда являются действующими и вступают в силу "
-"немедленно.\n"
-"Опции загрузки сеанса применяются только при загрузке файла сеанса."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Терминал"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Закрыть"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Развернуть"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Выключить синхронизацию ввода для этого терминала"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Только чтение"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Подавать гудок"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Редактировать профиль"
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr "Редактировать кодировки"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Включить синхронизацию ввода для этого терминала"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Невозможно загрузить библиотеку %s, функциональность паролей недоступна."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Библиотека не загружается"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Сохранить содержимое…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Сброс"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Сброс и очистка"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Профили"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Кодировка"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr "Добавить закладку..."
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr "Выбрать закладки..."
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr "Закладки"
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Найти…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Параметры оформления…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Добавить справа"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Добавить снизу"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Восстановить"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Открыть ссылку"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Копировать адрес ссылки"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Копировать"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Вставить"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Выбрать всё"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Буфер обмена"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Синхронизировать ввод"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-"Пользовательское регулярное выражение \"%s\" содержит ошибку, игнорируем"
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Произошла неожиданная ошибка, дополнительная информация отсутствует"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Произошла неожиданная ошибка: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Сохранить содержимое терминала"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Сохранить"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Все текстовые файлы"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Все файлы"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Дочерний процесс завершился нормально со статусом %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Дочерний процесс был прерван сигналом %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Дочерний процесс был прерван."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Перезапустить"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Не вставлять"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Все равно вставить"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Параметры поиска"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Найти следующее"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Найти предыдущее"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Учитывать регистр"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Только полные слова"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "По регулярному выражению"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Автоматически переходить к началу"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Эта команда запрашивает административный доступ к вашему компьютеру"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Копирование команд из интернета может быть опасным. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Убедитесь, что вы понимаете, что делает каждая часть этой команды."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Преображение"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Преобразование пробелов в табы"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Преобразование CRLF и CR в LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Расширенная вставка"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Новый"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Изменить"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Удалить"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Вставить символы перевода строки с паролем"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Вставить пароль"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Применить"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Пароль"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Подтвердить пароль"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Добавить пароль"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Изменить пароль"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Не показывать это снова"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Окно (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Сеанс (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Закрыть приложение"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Закрыть окно"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Завершить сеанс"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Новое окно"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Параметры"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Комбинации клавиш"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "О программе"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Завершить"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Признательности"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Установить рабочий каталог терминала"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "КАТАЛОГ"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Установить стартовый профиль"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "ИМЯ-ПРОФИЛЯ"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Установить название нового терминала"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "ЗАГОЛОВОК"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Открыть указанную сессию"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "ИМЯ-СЕАНСА"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Отправить действие в текущий экземпляр Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ИМЯ-ДЕЙСТВИЯ"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Выполнить параметр как команду"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "КОМАНДА"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Развернуть окно терминала"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Свернуть окно терминала"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Полноэкранный режим окна терминала"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Сделать активным существующее окно"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-"Запустить дополнительный экземпляр в качестве нового процесса (Не "
-"рекомендуется)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Установить размер окна; например: 80x24 или 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "ГЕОМЕТРИЯ"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Открывает новое или показывает/скрывает существующее окно в выпадающем режиме"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Показать версии Terminix и компонентов"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr "Показать только диалог настроек Terminix"
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Скрытый аргумент для передачи UUID терминала"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "UUID-ТЕРМИНАЛА"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Похоже, есть проблема с конфигурацией терминала.\n"
-"Эта проблема не является серьёзной, но её исправление улучшит эксплуатацию "
-"приложения.\n"
-"Нажмите на ссылку ниже для получения дополнительной информации:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Найдена ошибка конфигурации"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Больше не показывать это сообщение"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Показать сеанс в боковой панели"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Создать новый сеанс"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Добавить терминал справа"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Добавить терминал вниз"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Найти текст в терминале"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Смена названия сеанса"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Введите новое имя сеанса"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Открыть…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Сохранить как…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Имя…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Синхронизировать ввод"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Открыто несколько сессий. Все равно закрыть?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Все JSON файлы"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Имя файла '%s' не существует"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Загрузить сеанс"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Открыть"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Не удалось загрузить сеанс из-за неожиданной ошибки."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Ошибка загрузки сеанса"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Сохранить сеанс"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Файл %s не является цветовой схемой совместимой с файлом формата JSON"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Палитра цветовой схемы требует 16 цветов"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr "Добавить закладку"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr "Редактировать закладку"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr "Удалить закладку"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr "Снять отметку с закладки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Параметры Terminix"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Основные"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Оформление"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Выпадающий режим"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Добавить профиль"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Удалить профиль"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Профиль: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Клонировать"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Использовать для новых терминалов"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Кодировки, доступные в меню:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Включено"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Действие"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Комбинация клавиш"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Включить комбинации клавиш"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Перепись существующей комбинации клавиш"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Комбинация клавиш %s уже назначена для %s.\n"
-"Отключить комбинацию клавиш для других действий и назначить здесь вместо "
-"этого?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Включение прозрачности требует перезагрузки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr "Стиль окна"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Обычный"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr "Отключить CSD"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr "Отключить CSD, спрятать панель инструментов"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr "Не показывать границы"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr "Требуется перезапуск окна"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Стиль заголовока терминала"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Мелкий"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Отсутствует"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Вариант темы"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Светлый"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Тёмный"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Фоновое изображение"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Выбор изображения"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Все файлы изображений"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Сброс фонового изображения"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Маштабировать"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Повторять"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "По центру"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Растянуть"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Имя сессии по умолчанию"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Заголовок приложения"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Использовать широкие отступы"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Разместить боковую панель справа"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Показывать название терминала, даже если это единственный терминал"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Размер"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Высота в процентах"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Ширина в процентах"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Выравнивание"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Слева"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Справа"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Настройки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Показывать терминал на всех рабочих пространствах"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Установить свойство менеджера окон для отключения анимации"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Прятать окно при потере фокуса"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Прятать заголовок окна"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Отображать терминал на активном мониторе"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Отображать на указанном мониторе"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Поведение"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Подсказка при создании нового сеанса"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Фокусировать терминал, когда мышь над ним"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Скрывать указатель мыши при наборе"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Закрывать терминал нажатием средней кнопки мыши по заголовку"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Изменять масштаб с помощью <Control> и колёсика прокрутки мыши"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Закрыть окно, когда последняя сессия закрыта"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Посылать извещение при окончании процесса"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Открывать новые терминалы"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Разделить справа"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Разделить снизу"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Показать текущее окно"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Всегда использовать расширенный диалог вставки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Предупреждать при попытке небезопасной вставки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Обрезать первый символ вставки, если это комментарий или определение "
-"переменной"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Автоматически копировать текст в буфер обмена при выделении"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Общие"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Цвета"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Прокрутка"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Совместимость"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Расширенные"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Имя профиля"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Размер терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "столбцов"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "строк"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Курсор"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Блок"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "I-образный"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Подчёркивание"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Режим мерцания"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Система"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Вкл"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Выкл"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Звук"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Значок и звук"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Заголовок терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Позиция знака"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Северо-запад"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Северо-восток"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Юго-запад"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Юго-восток"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Оформление текста"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Разрешить полужирный текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Переносить при изменении размера"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Пользовательский шрифт"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Выбрать шрифт терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "Идентификатор: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Цветовая схема"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Пользовательская"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Экспорт"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Цветовая палитра"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Использовать цвета темы для основного и фонового цветов"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Прозрачность"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Фокусировка неактивного состояния"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Фон"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Выбрать основной цвет курсора терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Выбрать цвет фона курсора терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Подсветка"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Выбрать основной цвет подсветки терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Выбрать цвет фона подсветки терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Неактивное состояние"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Выбрать цвет неактивного состояния терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Выбрать цвет значка"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Выбрать цвет фона"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Выбрать основной цвет"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Передний план"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Чёрный"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Красный"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Зелёный"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Оранжевый"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Синий"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Фиолетовый"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Бирюзовый"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Серый"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Выбрать %s цвет"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Выбрать светло-%s цвет"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Экспорт цветовой схемы"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Показать полосу прокрутки"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Прокручивать при выводе"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Прокручивать при нажатии клавиши"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Ограничить прокрутку:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Клавиша «Backspace» генерирует"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Автоматически"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Управляющая последовательность"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Клавиша «Delete» генерирует"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Символы неоднозначной ширины"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Узкие"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Широкие"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Запускать команду как оболочку входа"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Запускать другую команду вместо моей оболочки"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "При завершении команды"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Выйти из терминала"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Перезапустить команду"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Держать терминал открытым"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Пользовательские ссылки"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"Список определённых пользователем ссылок на основе регулярных выражений, "
-"которые можно нажать в терминале."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Триггеры"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Триггеры - это регулярные выражения, с которыми сравнивается текст в "
-"терминале. Как только найдётся совпадение, будет выполнено настроенное "
-"действие."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Автоматическое переключение профиля"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Профили автоматически выбираются на основании значений, введённых здесь.\n"
-"Значения вводятся в формате <i>hostname:directory</i>. Либо имя хоста, либо "
-"каталог могут быть пропущены, но знак двоеточия должен присутствовать. "
-"Записи без имени хоста и каталога не допускаются."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Профили автоматически выбираются на основании значений, введённых здесь.\n"
-"Значения вводятся в формате <i>hostname:directory</i>. Либо имя хоста, либо "
-"каталог могут быть пропущены, но знак двоеточия должен присутствовать. "
-"Записи без имени хоста и каталога не допускаются."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Совпадения"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Добавить"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Введите пользователь@хост:каталог для совпадения"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Введите хост:каталог для совпадения"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Добавить новое совпадение"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Редактировать пользователь@хост:каталог для совпадения"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Редактировать хост:каталог для совпадения"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Редактировать совпадение"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Регулярное выражение"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Без учета регистра"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Редактировать пользовательские ссылки"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Параметр"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Ограничить количество строк для обработки запуска до:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Редактировать триггеры"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr "Строка %d: "
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr "Окно"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr "Помощь"
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1859,42 +1794,127 @@ msgstr ""
 "Вы не можете использовать выпадающий режим с параметрами развернуть, "
 "свернуть или геометрия"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "Обновить состояние"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr "Ошибка десериализации закладки"
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "Выполнить команду"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr "Корень"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
-msgstr "Отправить уведомление"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Не удалось загрузить закладки из-за неожиданной ошибки"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "Обновить заголовок"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr "Папка"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "Проиграть звук"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr "Путь"
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "Отправить текст"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr "Удалённый"
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "Вставить пароль"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
+msgstr "Выбрать папку"
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "Обновить значок"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
+msgstr "Выбрать папку"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr "Очистить папку"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr "Добавить закладку"
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr "Редактировать закладку"
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr "Выбрать путь"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr "Протокол"
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr "Хост"
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr "Пользователь"
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr "Параметры"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr "Выбрать закладку"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "выключен"
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
-msgstr "%s (Скопировать)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "Ваша версия GTK устарела, вам нужна как минимум GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Произошло неожиданное исключение"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Ошибка: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Версии"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Версия Terminix: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "Версия VTE: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "Версия GTK: %d.%d.%d"
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr "Особые возможности Terminix"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Нотификации включены=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Триггеры включены=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr "Значки включены=%b"
 
 #: data/nautilus/open-terminix.py:108
 msgid "Open Remote Terminix"
@@ -2439,6 +2459,9 @@ msgstr ""
 #: data/appdata/com.gexperts.Terminix.appdata.xml.in:31
 msgid "Terminix has been tested with GNOME and with Unity."
 msgstr "Terminix был протестирован с GNOME и Unity."
+
+#~ msgid "Select Bookmark..."
+#~ msgstr "Выбрать закладки..."
 
 #~ msgid "The expression %s is not a valid regex"
 #~ msgstr "Выражение %s не является допустимым регулярным выражением"

--- a/po/sv.po
+++ b/po/sv.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-09-15 08:49+0000\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/terminix/"
@@ -18,181 +18,1571 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.8\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "Din GTK-version är för gammal, du behöver minst GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Ett oväntat undantag inträffade"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "Fel: "
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "Persisk"
+msgid "ExecuteCommand"
+msgstr "Kommando"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "Titel"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "Text"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "Titel"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "Öppna Terminix i %s"
+msgid "%s (Copy)"
+msgstr "Kopiera"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "Öppna Terminix i %s"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Allmänt"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "Öppna inställningar"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "inaktiverad"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Välj %s färg"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Välj %s färg"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "OK"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Namn"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Markera allt"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Kommando"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Färg"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Rullning"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Kompatibilitet"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Parameter"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Avancerat"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Välj %s färg"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Profilnamn"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Terminalstorlek"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "kolumner"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "rader"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Återställ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Markör"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Block"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "I-balk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Understreck"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Blinkningsläge"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "System"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "På"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Av"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Terminalljud"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Ingen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Ljud"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Ikon"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Ikon och ljud"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Terminaltitel"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Southeast"
+msgstr "Sydeuropeisk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Textutseende"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Tillåt fet text"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Justera radbrytningar vid storleksförändring"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Anpassat typsnitt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Välj ett terminaltypsnitt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Färgschema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Anpassat"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Färgpalett"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Alternativ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Använd temafärger för förgrund/bakgrund"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Transparens"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Ofokuserad dämpad"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Text"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Bakgrund"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Välj förgrundsfärg för markör"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Välj bakgrundsfärg för markör"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Färgmarkering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Välj förgrundsfärg för färgmarkering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Välj bakgrundsfärg för färgmarkering"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Dämpad"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Välj färg för dämpad"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "Välj %s färg"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Välj bakgrundsfärg"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Välj förgrundsfärg"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Förgrund"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Svart"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Röd"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Grön"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Orange"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Blå"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Lila"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turkos"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Grå"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Välj %s färg"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Välj %s färg (ljus)"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Färgschema"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Spara"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Alla JSON-filer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Alla filer"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Visa rullningslist"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Rulla vid utdata"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Rulla vid tangentnedtryckning"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Begränsa rullningshistorik till:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Backstegstangenten genererar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Automatisk"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Kontrollsekvens"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Delete-tangenten genererar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Kodning"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Tecken med tvetydig bredd"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Smal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Bred"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Kör kommando som ett inloggningsskal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Kör ett eget kommando istället för mitt skal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Då kommandot avslutar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Avsluta terminal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Starta om kommandot"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Håll terminalen öppen"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+#, fuzzy
+msgid "Custom Links"
+msgstr "Anpassat typsnitt"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"En lista över användardefinierade länkar som kan klickas på i terminalen "
+"baserad på reguljära uttrycksdefinitioner."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Redigera"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Automatisk profilväxling"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
+"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
+"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
+"varken värdnamn eller katalog tillåts inte"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
+"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
+"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
+"varken värdnamn eller katalog tillåts inte"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Matchning"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Lägg till"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "Ange värdnamn:katalog att matcha"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Ange värdnamn:katalog att matcha"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Lägg till ny matchning"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "Redigera värdnamn:katalog att matcha"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Redigera värdnamn:katalog att matcha"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Redigera matchning"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Ta bort"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Skiftlägesokänslig"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Verkställ"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Åtgärd"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Parameter"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Redigera profil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "Fönster"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "Öppna inställningar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Globala"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Utseende"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Kortkommandon"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "Redigera profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "Ny profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profiler"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "Profiler"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "Återställ terminalen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Kodningar som visas i meny:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Aktiverad"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Snabbtangent"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Aktivera genvägar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Skriv över befintligt kortkommando"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Kortkommandot %s är redan tilldelat till %s.\n"
+"Inaktivera kortkommandot för den andra åtgärden och tilldela det här "
+"istället?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Aktivera transparens, kräver omstart"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Fönster"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "inaktiverad"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Titelstil för terminal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Liten"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Temavariant"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Standard"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Ljus"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Mörk"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Bakgrundsbild"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Välj bild"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Alla bildfiler"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Återställ bakgrundsbild"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Skala"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Sida vid sida"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Centrera"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Sträck ut"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "Redigera sessionsnamnet"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "Program"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Använd ett brett handtag för delare"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Ställ in titeln för den nya terminalen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Ljus"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Visa terminal på alla arbetsytor"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+#, fuzzy
+msgid "Hide window when focus is lost"
+msgstr "Stäng fönster då sista session stängs"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Ställ in titeln för den nya terminalen"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "Visa terminal på primär skärm"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Visa på specifik skärm"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Beteende"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Fråga då en ny session skapas"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Fokusera en terminal då musen hålls över den"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Dölj automatiskt muspekaren då du skriver"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Stäng fönster då sista session stängs"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Skicka skrivbordsaviseringar då process klar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Vid ny instans"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Nytt fönster"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Ny session"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Dela åt höger"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Dela nedåt"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Fokusera fönster"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Urklipp"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Varna vid försök till osäker inklistring"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Ta bort första tecken i inklistring om kommentar eller variabeldeklaration"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Kopiera automatiskt text till urklipp vid markering"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Titel"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Visa inte detta meddelande igen"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "Fönster"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "Session"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "Program"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "Fokusera fönster"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "Ny session"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "OK"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Det här kommandot efterfrågar administratörsåtkomst till din dator"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Att kopiera kommandon från internet kan vara farligt. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Säkerställ att du förstår vad varje del av det här kommandot gör."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Avancerat"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Klistra in"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Namn"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "ID"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Ny"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Infoga lösenord"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Lösenord"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Bekräfta lösenord"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Lägg till lösenord"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Redigera lösenord"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Sökalternativ"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Gör skillnad på gemener/VERSALER"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Sök endast hela ord"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Matcha som reguljärt uttryck"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Börja om från början"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Stäng"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Maximera"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Inaktivera inmatningssynkronisering för denna terminal"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Skrivskyddad"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Redigera profil"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Kodning"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Aktivera inmatningssynkronisering för denna terminal"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Biblioteket %s kunde inte läsas in, lösenordsfunktionalitet är ej "
+"tillgänglig."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Bibliotek ej inläst"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Sök…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Lösenord"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Välj %s färg"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Spara utdata…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Återställ och töm"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Layoutalternativ…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Annat"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Lägg till åt höger"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Lägg till nedåt"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Återställ"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Öppna länk"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Kopiera länkadress"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Kopiera"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Markera allt"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Synkronisera inmatning"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Oväntat fel inträffade, ingen ytterligare information tillgänglig"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Oväntat fel inträffade: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Spara terminalutdata"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Alla textfiler"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Underprocessen avslutades normalt med status %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Underprocessen terminerades av signal %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Underprocessen terminerades."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Starta om"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Klistra inte in"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Klistra in i alla fall"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Layoutalternativ"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Aktivt"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Sessionsinläst"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Aktiva alternativ är alltid aktiva och tillämpas omedelbart.\n"
+"Sessionsinlästa alternativ tillämpas då en sessionsfil läses in."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Visa sessionssidopanel"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Skapa en ny session"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Lägg till terminal åt höger"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Lägg till terminal nedåt"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Sök nästa i terminal"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Ändra sessionsnamn"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Ange ett nytt namn för sessionen"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Öppna…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Spara som…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Namn…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Synkronisera inmatning"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Det finns fortfarande processer som är igång, stäng i alla fall?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Filenamnet ”%s” existerar inte"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Läs in session"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Öppna"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Kunde inte läsa in session på grund av ett oväntat fel."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Fel vid inläsning av session"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Spara session"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Om"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Avsluta"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Anders Jonsson"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Tack till"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Ställ in arbetskatalogen för terminalen"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "KATALOG"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Ställ in startprofilen"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "PROFILNAMN"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Ställ in titeln för den nya terminalen"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "TITEL"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Öppna den angivna sessionen"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "SESSIONSNAMN"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Skicka en åtgärd till aktuell Terminix-instans"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ÅTGÄRDSNAMN"
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Kör det skickade kommandot"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Maximera terminalfönstret"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Maximera terminalfönstret"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Helskärm för terminalfönstret"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Fokusera det befintliga fönstret"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Starta ytterligare instans som ny process (Rekommenderas ej)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
+"Ställ in fönsterstorleken; till exempel: 80x24, eller 80x24+200+200 (KOLxRAD"
+"+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRI"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Dolt argument för att skicka terminal-UUID"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL-UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Det verkar ha uppstått problem med konfigurationen av terminalen.\n"
+"Detta är inte allvarligt, men att rätta till det kommer förbättra din "
+"användarupplevelse.\n"
+"Klick på länken nedan för mer information:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Konfigurationsproblem upptäckt"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Visa inte detta meddelande igen"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Filen %s är inte en JSON-fil som följer färgschemat"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Palett för färgschema kräver 16 färger"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Kunde inte hitta släppt terminal"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Kunde inte hitta session för släppt terminal"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -222,80 +1612,46 @@ msgstr "GtkD för att ha tillhandahållit ett utmärkt GTK-omslag"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org för det fantastiska språket D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Titel"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Program"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "ID"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "kolumner"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Program"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Sessionsinläst"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Session"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Kunde inte hitta släppt terminal"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Kunde inte hitta session för släppt terminal"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Standard"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Ny session"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -432,1437 +1788,6 @@ msgstr "Vietnamesisk"
 msgid "Thai"
 msgstr "Thai"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Layoutalternativ"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Aktivt"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Sessionsinläst"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Aktiva alternativ är alltid aktiva och tillämpas omedelbart.\n"
-"Sessionsinlästa alternativ tillämpas då en sessionsfil läses in."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Stäng"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Maximera"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Inaktivera inmatningssynkronisering för denna terminal"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Skrivskyddad"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Terminalljud"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Redigera profil"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Kodning"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Aktivera inmatningssynkronisering för denna terminal"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Biblioteket %s kunde inte läsas in, lösenordsfunktionalitet är ej "
-"tillgänglig."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Bibliotek ej inläst"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Spara utdata…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Återställ"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Återställ och töm"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profiler"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Kodning"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Välj %s färg"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Sök…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Layoutalternativ…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Lägg till åt höger"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Lägg till nedåt"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Återställ"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Öppna länk"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Kopiera länkadress"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Kopiera"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Klistra in"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Markera allt"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Urklipp"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Synkronisera inmatning"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Oväntat fel inträffade, ingen ytterligare information tillgänglig"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Oväntat fel inträffade: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Spara terminalutdata"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Spara"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Alla textfiler"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Alla filer"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Underprocessen avslutades normalt med status %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Underprocessen terminerades av signal %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Underprocessen terminerades."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Starta om"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Klistra inte in"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Klistra in i alla fall"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Sökalternativ"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Sök nästa"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Sök föregående"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Gör skillnad på gemener/VERSALER"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Sök endast hela ord"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Matcha som reguljärt uttryck"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Börja om från början"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Det här kommandot efterfrågar administratörsåtkomst till din dator"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Att kopiera kommandon från internet kan vara farligt. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Säkerställ att du förstår vad varje del av det här kommandot gör."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Avancerat"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Ny"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Redigera"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Ta bort"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Infoga lösenord"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Verkställ"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Lösenord"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Bekräfta lösenord"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Lägg till lösenord"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Redigera lösenord"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Visa inte detta meddelande igen"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "Fönster"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "Session"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "Program"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "Fokusera fönster"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "Ny session"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Nytt fönster"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Inställningar"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Kortkommandon"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Om"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Avsluta"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Tack till"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Ställ in arbetskatalogen för terminalen"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "KATALOG"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Ställ in startprofilen"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "PROFILNAMN"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Ställ in titeln för den nya terminalen"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "TITEL"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Öppna den angivna sessionen"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "SESSIONSNAMN"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Skicka en åtgärd till aktuell Terminix-instans"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ÅTGÄRDSNAMN"
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Kör det skickade kommandot"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Maximera terminalfönstret"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Maximera terminalfönstret"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Helskärm för terminalfönstret"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Fokusera det befintliga fönstret"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Starta ytterligare instans som ny process (Rekommenderas ej)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Ställ in fönsterstorleken; till exempel: 80x24, eller 80x24+200+200 (KOLxRAD"
-"+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRI"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Dolt argument för att skicka terminal-UUID"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL-UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Det verkar ha uppstått problem med konfigurationen av terminalen.\n"
-"Detta är inte allvarligt, men att rätta till det kommer förbättra din "
-"användarupplevelse.\n"
-"Klick på länken nedan för mer information:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Konfigurationsproblem upptäckt"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Visa inte detta meddelande igen"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Visa sessionssidopanel"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Skapa en ny session"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Lägg till terminal åt höger"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Lägg till terminal nedåt"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Sök nästa i terminal"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Ändra sessionsnamn"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Ange ett nytt namn för sessionen"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Öppna…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Spara som…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Namn…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Synkronisera inmatning"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Det finns fortfarande processer som är igång, stäng i alla fall?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Alla JSON-filer"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Filenamnet ”%s” existerar inte"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Läs in session"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Öppna"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Kunde inte läsa in session på grund av ett oväntat fel."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Fel vid inläsning av session"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Spara session"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Filen %s är inte en JSON-fil som följer färgschemat"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Palett för färgschema kräver 16 färger"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "Öppna inställningar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Globala"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Utseende"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "Redigera profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "Ny profil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "Profiler"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "Återställ terminalen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Kodningar som visas i meny:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Aktiverad"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Åtgärd"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Snabbtangent"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Aktivera genvägar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Skriv över befintligt kortkommando"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Kortkommandot %s är redan tilldelat till %s.\n"
-"Inaktivera kortkommandot för den andra åtgärden och tilldela det här "
-"istället?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Aktivera transparens, kräver omstart"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Fönster"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "inaktiverad"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Titelstil för terminal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Liten"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Ingen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Temavariant"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Ljus"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Mörk"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Bakgrundsbild"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Välj bild"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Alla bildfiler"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Återställ bakgrundsbild"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Skala"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Sida vid sida"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Centrera"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Sträck ut"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "Redigera sessionsnamnet"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "Program"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Använd ett brett handtag för delare"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Ställ in titeln för den nya terminalen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Ljus"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Alternativ"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Visa terminal på alla arbetsytor"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-#, fuzzy
-msgid "Hide window when focus is lost"
-msgstr "Stäng fönster då sista session stängs"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Ställ in titeln för den nya terminalen"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "Visa terminal på primär skärm"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Visa på specifik skärm"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Beteende"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Fråga då en ny session skapas"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Fokusera en terminal då musen hålls över den"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Dölj automatiskt muspekaren då du skriver"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Stäng fönster då sista session stängs"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Skicka skrivbordsaviseringar då process klar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Vid ny instans"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Dela åt höger"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Dela nedåt"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Fokusera fönster"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Varna vid försök till osäker inklistring"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Ta bort första tecken i inklistring om kommentar eller variabeldeklaration"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Kopiera automatiskt text till urklipp vid markering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Allmänt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Färg"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Rullning"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Kompatibilitet"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Avancerat"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Profilnamn"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Terminalstorlek"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "kolumner"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "rader"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Markör"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Block"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "I-balk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Understreck"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Blinkningsläge"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "System"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "På"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Av"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Ljud"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Ikon och ljud"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Terminaltitel"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "Sydeuropeisk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Textutseende"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Tillåt fet text"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Justera radbrytningar vid storleksförändring"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Anpassat typsnitt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Välj ett terminaltypsnitt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Färgschema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Anpassat"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Färgpalett"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Använd temafärger för förgrund/bakgrund"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Transparens"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Ofokuserad dämpad"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Text"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Bakgrund"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Välj förgrundsfärg för markör"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Välj bakgrundsfärg för markör"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Färgmarkering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Välj förgrundsfärg för färgmarkering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Välj bakgrundsfärg för färgmarkering"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Dämpad"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Välj färg för dämpad"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "Välj %s färg"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Välj bakgrundsfärg"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Välj förgrundsfärg"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Förgrund"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Svart"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Röd"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Grön"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Orange"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Blå"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Lila"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turkos"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Grå"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Välj %s färg"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Välj %s färg (ljus)"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Färgschema"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Visa rullningslist"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Rulla vid utdata"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Rulla vid tangentnedtryckning"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Begränsa rullningshistorik till:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Backstegstangenten genererar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Automatisk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Kontrollsekvens"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Delete-tangenten genererar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Tecken med tvetydig bredd"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Smal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Bred"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Kör kommando som ett inloggningsskal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Kör ett eget kommando istället för mitt skal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Då kommandot avslutar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Avsluta terminal"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Starta om kommandot"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Håll terminalen öppen"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-#, fuzzy
-msgid "Custom Links"
-msgstr "Anpassat typsnitt"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"En lista över användardefinierade länkar som kan klickas på i terminalen "
-"baserad på reguljära uttrycksdefinitioner."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Automatisk profilväxling"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
-"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
-"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
-"varken värdnamn eller katalog tillåts inte"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Profiler väljs automatiskt baserat på värdena som matas in här.\n"
-"Värden matas in med ett <i>värdnamn:katalog</i>-format. Antingen värdnamnet "
-"eller katalogen kan uteslutas men kolonet måste finnas med. Värden med "
-"varken värdnamn eller katalog tillåts inte"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Matchning"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Lägg till"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "Ange värdnamn:katalog att matcha"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Ange värdnamn:katalog att matcha"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Lägg till ny matchning"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "Redigera värdnamn:katalog att matcha"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Redigera värdnamn:katalog att matcha"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Redigera matchning"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Skiftlägesokänslig"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Parameter"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Redigera profil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Fönster"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1895,46 +1820,135 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Kommando"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "Titel"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Kunde inte läsa in session på grund av ett oväntat fel."
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "Text"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "Titel"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "Välj %s färg"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Välj %s färg"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Markera allt"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "Parameter"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Välj %s färg"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "inaktiverad"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "Din GTK-version är för gammal, du behöver minst GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Ett oväntat undantag inträffade"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Fel: "
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "Persisk"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Kopiera"
+msgid "Terminix version: %s"
+msgstr "Öppna Terminix i %s"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "Öppna Terminix i %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "Öppna inställningar"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/terminix.pot
+++ b/po/terminix.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,172 +16,1507 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: source/app.d:110
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:326
 #, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgid "%s (Copy)"
 msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
 msgstr ""
 
-#: source/app.d:128
-msgid "Error: "
-msgstr ""
-
-#: source/app.d:138
-msgid "Versions"
-msgstr ""
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr ""
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr ""
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-msgid "Terminix Special Features"
-msgstr ""
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-msgid "Select folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-msgid "Select Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-msgid "Select Bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr ""
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
-msgid "Could not load bookmarks due to unexpected error"
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+msgid "Window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+msgid "Window style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:442
+msgid "Edit Encodings"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+msgid "Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:736
+msgid "Other"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr ""
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr ""
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr ""
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr ""
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr ""
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr ""
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr ""
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr ""
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
 msgstr ""
 
 #: source/gx/terminix/constants.d:60
@@ -207,74 +1542,40 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr ""
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 msgid "Icon title"
 msgstr ""
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 msgid "Columns"
 msgstr ""
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 msgid "Application name"
 msgstr ""
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 msgid "Session name"
 msgstr ""
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 msgid "Session number"
-msgstr ""
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr ""
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr ""
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr ""
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
 msgstr ""
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
@@ -412,1380 +1713,6 @@ msgstr ""
 msgid "Thai"
 msgstr ""
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:442
-msgid "Edit Encodings"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-msgid "Select Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr ""
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr ""
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr ""
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr ""
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr ""
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr ""
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr ""
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr ""
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr ""
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr ""
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr ""
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr ""
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-msgid "Window style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-msgid "Window"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1816,41 +1743,126 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:586
+msgid "Could not load bookmarks due to unexpected error"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
+#: source/gx/terminix/bookmark/bmeditor.d:74
+msgid "Select folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+msgid "Select Path"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+msgid "Select Bookmark"
+msgstr ""
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr ""
+
+#: source/app.d:110
 #, c-format
-msgid "%s (Copy)"
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr ""
+
+#: source/app.d:128
+msgid "Error: "
+msgstr ""
+
+#: source/app.d:138
+msgid "Versions"
+msgstr ""
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr ""
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr ""
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+msgid "Terminix Special Features"
+msgstr ""
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
 msgstr ""
 
 #: data/nautilus/open-terminix.py:108

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2017-01-30 20:14+0000\n"
 "Last-Translator: Mahmutcan İlhandağ <ilhandagm@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/terminix/"
@@ -18,179 +18,1551 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.11-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "GTK sürümün çok eski, en azından GTK %d.%d.%d. lazım!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Kuraldışı bir durum oluştu"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "Hata: "
-
-#: source/app.d:138
-msgid "Versions"
-msgstr "Sürüm"
-
-#: source/app.d:139
-#, c-format
-msgid "Terminix version: %s"
-msgstr "Terminix sürümü: %s"
-
-#: source/app.d:140
-#, c-format
-msgid "VTE version: %s"
-msgstr "VTE sürümü: %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr "GTK Sürümü: %d.%d.%d"
-
-#: source/app.d:142
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Terminix Special Features"
-msgstr "Tercihleri aç"
+msgid "ExecuteCommand"
+msgstr "Komut"
 
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr "Bildirimleri etkinleştir=%b"
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr "Tetikleyiciler etkinleştirildi=%b"
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
 msgstr ""
 
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "etkisiz"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/preferences.d:215
 #, fuzzy
-msgid "Select Folder"
-msgstr "%s rengi seç"
+msgid "UpdateTitle"
+msgstr "Başlık"
 
-#: source/gx/terminix/bookmark/bmeditor.d:74
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
 #, fuzzy
-msgid "Select folder"
-msgstr "%s rengi seç"
+msgid "SendText"
+msgstr "Metin"
 
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Tamam"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "İptal"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "İsim"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
+#: source/gx/terminix/preferences.d:219
 #, fuzzy
-msgid "Select Path"
-msgstr "Tümünü seç"
+msgid "UpdateBadge"
+msgstr "Başlık"
 
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/preferences.d:326
+#, fuzzy, c-format
+msgid "%s (Copy)"
+msgstr "Kopyala"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Genel"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Komut"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Renk"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Akma"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Uyumluluk"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Gelişmiş"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "%s rengi seç"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Profil ismi"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Terminal boyutu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "sütunl"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "satır"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "İmleç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Blok"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "I-şekli"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Alt-çizgi"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Yanar söner kipi"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Sistem"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Açık"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Kapalı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Terminal çanı"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Hiçbiri"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Ses"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Simge"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Simge ve ses"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Terminal başlığı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Kuzey batı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Kuzey doğu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Güney batı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Southeast"
+msgstr "Güney Avrupa"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Metin görünümü"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Kalın metine izin ver"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Boyutlandırmada metni sar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Özel font"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Terminal fontu seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Renk düzeni"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Özel"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Dışa aktar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Renk paleti"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Seçenekler"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Ön/Arka plan için temanın renklerini kullan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Saydamlık"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Odaklanmadığında karart"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Metin"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Arkaplan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "İmleç önplan rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "İmleç arkaplan rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Vurgulama"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Önplan vurgulama rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Arkaplan vurgulama rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Karartma"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Karartma rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "%s rengi seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Arkaplan rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Önplan rengini seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Önplan"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Siyah"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Kırmızı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Yeşil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Turuncu"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Mavi"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Mor"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Turkuaz"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Gri"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "%s rengi seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "%s açık rengi seç"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "Renk düzeni"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Kaydet"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "İptal"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Bütün JSON Dosyaları"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Bütün Dosyalar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Kaydırma çubuğunu göster"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Çıktı esnasında kaydır"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Tuş basımında kaydır"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Kaydırmayı kısıtla:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Backspace tuşu üretir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Otomatik"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Escape sekansı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Delete tuşu üretir"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Kodlama"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Belirsiz-genişlikteki hafler"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Dar"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Geniş"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Komutu oturum açılış kabuğu olarak çalıştır"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Kabuk yerine özel komut çalıştır"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Komut sonlanınca"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Terminalden çık"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Komutu yeniden çalıştır"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Terminali açık tut"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+#, fuzzy
+msgid "Custom Links"
+msgstr "Özel font"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Düzenle"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+#, fuzzy
+msgid "Match"
+msgstr "Büyük - Küçük Harf Duyarlı"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Ekle"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Sil"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Regex"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Uygula"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Eylem"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "Profil Düzenle"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Terminal"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "Pencere"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "Tercihleri aç"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Global"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Görünüm"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Kısa yollar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Profil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Profil ekle"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Profili sil"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Tercihler"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Profiller"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Profil: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Klon"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Menü de gösterilen Kodlamalar:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Etkin"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Kısayol Tuşu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Kısa yolları etkinleştir"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Varolan Kısayolun Üzerine Yaz"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"%s kısayolu %s'e tayin edilmiş.\n"
+"Önceki kısayolu iptal edip buraya tayin et?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Şefaflık etkinleştir, yeniden başlatma gerektirir"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Pencere (%s)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Normal"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "etkisiz"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Terminal başlık tarzı"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Küçük"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Tema variyasyonu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Varsayılan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Açık"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Koyu"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Arkaplan resmi"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Resim seç"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Bütün Resim Dosyaları"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Arkaplan resmini sıfırla"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Ölçek"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Döşe"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Ortala"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "Oturum ismini değiştir"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Uygulama başlığı"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Ayraçlar için geniş kulp kullan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Boyut"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Hizalama"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Sol"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "Açık"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Terminali tüm çalışma alanlarında göster"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Davranış"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Yeni oturum açarken sorgula"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Fare üstündeyken terminale odakla"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Fare imlecini yazareken gizle"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Masaüstüne işlem bitince haber ver"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Yeni Örnekte"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Yeni Pencere"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Yeni Oturum"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Sağa doğru böl"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Aşağı doğru böl"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Pencereye odaklan"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Pano"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Emminyetsiz yapıştırmada beni uyar"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "Açıklama (comment) veya değişken yapıştırken ilk harfi a"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Başlık"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "Bu mesjaı tekrar gösterme"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Pencere (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Oturum (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Uygulamayı Kapat"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Pencereyi Kapat"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Oturumu Kapat"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Tamam"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Bu komut bilgisayara yönetici erişimi istemekte"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "İnternetden komut kopyalamak tehlike arz edebilir "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Komutun her bölümünün ne yaptığını anladığından emmin ol."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "Gelişmiş"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Yapıştır"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "İsim"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "Kimlik"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Yeni"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Şifre Ekle"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Şifre"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Şifreyi Onayla"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Şifre Ekle"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Şifreyi Düzenle"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Arama Seçenekleri"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Büyük - Küçük Harf Duyarlı"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Bütün kelimle bul"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Regular Expression olarak bul"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Başa sar"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Kapa"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Enbüyüt"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Girdi senkronizasyonunu bu terminal için kapa"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Salt-Okunur"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Profil Düzenle"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Kodlama"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Girdi senkronizasyonunu bu terminal için aç"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Bul…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Şifre"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "%s rengi seç"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Çıktıyı Kaydet…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Sıfırla ve Temizle"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Yerleşim Seçenekleri…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+msgid "Other"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:745
+#, fuzzy
+msgid "Add Right"
+msgstr "Sağa doğru böl"
+
+#: source/gx/terminix/terminal/terminal.d:749
+#, fuzzy
+msgid "Add Down"
+msgstr "Aşağıya doğru böl"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Geri al"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Link'i Aç"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Link Adresini Kopyala"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Kopyala"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Hepsini Seç"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Grirdiyi Senkronize et"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Beklenmeyen bir hata oluştu, daha fazla bilgi mevcut değil"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Beklenmeyen hata oluştu: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Terminal Çıktısını Kaydet"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Bütün Metin Dosyaları"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Alt işlem beklenmedik bir şekilde kapandı: %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Alt işlem sinyal %d ile durduruldu."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Alt işlem durduruldu."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Tekrar başlat"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Yapıştırma"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Yinede Yapıştır"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Düzenleme Ayaları"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Etkin"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Oturum Yükle"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Etkin ayalar her zaman etkin olup hemen gerçerli kılınır.\n"
+"Oturum Yükleme ayaları sadece oturum dosyası yüklenince etkin olur."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Oturum kenar çubuğunü göster"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Yeni oturum aç"
+
+#: source/gx/terminix/appwindow.d:363
+#, fuzzy
+msgid "Add terminal right"
+msgstr "Terminal başlığı"
+
+#: source/gx/terminix/appwindow.d:367
+#, fuzzy
+msgid "Add terminal down"
+msgstr "Terminali açık tut"
+
+#: source/gx/terminix/appwindow.d:373
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "Terminalden çık"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Oturum ismini değiştir"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Oturum için yeni isim gir"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Aç…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Yeni Adla Kaydet…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "İsim…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Girdiyi Senkronize et"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Çalışan işlemler mevcut, yinede kapatalım mı?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "'%s' dosyası bulunamadı"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Oturum Yükle"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Aç"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Beklenmeyen bir hatadan dolayı oturum yüklenemedi."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Oturum Yükeleme Hatası"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Oturumu Kaydet"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Hakkında"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Çıkış"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Giray Devlet\n"
+"Mahmutcan İlhandağ\n"
+"Tolga Golelcin"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Teşekkürler"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIZIN"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Başlangıç profilini seç"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:625
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "Terminalin çalışma dizinini ayarla"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "BAŞLIK"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Belirtilmiş oturumu seç"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Geçerli Terminix'e eylem yolla"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "Yollanan komutu çalıştır"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "KOMUT"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Terminal penceresini enbüyüt"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "Terminal penceresini enbüyüt"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Terminal pençeresini tam ekran yap"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Var olan pencereye odakla"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
 msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "GEOMETRİ"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Terminal UUIDsine yollanacak gizli değişken"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"Terminal ayarlarında bir sorun varmış gibi gözüküyor.\n"
+"Sorun ciddi olmamakla birlikte, bunu düzeltmek deneyiminizi "
+"iyileştirecektir.\n"
+"Daha fazla bilgi için aşağıdaki bilgiye klikleyin:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Ayar sorunu tespit edildi"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Bu mesjaı tekrar gösterme"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "%s uygun bir renk planı JSON dosyası değil"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Renk planı paleti 16 renk gerektirmektedir"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Bırakılan terminalin konumu tespi edilemedi"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Bırakılan terminal için oturum bulunamadı"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -220,80 +1592,46 @@ msgstr "GtkD'e böyle mükemmel bir GTK sarıcı sağladıkları için"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org'a böyle harika bir dil için"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Başlık"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Uygulama başlığı"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Kimlik"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "sütunl"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Uygulama"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Oturum Yükle"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Oturum"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Bırakılan terminalin konumu tespi edilemedi"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Bırakılan terminal için oturum bulunamadı"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Varsayılan"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Profil"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Yeni Oturum"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -430,1415 +1768,6 @@ msgstr "Vietnamca"
 msgid "Thai"
 msgstr "Thaica"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Düzenleme Ayaları"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Etkin"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Oturum Yükle"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Etkin ayalar her zaman etkin olup hemen gerçerli kılınır.\n"
-"Oturum Yükleme ayaları sadece oturum dosyası yüklenince etkin olur."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Terminal"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Kapa"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Enbüyüt"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Girdi senkronizasyonunu bu terminal için kapa"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Salt-Okunur"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Terminal çanı"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Profil Düzenle"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Kodlama"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Girdi senkronizasyonunu bu terminal için aç"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Çıktıyı Kaydet…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Sıfırla"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Sıfırla ve Temizle"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Profiller"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Kodlama"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "%s rengi seç"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Bul…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Yerleşim Seçenekleri…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-#, fuzzy
-msgid "Add Right"
-msgstr "Sağa doğru böl"
-
-#: source/gx/terminix/terminal/terminal.d:741
-#, fuzzy
-msgid "Add Down"
-msgstr "Aşağıya doğru böl"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Geri al"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Link'i Aç"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Link Adresini Kopyala"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Kopyala"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Yapıştır"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Hepsini Seç"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Pano"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Grirdiyi Senkronize et"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Beklenmeyen bir hata oluştu, daha fazla bilgi mevcut değil"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Beklenmeyen hata oluştu: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Terminal Çıktısını Kaydet"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Kaydet"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Bütün Metin Dosyaları"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Bütün Dosyalar"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Alt işlem beklenmedik bir şekilde kapandı: %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Alt işlem sinyal %d ile durduruldu."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Alt işlem durduruldu."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Tekrar başlat"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Yapıştırma"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Yinede Yapıştır"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Arama Seçenekleri"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Büyük - Küçük Harf Duyarlı"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Bütün kelimle bul"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Regular Expression olarak bul"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Başa sar"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Bu komut bilgisayara yönetici erişimi istemekte"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "İnternetden komut kopyalamak tehlike arz edebilir "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Komutun her bölümünün ne yaptığını anladığından emmin ol."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "Gelişmiş"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Yeni"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Düzenle"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Sil"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Şifre Ekle"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Uygula"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Şifre"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Şifreyi Onayla"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Şifre Ekle"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Şifreyi Düzenle"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "Bu mesjaı tekrar gösterme"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Pencere (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Oturum (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Uygulamayı Kapat"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Pencereyi Kapat"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Oturumu Kapat"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Yeni Pencere"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Tercihler"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Kısa yollar"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Hakkında"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Çıkış"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Teşekkürler"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIZIN"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Başlangıç profilini seç"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:624
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "BAŞLIK"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Belirtilmiş oturumu seç"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Geçerli Terminix'e eylem yolla"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "Yollanan komutu çalıştır"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "KOMUT"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Terminal penceresini enbüyüt"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "Terminal penceresini enbüyüt"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Terminal pençeresini tam ekran yap"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Var olan pencereye odakla"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "GEOMETRİ"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Terminal UUIDsine yollanacak gizli değişken"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Terminal ayarlarında bir sorun varmış gibi gözüküyor.\n"
-"Sorun ciddi olmamakla birlikte, bunu düzeltmek deneyiminizi "
-"iyileştirecektir.\n"
-"Daha fazla bilgi için aşağıdaki bilgiye klikleyin:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Ayar sorunu tespit edildi"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Bu mesjaı tekrar gösterme"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Oturum kenar çubuğunü göster"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Yeni oturum aç"
-
-#: source/gx/terminix/appwindow.d:363
-#, fuzzy
-msgid "Add terminal right"
-msgstr "Terminal başlığı"
-
-#: source/gx/terminix/appwindow.d:367
-#, fuzzy
-msgid "Add terminal down"
-msgstr "Terminali açık tut"
-
-#: source/gx/terminix/appwindow.d:373
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "Terminalden çık"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Oturum ismini değiştir"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Oturum için yeni isim gir"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Aç…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Yeni Adla Kaydet…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "İsim…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Girdiyi Senkronize et"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Çalışan işlemler mevcut, yinede kapatalım mı?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Bütün JSON Dosyaları"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "'%s' dosyası bulunamadı"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Oturum Yükle"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Aç"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Beklenmeyen bir hatadan dolayı oturum yüklenemedi."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Oturum Yükeleme Hatası"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Oturumu Kaydet"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "%s uygun bir renk planı JSON dosyası değil"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Renk planı paleti 16 renk gerektirmektedir"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "Tercihleri aç"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Global"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Görünüm"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Profil ekle"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Profili sil"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Profil: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Klon"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Menü de gösterilen Kodlamalar:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Etkin"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Eylem"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Kısayol Tuşu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Kısa yolları etkinleştir"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Varolan Kısayolun Üzerine Yaz"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"%s kısayolu %s'e tayin edilmiş.\n"
-"Önceki kısayolu iptal edip buraya tayin et?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Şefaflık etkinleştir, yeniden başlatma gerektirir"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Pencere (%s)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Normal"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "etkisiz"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Terminal başlık tarzı"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Küçük"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Hiçbiri"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Tema variyasyonu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Açık"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Koyu"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Arkaplan resmi"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Resim seç"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Bütün Resim Dosyaları"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Arkaplan resmini sıfırla"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Ölçek"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Döşe"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Ortala"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "Oturum ismini değiştir"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Uygulama başlığı"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Ayraçlar için geniş kulp kullan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Boyut"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Hizalama"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Sol"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "Açık"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Seçenekler"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Terminali tüm çalışma alanlarında göster"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "Terminalin çalışma dizinini ayarla"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Davranış"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Yeni oturum açarken sorgula"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Fare üstündeyken terminale odakla"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Fare imlecini yazareken gizle"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Masaüstüne işlem bitince haber ver"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Yeni Örnekte"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Sağa doğru böl"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Aşağı doğru böl"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Pencereye odaklan"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Emminyetsiz yapıştırmada beni uyar"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "Açıklama (comment) veya değişken yapıştırken ilk harfi a"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Genel"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Renk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Akma"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Uyumluluk"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Gelişmiş"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Profil ismi"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Terminal boyutu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "sütunl"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "satır"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "İmleç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Blok"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "I-şekli"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Alt-çizgi"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Yanar söner kipi"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Sistem"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Açık"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Kapalı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Ses"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Simge ve ses"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Terminal başlığı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Kuzey batı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Kuzey doğu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Güney batı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "Güney Avrupa"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Metin görünümü"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Kalın metine izin ver"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Boyutlandırmada metni sar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Özel font"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Terminal fontu seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Renk düzeni"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Özel"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Dışa aktar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Renk paleti"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Ön/Arka plan için temanın renklerini kullan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Saydamlık"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Odaklanmadığında karart"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Metin"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Arkaplan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "İmleç önplan rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "İmleç arkaplan rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Vurgulama"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Önplan vurgulama rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Arkaplan vurgulama rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Karartma"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Karartma rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "%s rengi seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Arkaplan rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Önplan rengini seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Önplan"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Siyah"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Kırmızı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Yeşil"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Turuncu"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Mavi"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Mor"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Turkuaz"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Gri"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "%s rengi seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "%s açık rengi seç"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "Renk düzeni"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Kaydırma çubuğunu göster"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Çıktı esnasında kaydır"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Tuş basımında kaydır"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Kaydırmayı kısıtla:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Backspace tuşu üretir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Otomatik"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Escape sekansı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Delete tuşu üretir"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Belirsiz-genişlikteki hafler"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Dar"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Geniş"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Komutu oturum açılış kabuğu olarak çalıştır"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Kabuk yerine özel komut çalıştır"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Komut sonlanınca"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Terminalden çık"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Komutu yeniden çalıştır"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Terminali açık tut"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-#, fuzzy
-msgid "Custom Links"
-msgstr "Özel font"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-#, fuzzy
-msgid "Match"
-msgstr "Büyük - Küçük Harf Duyarlı"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Ekle"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Regex"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "Profil Düzenle"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Pencere"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1871,46 +1800,133 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "Komut"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "Başlık"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Beklenmeyen bir hatadan dolayı oturum yüklenemedi."
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "Metin"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "Başlık"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
-#, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "Kopyala"
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "%s rengi seç"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "%s rengi seç"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Tümünü seç"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "%s rengi seç"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "etkisiz"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "GTK sürümün çok eski, en azından GTK %d.%d.%d. lazım!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Kuraldışı bir durum oluştu"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Hata: "
+
+#: source/app.d:138
+msgid "Versions"
+msgstr "Sürüm"
+
+#: source/app.d:139
+#, c-format
+msgid "Terminix version: %s"
+msgstr "Terminix sürümü: %s"
+
+#: source/app.d:140
+#, c-format
+msgid "VTE version: %s"
+msgstr "VTE sürümü: %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr "GTK Sürümü: %d.%d.%d"
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "Tercihleri aç"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr "Bildirimleri etkinleştir=%b"
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr "Tetikleyiciler etkinleştirildi=%b"
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminix\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-12-14 19:18+0000\n"
 "Last-Translator: Мирослав Білоус <murukmaniak@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/terminix/"
@@ -18,182 +18,1542 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.10-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "Версія GTK — застара, потрібно щонайменше GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr "Оновити стан"
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "Трапився неочікувана виняток"
+#: source/gx/terminix/preferences.d:213
+msgid "ExecuteCommand"
+msgstr "Виконати команду"
 
-#: source/app.d:128
-msgid "Error: "
-msgstr "Помилка: "
-
-#: source/app.d:138
-#, fuzzy
-msgid "Versions"
-msgstr "Перське"
-
-#: source/app.d:139
-#, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "Відкрити Terminix в %s"
-
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "Відкрити Terminix в %s"
-
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "Параметри Terminix"
-
-#: source/app.d:143
-#, fuzzy
-msgid "Notifications enabled=%b"
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
 msgstr "Надіслати сповіщення"
 
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
+#: source/gx/terminix/preferences.d:215
+msgid "UpdateTitle"
+msgstr "Оновити заголовок"
 
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr "Дати гудок"
 
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "вимкнено"
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr "Надіслати повідомлення"
 
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "Вибрати %s колір"
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr "Вставити пароль"
 
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "Вибрати %s колір"
+#: source/gx/terminix/preferences.d:219
+msgid "UpdateBadge"
+msgstr "Оновити значок"
 
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
+#: source/gx/terminix/preferences.d:326
+#, c-format
+msgid "%s (Copy)"
+msgstr "%s (Копіювати)"
 
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "Загальне"
 
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "Гаразд"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "Назва"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "Вибрати все"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "Команда"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "Колір"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "Прокручування"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "Сумісність"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-#, fuzzy
-msgid "Parameters"
-msgstr "Параметр"
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "Додатково"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "Вибрати колір значка"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "Назва профілю"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "Розмір терміналу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "стовпці"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "рядки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "Скинути"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "Курсор"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "Блок"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "Підкреслення"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "Режим блимання"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "Система"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "Увімкнено"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "Вимкнено"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "Гудки терміналу"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "Немає"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "Звук"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "Піктограма"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "Піктограма та звук"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "Заголовок терміналу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr "Знак"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr "Позиція знака"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr "Північний захід"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr "Північний схід"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr "Південний захід"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southeast"
+msgstr "Південний схід"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "Вигляд тексту"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "Дозволити жирний текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "Підлаштовувати під розмір"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "Інший шрифт"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "Виберіть шрифт терміналу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "Ідентифікатор: %s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "Схема кольорів"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "Інша"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr "Експорт"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "Палітра кольорів"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "Параметри"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "Використовувати кольори для тексту й тла"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "Прозорість"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "Несфокусоване затемнювання"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "Текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "Тло"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "Вибрати колір тексту курсора"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "Вибрати колір тла курсора"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "Підсвічування"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "Вибрати колір підсвічування тексту"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "Вибрати колір підсвічування тла"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "Затемнювання"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "Вибрати колір затемнювання"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+msgid "Select Badge Color"
+msgstr "Вибрати колір значка"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "Вибрати колір тла"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "Вибрати колір тексту"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "Текст"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "Чорний"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "Червоний"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "Зелений"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "Оранжевий"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "Синій"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "Фіолетовий"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "Бірюзовий"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "Сірий"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "Вибрати %s колір"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "Вибрати світлий %s колір"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+msgid "Export Color Scheme"
+msgstr "Експорт кольорової схеми"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "Зберегти"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "Усі файли JSON"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "Всі файли"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "Показувати прокручування"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "Прокручувати при виведенні"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "Прокручувати клавішами"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "Обмежено прокручування до:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "Клавіша «Backspace» породжує"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "Керівні послідовності"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "Клавіша «Delete» породжує"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "Кодування"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "Неоднозначної ширини символи"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "Вузькі"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "Широкі"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "Запустити команду як оболонку входу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "Запустити іншу команду замість моєї оболонки"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "Коли виходите з команди"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "Вийти з терміналу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "Перезапустити команду"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "Утримувати термінал відкритим"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "Власні посилання"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+"перелік користувацьких посилань, на які можна натиснути в терміналі на "
+"основі означень формальних виразів."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "Редагувати"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr "Перемикачі"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+"Перемикачі — формальні вирази, які перевіряють текст виводу в терміналі. "
+"Коли виникає збіг, виконується певна налаштована дії."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "Автоматичне перемикання профілів"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"Профілі автоматично вибирають на основі значення введених тут.\n"
+"Значення введено через формат <i>користувач@вузол:каталог</i>. Або вузол, "
+"або каталог можуть бути порожні, але стовпці мають бути. Записи без вузла і "
+"каталогу — заборонені."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"Профілі автоматично вибирають на основі значення введених тут.\n"
+"Значення введено через формат <i>вузол:каталог</i>. Або вузол, або каталог "
+"можуть бути порожні, але стовпці мають бути. Записи без вузла і каталогу — "
+"заборонені."
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "Збіги"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "Додати"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr "Ввести користувач@вузол:каталог для збігу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "Введіть вузол:каталог для збігу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "Додати новий збіг"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr "Редагувати користувач@вузол:каталог для збігу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "Редагувати вузол:каталог для збігу"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "Редагувати збіг"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "Вилучити"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "Формальний вираз"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "Без урахування регістру"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "Редагувати власні посилання"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "Застосувати"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "Дія"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr "Параметр"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr "Обмежити кількість рядків для обробки запуску до:"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+msgid "Edit Triggers"
+msgstr "Редагувати перемикачі"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "Термінал"
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/titleeditor.d:108
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Window"
+msgstr "Вікно"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+msgid "Terminix Preferences"
+msgstr "Параметри Terminix"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "Загальне"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "Вигляд"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr "Обвал"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "Скорочення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "Профіль"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+msgid "Add profile"
+msgstr "Додати профіль"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+msgid "Delete profile"
+msgstr "Видалити профіль"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "Параметри"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "Профілі"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, c-format
+msgid "Profile: %s"
+msgstr "Профілі: %s"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr "Клонування"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+msgid "Use for new terminals"
+msgstr "Використовувати для нових терміналів"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "Кодування в меню:"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "Клавіша скорочення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "Увімкнути скорочення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "Перезаписати наявні скорочення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"Скорочення  %s уже призначено на %s.\n"
+"Вимкнути скорочення для іншої дії і призначити сюди натомість?"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "Увімкнути прозорість, вимагає перезапуск"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "Вікно (%s)"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "Звичайний"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "вимкнено"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "Стиль заголовку термінала"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "Малий"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "Варіант теми"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "Типово"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "Світлий"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "Темний"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "Зображення тла"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "Вибрати зображення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "Усі файли зображення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "Скинути зображення тла"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "Шкала"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "Черепиця"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "Центр"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "Розтягнення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+msgid "Default session name"
+msgstr "Стандартне ім'я сесії"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+msgid "Application title"
+msgstr "Заголовок програми"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "Використовувати широкі відступи"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr "Розмістити бокову панель праворуч"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "Показувати назву терміналу, навіть якщо це єдиний термінал"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr "Розмір"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr "Висота у відсотках"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr "Ширина у відсотках"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr "Вирівнювання"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr "Ліворуч"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Right"
+msgstr "Праворуч"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr "Показувати термінал на всіх робочих просторах"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr "Встановити властивість вікон для відключення анімації"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr "Ховати вікно, коли фокус втрачено"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+msgid "Hide the titlebar of the window"
+msgstr "Приховати заголовок вікна"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+msgid "Display terminal on active monitor"
+msgstr "Показувати термінал на основному екрані"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr "Показувати на певному екрані"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "Поведінка"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "Запитувати, якщо створюється новий сеанс"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "Фокусуватись на терміналі, коли мишка над ним"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "Автоматично ховати вказівник миші, коли щось вводите"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr "Закрити термінал натиском на середню кнопку миші на заголовку"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr "Зум терміналу використовуючи <Ctrl> і колесо мишки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr "Закрити вікно, коли останній сеанс закрито"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "Надсилати сповіщення, коли дія закінчиться"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "Відкривати новий термінал"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "Створити вікно"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "Створити сеанс"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "Розділити праворуч"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "Розділити додолу"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "Сфокусувати вікно"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "Буфер"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr "Завжди використовувати розширений діалог вставки"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "Попереджати про небезпечні вставлення"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr ""
+"Обрізати перший символ вставлення, якщо це коментар або оголошення змінної"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "Автоматично копіювати текст у буфер, коли його вибираєте"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "Заголовок"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+msgid "Do not show this again"
+msgstr "Більше не показувати це повідомлення"
+
+#: source/gx/terminix/closedialog.d:160
+#, c-format
+msgid "Window (%s)"
+msgstr "Вікно (%s)"
+
+#: source/gx/terminix/closedialog.d:163
+#, c-format
+msgid "Session (%s)"
+msgstr "Сеанс (%s)"
+
+#: source/gx/terminix/closedialog.d:183
+msgid "Close Application"
+msgstr "Вийти з програми"
+
+#: source/gx/terminix/closedialog.d:186
+msgid "Close Window"
+msgstr "Закрити вікно"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+msgid "Close Session"
+msgstr "Вийти з сесії"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "Гаразд"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "Ця команда прохає адміністраторські права до вашого комп'ютера"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "Копіювання команд з інтернету можуть бути небезпечним. "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "Переконайтесь, що кожна частина цієї команди робить."
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr "Перетворення"
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr "Перетворення пробілів в таби"
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr "Перетворення CRLF і CR в LF"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr "Розширена вставка"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "Вставити"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "Назва"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr "Ідентифікатор"
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "Додати"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr "Враховувати повернення символу з паролем"
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr "Вставити пароль"
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr "Пароль"
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr "Підтвердити пароль"
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr "Додати пароль"
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr "Редагувати пароль"
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "Параметри пошуку"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "Знайти наступне"
+
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "Знайти попереднє"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "Враховувати регістр"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "Враховувати тільки цілі слова"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "Враховувати як формальний вираз"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "Обгорнути довкола"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "Закрити"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "Розгорнути"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "Вимкнути синхронізування вводу для цього терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "Тільки для читання"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "Редагувати профіль"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "Кодування"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "Увімкнути синхронізування вводу для цього терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+"Бібліотеку %s неможливо завантажити, можливість введення паролю недоступна."
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr "Бібліотеку не завантажено"
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "Знайти…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+#, fuzzy
+msgid "Password..."
+msgstr "Пароль"
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "Вибрати колір значка"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "Зберегти вивід…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "Скинути і очистити"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "Параметри компонування…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "Інше"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "Додати праворуч"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "Додати додолу"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "Відновити"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "Відкрити посилання"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "Скопіювати адресу посилання"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "Скопіювати"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "Вибрати все"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "Синхронізувати введення"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "Трапилася неочікувана помилка, додаткових відомостей немає"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "Трапилась неочікувана помилка: %s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "Зберегти вивід терміналу"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "Всі текстові файли"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "Підпроцес вийшов нормально зі станом %d"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "Підпроцес завершено сигналом %d."
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "Підпроцес завершено."
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "Перезапустити"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "Не вставляти"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "Однаково вставити"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "Параметри компонування"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "Чинний"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "Завантаження сеансу"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"Чинні параметри завжди діють і негайно застосовуються.\n"
+"Параметри завантаження сеансу застосовуються тільки, коли завантажується "
+"файл сеансу."
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "Переглянути бокову панель сеансів"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "Створити новий сеанс"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "Додати термінал праворуч"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "Додати термінал додолу"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "Знайти текст у терміналі"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "Змінити назву сеансу"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "Ввести нову назву для сеансу"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "Відкрити…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "Зберегти як…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "Назва…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "Синхронізувати введення"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+msgid "There are multiple sessions open, close anyway?"
+msgstr "Відкрито декілька сесій. Все одно закрити?"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "Файл з назвою «%s» не існує"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "Завантажити сеанс"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "Відкрити"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "Неможливо завантажити сеанс через неочікувану помилку."
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "Помилка завантаження сеансу"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "Зберегти сеанс"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "Про програму"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "Вийти"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Danylo Korostil\n"
+"Мирослав Білоус"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "Подяки"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "Вказати робочий каталог термінала"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "КАТАЛОГ"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "Вказати початковий профіль"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "НАЗВА_ПРОФІЛЮ"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "Вказати заголовок нового термінала"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "ЗАГОЛОВОК"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "Відкрити певний сеанс"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "НАЗВА_СЕАНСУ"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "Надіслати дію до поточного зразку Terminix"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "НАЗВА_ДІЇ"
+
+#: source/gx/terminix/application.d:628
+msgid "Execute the parameter as a command"
+msgstr "Виконати параметр як команду"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr "КОМАНДА"
+
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "Розгорнути вікно термінала"
+
+#: source/gx/terminix/application.d:630
+msgid "Minimize the terminal window"
+msgstr "Згорнути вікно терміналу"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "Повноекранне вікно термінала"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "Сфокусувати наявне вікно"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "Запускати додатковий зразок як новий процес (не бажано)"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+"Вказати розмір вікна, наприклад: 80x24 або 80x24+200+200 (СТОВПЦІxРЯДКИ+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "ГЕОМЕТРІЯ"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+"Відкриває вікно в обвальному режимі або перемикає видимість поточного "
+"обвального режиму"
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr "Показати версії Terminix і компонентів"
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "Прихований аргумент, який передається в UUID терміналу"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
 msgstr ""
+"Схоже, це помилка в налаштуваннях терміналу.\n"
+"Це несерйозна помилка, однак її виправлення покращить роботу.\n"
+"Натисніть на посилання нижче для подробиць:"
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "Виявлено проблему в налаштуваннях"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "Більше не показувати це повідомлення"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "Файл %s — не схема кольорів, яка сумісна з файлами JSON"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "Палітра схеми кольорів потребує 16 кольорів"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "Неможливо знайти втрачений термінал"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "Неможливо знайти сеанс втраченого термінала"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -221,80 +1581,46 @@ msgstr "GtkD за надання такої чудової обгортки на
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org за таку чудову мови, D"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "Заголовок"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "Заголовок програми"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr "Ідентифікатор"
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "стовпці"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "Програма"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "Завантаження сеансу"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "Сеанс"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "Неможливо знайти втрачений термінал"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "Неможливо знайти сеанс втраченого термінала"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "Типово"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "Профіль"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "Створити сеанс"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -431,1410 +1757,6 @@ msgstr "В'єтнамське"
 msgid "Thai"
 msgstr "Тайське"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "Параметри компонування"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "Чинний"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr "Знак"
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "Завантаження сеансу"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"Чинні параметри завжди діють і негайно застосовуються.\n"
-"Параметри завантаження сеансу застосовуються тільки, коли завантажується "
-"файл сеансу."
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "Термінал"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "Закрити"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "Розгорнути"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "Вимкнути синхронізування вводу для цього терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "Тільки для читання"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "Гудки терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "Редагувати профіль"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "Кодування"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "Увімкнути синхронізування вводу для цього терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-"Бібліотеку %s неможливо завантажити, можливість введення паролю недоступна."
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr "Бібліотеку не завантажено"
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "Зберегти вивід…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "Скинути"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "Скинути і очистити"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "Профілі"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "Кодування"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "Вибрати колір значка"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "Знайти…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "Параметри компонування…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "Додати праворуч"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "Додати додолу"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "Відновити"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "Відкрити посилання"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "Скопіювати адресу посилання"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "Скопіювати"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "Вставити"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "Вибрати все"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "Буфер"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "Синхронізувати введення"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "Трапилася неочікувана помилка, додаткових відомостей немає"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "Трапилась неочікувана помилка: %s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "Зберегти вивід терміналу"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "Зберегти"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "Всі текстові файли"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "Всі файли"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "Підпроцес вийшов нормально зі станом %d"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "Підпроцес завершено сигналом %d."
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "Підпроцес завершено."
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "Перезапустити"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "Не вставляти"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "Однаково вставити"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "Параметри пошуку"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "Знайти наступне"
-
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "Знайти попереднє"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "Враховувати регістр"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "Враховувати тільки цілі слова"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "Враховувати як формальний вираз"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "Обгорнути довкола"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "Ця команда прохає адміністраторські права до вашого комп'ютера"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "Копіювання команд з інтернету можуть бути небезпечним. "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "Переконайтесь, що кожна частина цієї команди робить."
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr "Перетворення"
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr "Перетворення пробілів в таби"
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr "Перетворення CRLF і CR в LF"
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr "Розширена вставка"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "Додати"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "Редагувати"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "Вилучити"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr "Враховувати повернення символу з паролем"
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr "Вставити пароль"
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "Застосувати"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr "Пароль"
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr "Підтвердити пароль"
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr "Додати пароль"
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr "Редагувати пароль"
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-msgid "Do not show this again"
-msgstr "Більше не показувати це повідомлення"
-
-#: source/gx/terminix/closedialog.d:160
-#, c-format
-msgid "Window (%s)"
-msgstr "Вікно (%s)"
-
-#: source/gx/terminix/closedialog.d:163
-#, c-format
-msgid "Session (%s)"
-msgstr "Сеанс (%s)"
-
-#: source/gx/terminix/closedialog.d:183
-msgid "Close Application"
-msgstr "Вийти з програми"
-
-#: source/gx/terminix/closedialog.d:186
-msgid "Close Window"
-msgstr "Закрити вікно"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-msgid "Close Session"
-msgstr "Вийти з сесії"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "Створити вікно"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "Параметри"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "Скорочення"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "Про програму"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "Вийти"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "Подяки"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "Вказати робочий каталог термінала"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "КАТАЛОГ"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "Вказати початковий профіль"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "НАЗВА_ПРОФІЛЮ"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "Вказати заголовок нового термінала"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "ЗАГОЛОВОК"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "Відкрити певний сеанс"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "НАЗВА_СЕАНСУ"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "Надіслати дію до поточного зразку Terminix"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "НАЗВА_ДІЇ"
-
-#: source/gx/terminix/application.d:627
-msgid "Execute the parameter as a command"
-msgstr "Виконати параметр як команду"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr "КОМАНДА"
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "Розгорнути вікно термінала"
-
-#: source/gx/terminix/application.d:629
-msgid "Minimize the terminal window"
-msgstr "Згорнути вікно терміналу"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "Повноекранне вікно термінала"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "Сфокусувати наявне вікно"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "Запускати додатковий зразок як новий процес (не бажано)"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-"Вказати розмір вікна, наприклад: 80x24 або 80x24+200+200 (СТОВПЦІxРЯДКИ+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "ГЕОМЕТРІЯ"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-"Відкриває вікно в обвальному режимі або перемикає видимість поточного "
-"обвального режиму"
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr "Показати версії Terminix і компонентів"
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "Прихований аргумент, який передається в UUID терміналу"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"Схоже, це помилка в налаштуваннях терміналу.\n"
-"Це несерйозна помилка, однак її виправлення покращить роботу.\n"
-"Натисніть на посилання нижче для подробиць:"
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "Виявлено проблему в налаштуваннях"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "Більше не показувати це повідомлення"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "Переглянути бокову панель сеансів"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "Створити новий сеанс"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "Додати термінал праворуч"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "Додати термінал додолу"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "Знайти текст у терміналі"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "Змінити назву сеансу"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "Ввести нову назву для сеансу"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "Відкрити…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "Зберегти як…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "Назва…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "Синхронізувати введення"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-msgid "There are multiple sessions open, close anyway?"
-msgstr "Відкрито декілька сесій. Все одно закрити?"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "Усі файли JSON"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "Файл з назвою «%s» не існує"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "Завантажити сеанс"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "Відкрити"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "Неможливо завантажити сеанс через неочікувану помилку."
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "Помилка завантаження сеансу"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "Зберегти сеанс"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "Файл %s — не схема кольорів, яка сумісна з файлами JSON"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "Палітра схеми кольорів потребує 16 кольорів"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-msgid "Terminix Preferences"
-msgstr "Параметри Terminix"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "Загальне"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "Вигляд"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr "Обвал"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-msgid "Add profile"
-msgstr "Додати профіль"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-msgid "Delete profile"
-msgstr "Видалити профіль"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, c-format
-msgid "Profile: %s"
-msgstr "Профілі: %s"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr "Клонування"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-msgid "Use for new terminals"
-msgstr "Використовувати для нових терміналів"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "Кодування в меню:"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "Увімкнено"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "Дія"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "Клавіша скорочення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "Увімкнути скорочення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "Перезаписати наявні скорочення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"Скорочення  %s уже призначено на %s.\n"
-"Вимкнути скорочення для іншої дії і призначити сюди натомість?"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "Увімкнути прозорість, вимагає перезапуск"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "Вікно (%s)"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "Звичайний"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "вимкнено"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "Стиль заголовку термінала"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "Малий"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "Немає"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "Варіант теми"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "Світлий"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "Темний"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "Зображення тла"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "Вибрати зображення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "Усі файли зображення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "Скинути зображення тла"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "Шкала"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "Черепиця"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "Центр"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "Розтягнення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-msgid "Default session name"
-msgstr "Стандартне ім'я сесії"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-msgid "Application title"
-msgstr "Заголовок програми"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "Використовувати широкі відступи"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr "Розмістити бокову панель праворуч"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "Показувати назву терміналу, навіть якщо це єдиний термінал"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr "Розмір"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr "Висота у відсотках"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr "Ширина у відсотках"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr "Вирівнювання"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr "Ліворуч"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Right"
-msgstr "Праворуч"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "Параметри"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr "Показувати термінал на всіх робочих просторах"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr "Встановити властивість вікон для відключення анімації"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr "Ховати вікно, коли фокус втрачено"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-msgid "Hide the titlebar of the window"
-msgstr "Приховати заголовок вікна"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-msgid "Display terminal on active monitor"
-msgstr "Показувати термінал на основному екрані"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr "Показувати на певному екрані"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "Поведінка"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "Запитувати, якщо створюється новий сеанс"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "Фокусуватись на терміналі, коли мишка над ним"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "Автоматично ховати вказівник миші, коли щось вводите"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr "Закрити термінал натиском на середню кнопку миші на заголовку"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr "Зум терміналу використовуючи <Ctrl> і колесо мишки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr "Закрити вікно, коли останній сеанс закрито"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "Надсилати сповіщення, коли дія закінчиться"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "Відкривати новий термінал"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "Розділити праворуч"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "Розділити додолу"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "Сфокусувати вікно"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr "Завжди використовувати розширений діалог вставки"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "Попереджати про небезпечні вставлення"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr ""
-"Обрізати перший символ вставлення, якщо це коментар або оголошення змінної"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "Автоматично копіювати текст у буфер, коли його вибираєте"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "Загальне"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "Колір"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "Прокручування"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "Сумісність"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "Додатково"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "Назва профілю"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "Розмір терміналу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "стовпці"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "рядки"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "Курсор"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "Блок"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "IBeam"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "Підкреслення"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "Режим блимання"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "Система"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "Увімкнено"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "Вимкнено"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "Звук"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "Піктограма та звук"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "Заголовок терміналу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr "Позиція знака"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr "Північний захід"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr "Північний схід"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr "Південний захід"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southeast"
-msgstr "Південний схід"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "Вигляд тексту"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "Дозволити жирний текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "Підлаштовувати під розмір"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "Інший шрифт"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "Виберіть шрифт терміналу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "Ідентифікатор: %s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "Схема кольорів"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "Інша"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr "Експорт"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "Палітра кольорів"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "Використовувати кольори для тексту й тла"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "Прозорість"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "Несфокусоване затемнювання"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "Текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "Тло"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "Вибрати колір тексту курсора"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "Вибрати колір тла курсора"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "Підсвічування"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "Вибрати колір підсвічування тексту"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "Вибрати колір підсвічування тла"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "Затемнювання"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "Вибрати колір затемнювання"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-msgid "Select Badge Color"
-msgstr "Вибрати колір значка"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "Вибрати колір тла"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "Вибрати колір тексту"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "Текст"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "Чорний"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "Червоний"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "Зелений"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "Оранжевий"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "Синій"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "Фіолетовий"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "Бірюзовий"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "Сірий"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "Вибрати %s колір"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "Вибрати світлий %s колір"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-msgid "Export Color Scheme"
-msgstr "Експорт кольорової схеми"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "Показувати прокручування"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "Прокручувати при виведенні"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "Прокручувати клавішами"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "Обмежено прокручування до:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "Клавіша «Backspace» породжує"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "Автоматично"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "Керівні послідовності"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "Клавіша «Delete» породжує"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "Неоднозначної ширини символи"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "Вузькі"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "Широкі"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "Запустити команду як оболонку входу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "Запустити іншу команду замість моєї оболонки"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "Коли виходите з команди"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "Вийти з терміналу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "Перезапустити команду"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "Утримувати термінал відкритим"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "Власні посилання"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-"перелік користувацьких посилань, на які можна натиснути в терміналі на "
-"основі означень формальних виразів."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr "Перемикачі"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-"Перемикачі — формальні вирази, які перевіряють текст виводу в терміналі. "
-"Коли виникає збіг, виконується певна налаштована дії."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "Автоматичне перемикання профілів"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"Профілі автоматично вибирають на основі значення введених тут.\n"
-"Значення введено через формат <i>користувач@вузол:каталог</i>. Або вузол, "
-"або каталог можуть бути порожні, але стовпці мають бути. Записи без вузла і "
-"каталогу — заборонені."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"Профілі автоматично вибирають на основі значення введених тут.\n"
-"Значення введено через формат <i>вузол:каталог</i>. Або вузол, або каталог "
-"можуть бути порожні, але стовпці мають бути. Записи без вузла і каталогу — "
-"заборонені."
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "Збіги"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "Додати"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr "Ввести користувач@вузол:каталог для збігу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "Введіть вузол:каталог для збігу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "Додати новий збіг"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr "Редагувати користувач@вузол:каталог для збігу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "Редагувати вузол:каталог для збігу"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "Редагувати збіг"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "Формальний вираз"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "Без урахування регістру"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "Редагувати власні посилання"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr "Параметр"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr "Обмежити кількість рядків для обробки запуску до:"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Edit Triggers"
-msgstr "Редагувати перемикачі"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "Вікно"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1870,42 +1792,136 @@ msgstr ""
 "Неможливо використовувати випадаючий режим з параметрами: розгорнути, "
 "згорнути, на весь екран чи геометрія"
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
-msgstr "Оновити стан"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-msgid "ExecuteCommand"
-msgstr "Виконати команду"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:586
+#, fuzzy
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "Неможливо завантажити сеанс через неочікувану помилку."
+
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "Вибрати %s колір"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "Вибрати %s колір"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "Вибрати все"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+#, fuzzy
+msgid "Parameters"
+msgstr "Параметр"
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "Вибрати колір значка"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "вимкнено"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "Версія GTK — застара, потрібно щонайменше GTK %d.%d.%d!"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "Трапився неочікувана виняток"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "Помилка: "
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "Перське"
+
+#: source/app.d:139
+#, fuzzy, c-format
+msgid "Terminix version: %s"
+msgstr "Відкрити Terminix в %s"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "Відкрити Terminix в %s"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "Параметри Terminix"
+
+#: source/app.d:143
+#, fuzzy
+msgid "Notifications enabled=%b"
 msgstr "Надіслати сповіщення"
 
-#: source/gx/terminix/preferences.d:215
-msgid "UpdateTitle"
-msgstr "Оновити заголовок"
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr "Дати гудок"
-
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr "Надіслати повідомлення"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr "Вставити пароль"
-
-#: source/gx/terminix/preferences.d:219
-msgid "UpdateBadge"
-msgstr "Оновити значок"
-
-#: source/gx/terminix/preferences.d:326
-#, c-format
-msgid "%s (Copy)"
-msgstr "%s (Копіювати)"
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 #: data/nautilus/open-terminix.py:108
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-08-09 00:53+0000\n"
 "Last-Translator: Mingcong Bai <jeffbai@aosc.xyz>\n"
 "Language-Team: Chinese (China) <https://hosted.weblate.org/projects/terminix/"
@@ -16,180 +16,1562 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.8-dev\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
-msgstr "你的 GTK 版本太老，需要至少 GTK %d.%d.%d！"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
+msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr "发生未预期错误"
-
-#: source/app.d:128
-msgid "Error: "
-msgstr "错误： "
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "波斯"
+msgid "ExecuteCommand"
+msgstr "命令"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "标题"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+#, fuzzy
+msgid "SendText"
+msgstr "文字"
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "标题"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "在 %s 打开 Terminix"
+msgid "%s (Copy)"
+msgstr "复制"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "在 %s 打开 Terminix"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "常规"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "打开首选项"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-msgid "disabled"
-msgstr "已禁用"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "选择 %s 个颜色"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "选择 %s 个颜色"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr "确定"
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr "取消"
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "名称"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "全选"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "命令"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "颜色"
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "滚动"
 
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "兼容性"
 
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr ""
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
+msgstr "高级选项"
 
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Bookmark"
-msgstr "选择 %s 个颜色"
+#: source/gx/terminix/prefeditor/profileeditor.d:216
+msgid "Profile name"
+msgstr "配置方案名称"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+msgid "Terminal size"
+msgstr "终端大小"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "列"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "行"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "重置"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "光标"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "方块"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "下划线"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+msgid "Blink mode"
+msgstr "闪烁模式"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "系统"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "开启"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "关闭"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+msgid "Terminal bell"
+msgstr "终端响铃"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr "无"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr "声音"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr "图标"
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
+msgstr "图标和声音"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:301
+msgid "Terminal title"
+msgstr "终端标题"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Southeast"
+msgstr "南欧"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "文本外观"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "允许粗体"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "缩放时重新换行"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+msgid "Custom font"
+msgstr "自定义字体"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "选择终端字体"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID：%s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "配色方案"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "自定义"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "调色板"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "选项"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "为前景/背景色使用主题颜色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "透明度"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr "失去焦点时黯淡"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr "文字"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "背景"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+msgid "Select Cursor Foreground Color"
+msgstr "选择前景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+msgid "Select Cursor Background Color"
+msgstr "选择背景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr "高亮"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+msgid "Select Highlight Foreground Color"
+msgstr "选择高亮前景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+msgid "Select Highlight Background Color"
+msgstr "选择高亮背景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr "黯淡"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+msgid "Select Dim Color"
+msgstr "选择黯淡颜色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "选择 %s 个颜色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "选择背景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "选择前景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "前景"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "黑色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "红色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "绿色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "橙色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "蓝色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "紫色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "绿松色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "灰"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "选择 %s 个颜色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "选择 %s 个淡色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "配色方案"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "保存"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr "取消"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr "所有 JSON 文件"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr "所有文件"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "显示滚动条"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "输出时滚动"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "击键时滚动"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "回滚限制："
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "按 Backspace 键产生"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "自动"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "转义序列"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "按 Delete 键产生"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "编码"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "模糊宽度字符"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "窄"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "宽"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "运行作为登录程序的命令"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "运行自定义命令而不是我的命令行外壳"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "命令退出时"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "退出终端"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "重启命令"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "保持终端开启"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+msgid "Custom Links"
+msgstr "自定义链接"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr "可根据正则表达式定义点击终端上一系列的用户定义链接。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "编辑"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr "自动切换配置档案"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+#, fuzzy
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+"根据此处输入的值自动选择配置档案。\n"
+"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
+"号。不允许同时忽略主机名和目录。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+"根据此处输入的值自动选择配置档案。\n"
+"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
+"号。不允许同时忽略主机名和目录。"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+msgid "Match"
+msgstr "匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr "添加"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+#, fuzzy
+msgid "Enter username@hostname:directory to match"
+msgstr "输入主机名:目录以匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr "输入主机名:目录以匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr "添加新匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+#, fuzzy
+msgid "Edit username@hostname:directory to match"
+msgstr "编辑主机名:目录以匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr "编辑主机名:目录以匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr "编辑匹配"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "删除"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr "正则表达式"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr "不区分大小写"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr "编辑自定义链接"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr "应用"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "动作"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "编辑配置方案"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "终端"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "窗口"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "打开首选项"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "全局"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+msgid "Appearance"
+msgstr "外观"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "快捷键"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "编辑配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "新建配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "首选项"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "重置终端"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "菜单中显示的编码："
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "已启用"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "快捷键"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+msgid "Enable shortcuts"
+msgstr "启用快捷键"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr "覆盖已有快捷键"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+"快捷键 %s 已指派为 %s。\n"
+"禁用另一动作的快捷键并在此指派？"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr "开启透明终端，需要重启终端"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "窗口"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr "一般"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "已禁用"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+msgid "Terminal title style"
+msgstr "终端标题样式"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr "较小"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+msgid "Theme variant"
+msgstr "主题变种"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "默认"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "淡色"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "深色"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+msgid "Background image"
+msgstr "背景图像"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+msgid "Select Image"
+msgstr "选择图像"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr "所有图像文件"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+msgid "Reset background image"
+msgstr "重置背景图像"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr "缩放"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr "平铺"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr "居中"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr "拉伸"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "编辑会话名称"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "应用程序"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr "使用较宽的分割手柄"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "设置新终端的标题"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "淡色"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "设置新终端的标题"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "保存终端内容"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "行为"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "创建新会话时提示"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "在鼠标移入时激活终端"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "打字时自动隐藏鼠标指针"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "进程完成时发送桌面通知"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr "创建新实例时"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "新建窗口"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "新建会话"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "向下分割"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Focus Window"
+msgstr "聚焦窗口"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr "剪贴板"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "进行不安全复制时警告"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "如果粘贴内容为注释或变量声明则切除第一个字符"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr "选择时自动将文本复制到剪贴板"
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+msgid "Title"
+msgstr "标题"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "不再显示该信息"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "窗口"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "会话"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "应用程序"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "聚焦窗口"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "新建会话"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr "确定"
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr "命令正在请求计算机的管理员权限"
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr "从互联网复制命令有一定危险性。 "
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr "你应当确认命令每个部分的作用。"
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#, fuzzy
+msgid "Advanced Paste"
+msgstr "高级选项"
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "粘贴"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "名称"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "新建"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "搜索选项"
+
+#: source/gx/terminix/terminal/search.d:135
+msgid "Find next"
+msgstr "查找下一个"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:141
+msgid "Find previous"
+msgstr "查找上一个"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "区分大小写"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "全字匹配"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "使用正则表达式匹配"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "换行"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "关闭"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr "为此终端关闭输入同步"
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "只读"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "编辑配置方案"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "编码"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr "为此终端启用输入同步"
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "查找…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "选择 %s 个颜色"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+msgid "Save Output…"
+msgstr "保存输出…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr "重置并清空"
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr "布局选项…"
+
+#: source/gx/terminix/terminal/terminal.d:736
+#, fuzzy
+msgid "Other"
+msgstr "其他"
+
+#: source/gx/terminix/terminal/terminal.d:745
+msgid "Add Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr "向下分割"
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr "恢复"
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr "打开链接"
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr "复制链接地址"
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "复制"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "全选"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+msgid "Synchronize input"
+msgstr "同步输入"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr "发生未知错误，无其他可用信息"
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr "发生未知错误：%s"
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr "保存终端输出"
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr "所有文本文件"
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr "子进程以 %d 状态正常退出"
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr "子进程被 %d 信号中止。"
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr "子进程已被中止。"
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr "重新启动"
+
+#: source/gx/terminix/terminal/terminal.d:3281
+msgid "Don't Paste"
+msgstr "不要粘贴"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr "依然粘贴"
+
+#: source/gx/terminix/terminal/layout.d:30
+msgid "Layout Options"
+msgstr "布局选项"
+
+#: source/gx/terminix/terminal/layout.d:45
+msgid "Active"
+msgstr "会话活动"
+
+#: source/gx/terminix/terminal/layout.d:69
+msgid "Session Load"
+msgstr "载入会话"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+"会话活动选项一直生效且立即应用。\n"
+"会话载入选项仅在载入会话文件时生效。"
+
+#: source/gx/terminix/appwindow.d:320
+msgid "View session sidebar"
+msgstr "显示会话侧边栏"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "创建会话"
+
+#: source/gx/terminix/appwindow.d:363
+msgid "Add terminal right"
+msgstr "右侧新建终端"
+
+#: source/gx/terminix/appwindow.d:367
+msgid "Add terminal down"
+msgstr "下侧新建终端"
+
+#: source/gx/terminix/appwindow.d:373
+msgid "Find text in terminal"
+msgstr "在终端查找文本"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "更改会话名称"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "为会话新建名称"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr "打开…"
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "另存为…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "名称…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "同步输入"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr "GC"
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "仍有正在运行的进程，依然要关闭吗？"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "文件名“%s”不存在"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "载入会话"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr "打开"
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "发生未知错误，无法载入会话。"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+msgid "Error Loading Session"
+msgstr "载入会话出错"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "保存会话"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "关于"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "退出"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr ""
+"Mingcong Bai\n"
+"Mingye Wang"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
+msgstr "感谢名单"
+
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "设置终端的工作目录"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
+msgstr "DIRECTORY"
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "设置启动配置文件"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr "PROFILE_NAME"
+
+#: source/gx/terminix/application.d:625
+msgid "Set the title of the new terminal"
+msgstr "设置新终端的标题"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr "标题"
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "打开指定会话"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr "SESSION_NAME"
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "向当前 Terminix 实例发送动作"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr "ACTION_NAME"
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "执行传入的命令"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:629
+msgid "Maximize the terminal window"
+msgstr "最大化终端窗口"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "最大化终端窗口"
+
+#: source/gx/terminix/application.d:631
+msgid "Full-screen the terminal window"
+msgstr "全屏终端窗口"
+
+#: source/gx/terminix/application.d:632
+msgid "Focus the existing window"
+msgstr "焦点集中到已有窗口"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr "将附加实例作为新进程启动（不推荐）"
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr "设置窗口大小；例如：80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr "尺寸"
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
 msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr "传入终端 UUID 的隐藏参数"
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr "TERMINAL_UUID"
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"终端配置似乎存在问题。这并不是严重问题，但是更正这些问题将改善你的使用体验。"
+"点击如下链接以获取更多信息："
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "检测到配置问题"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "不再显示该信息"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr "文件 %s 不是兼容的 JSON 颜色主题文件"
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr "颜色主题色板需要 16 个颜色"
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "无法定位放置的终端"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "无法定位放置的终端的会话"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -216,80 +1598,46 @@ msgstr "GtkD 提供了优秀的 GTK 封装"
 msgid "Dlang.org for such an excellent language, D"
 msgstr "Dlang.org 提供了优秀的编程语言，D 语言"
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-msgid "Title"
-msgstr "标题"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "应用程序"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "列"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "应用程序"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "载入会话"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "会话"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "无法定位放置的终端"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "无法定位放置的终端的会话"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "默认"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "配置方案"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "新建会话"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -429,1427 +1777,6 @@ msgstr "越南语"
 msgid "Thai"
 msgstr "泰语"
 
-#: source/gx/terminix/terminal/layout.d:30
-msgid "Layout Options"
-msgstr "布局选项"
-
-#: source/gx/terminix/terminal/layout.d:45
-msgid "Active"
-msgstr "会话活动"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-msgid "Session Load"
-msgstr "载入会话"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-"会话活动选项一直生效且立即应用。\n"
-"会话载入选项仅在载入会话文件时生效。"
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "终端"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "关闭"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr "为此终端关闭输入同步"
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "只读"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-msgid "Terminal bell"
-msgstr "终端响铃"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "编辑配置方案"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "编码"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr "为此终端启用输入同步"
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-msgid "Save Output…"
-msgstr "保存输出…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "重置"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr "重置并清空"
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "配置方案"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "编码"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "选择 %s 个颜色"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "查找…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr "布局选项…"
-
-#: source/gx/terminix/terminal/terminal.d:737
-msgid "Add Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr "向下分割"
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr "恢复"
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr "打开链接"
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr "复制链接地址"
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "复制"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "粘贴"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "全选"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr "剪贴板"
-
-#: source/gx/terminix/terminal/terminal.d:1465
-msgid "Synchronize input"
-msgstr "同步输入"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr "发生未知错误，无其他可用信息"
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr "发生未知错误：%s"
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr "保存终端输出"
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "保存"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr "所有文本文件"
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr "所有文件"
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr "子进程以 %d 状态正常退出"
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr "子进程被 %d 信号中止。"
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr "子进程已被中止。"
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr "重新启动"
-
-#: source/gx/terminix/terminal/terminal.d:3259
-msgid "Don't Paste"
-msgstr "不要粘贴"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr "依然粘贴"
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "搜索选项"
-
-#: source/gx/terminix/terminal/search.d:135
-msgid "Find next"
-msgstr "查找下一个"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:141
-msgid "Find previous"
-msgstr "查找上一个"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "区分大小写"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "全字匹配"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "使用正则表达式匹配"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "换行"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr "命令正在请求计算机的管理员权限"
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr "从互联网复制命令有一定危险性。 "
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr "你应当确认命令每个部分的作用。"
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-#, fuzzy
-msgid "Advanced Paste"
-msgstr "高级选项"
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "新建"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "编辑"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "删除"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr "应用"
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "不再显示该信息"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "窗口"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "会话"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "应用程序"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "聚焦窗口"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "新建会话"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "新建窗口"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "首选项"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "快捷键"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "关于"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "退出"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr "感谢名单"
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "设置终端的工作目录"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr "DIRECTORY"
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "设置启动配置文件"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr "PROFILE_NAME"
-
-#: source/gx/terminix/application.d:624
-msgid "Set the title of the new terminal"
-msgstr "设置新终端的标题"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr "标题"
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "打开指定会话"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr "SESSION_NAME"
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "向当前 Terminix 实例发送动作"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr "ACTION_NAME"
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "执行传入的命令"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-msgid "Maximize the terminal window"
-msgstr "最大化终端窗口"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "最大化终端窗口"
-
-#: source/gx/terminix/application.d:630
-msgid "Full-screen the terminal window"
-msgstr "全屏终端窗口"
-
-#: source/gx/terminix/application.d:631
-msgid "Focus the existing window"
-msgstr "焦点集中到已有窗口"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr "将附加实例作为新进程启动（不推荐）"
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr "设置窗口大小；例如：80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr "尺寸"
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr "传入终端 UUID 的隐藏参数"
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr "TERMINAL_UUID"
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"终端配置似乎存在问题。这并不是严重问题，但是更正这些问题将改善你的使用体验。"
-"点击如下链接以获取更多信息："
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "检测到配置问题"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "不再显示该信息"
-
-#: source/gx/terminix/appwindow.d:320
-msgid "View session sidebar"
-msgstr "显示会话侧边栏"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "创建会话"
-
-#: source/gx/terminix/appwindow.d:363
-msgid "Add terminal right"
-msgstr "右侧新建终端"
-
-#: source/gx/terminix/appwindow.d:367
-msgid "Add terminal down"
-msgstr "下侧新建终端"
-
-#: source/gx/terminix/appwindow.d:373
-msgid "Find text in terminal"
-msgstr "在终端查找文本"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "更改会话名称"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "为会话新建名称"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr "打开…"
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "另存为…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "名称…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "同步输入"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr "GC"
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "仍有正在运行的进程，依然要关闭吗？"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr "所有 JSON 文件"
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "文件名“%s”不存在"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "载入会话"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr "打开"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "发生未知错误，无法载入会话。"
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Error Loading Session"
-msgstr "载入会话出错"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "保存会话"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr "文件 %s 不是兼容的 JSON 颜色主题文件"
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr "颜色主题色板需要 16 个颜色"
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "打开首选项"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "全局"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-msgid "Appearance"
-msgstr "外观"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "编辑配置方案"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "新建配置方案"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "配置方案"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "重置终端"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "菜单中显示的编码："
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "已启用"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "动作"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "快捷键"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-msgid "Enable shortcuts"
-msgstr "启用快捷键"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr "覆盖已有快捷键"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-"快捷键 %s 已指派为 %s。\n"
-"禁用另一动作的快捷键并在此指派？"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr "开启透明终端，需要重启终端"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "窗口"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr "一般"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "已禁用"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-msgid "Terminal title style"
-msgstr "终端标题样式"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr "较小"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr "无"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-msgid "Theme variant"
-msgstr "主题变种"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "淡色"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "深色"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-msgid "Background image"
-msgstr "背景图像"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-msgid "Select Image"
-msgstr "选择图像"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr "所有图像文件"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-msgid "Reset background image"
-msgstr "重置背景图像"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr "缩放"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr "平铺"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr "居中"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr "拉伸"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "编辑会话名称"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "应用程序"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr "使用较宽的分割手柄"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "设置新终端的标题"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "淡色"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "选项"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "设置新终端的标题"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "保存终端内容"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "行为"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "创建新会话时提示"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "在鼠标移入时激活终端"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "打字时自动隐藏鼠标指针"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "进程完成时发送桌面通知"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr "创建新实例时"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "向下分割"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Focus Window"
-msgstr "聚焦窗口"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "进行不安全复制时警告"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "如果粘贴内容为注释或变量声明则切除第一个字符"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr "选择时自动将文本复制到剪贴板"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "常规"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "颜色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "滚动"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "兼容性"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr "高级选项"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-msgid "Profile name"
-msgstr "配置方案名称"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-msgid "Terminal size"
-msgstr "终端大小"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "列"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "行"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "光标"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "方块"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "IBeam"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "下划线"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-msgid "Blink mode"
-msgstr "闪烁模式"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "系统"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "开启"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "关闭"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr "声音"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr "图标和声音"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-msgid "Terminal title"
-msgstr "终端标题"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "南欧"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "文本外观"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "允许粗体"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "缩放时重新换行"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-msgid "Custom font"
-msgstr "自定义字体"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "选择终端字体"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID：%s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "配色方案"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "自定义"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "调色板"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "为前景/背景色使用主题颜色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "透明度"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr "失去焦点时黯淡"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr "文字"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "背景"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-msgid "Select Cursor Foreground Color"
-msgstr "选择前景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-msgid "Select Cursor Background Color"
-msgstr "选择背景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr "高亮"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-msgid "Select Highlight Foreground Color"
-msgstr "选择高亮前景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-msgid "Select Highlight Background Color"
-msgstr "选择高亮背景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr "黯淡"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-msgid "Select Dim Color"
-msgstr "选择黯淡颜色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "选择 %s 个颜色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "选择背景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "选择前景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "前景"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "黑色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "红色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "绿色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "橙色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "蓝色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "紫色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "绿松色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "灰"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "选择 %s 个颜色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "选择 %s 个淡色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "配色方案"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "显示滚动条"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "输出时滚动"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "击键时滚动"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "回滚限制："
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "按 Backspace 键产生"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "自动"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "转义序列"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "按 Delete 键产生"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "模糊宽度字符"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "窄"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "宽"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "运行作为登录程序的命令"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "运行自定义命令而不是我的命令行外壳"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "命令退出时"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "退出终端"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "重启命令"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "保持终端开启"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-msgid "Custom Links"
-msgstr "自定义链接"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr "可根据正则表达式定义点击终端上一系列的用户定义链接。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr "自动切换配置档案"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-#, fuzzy
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-"根据此处输入的值自动选择配置档案。\n"
-"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
-"号。不允许同时忽略主机名和目录。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-"根据此处输入的值自动选择配置档案。\n"
-"此处输入的值的格式为 <i>主机名:目录</i>。可忽略主机名或目录其一，但不能省去冒"
-"号。不允许同时忽略主机名和目录。"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-msgid "Match"
-msgstr "匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr "添加"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-#, fuzzy
-msgid "Enter username@hostname:directory to match"
-msgstr "输入主机名:目录以匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr "输入主机名:目录以匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr "添加新匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-#, fuzzy
-msgid "Edit username@hostname:directory to match"
-msgstr "编辑主机名:目录以匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr "编辑主机名:目录以匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr "编辑匹配"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr "正则表达式"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr "不区分大小写"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr "编辑自定义链接"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "编辑配置方案"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "窗口"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1882,46 +1809,134 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
-#, fuzzy
-msgid "ExecuteCommand"
-msgstr "命令"
-
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "标题"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "发生未知错误，无法载入会话。"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:217
-#, fuzzy
-msgid "SendText"
-msgstr "文字"
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:219
-#, fuzzy
-msgid "UpdateBadge"
-msgstr "标题"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Folder"
+msgstr "选择 %s 个颜色"
+
+#: source/gx/terminix/bookmark/bmeditor.d:74
+#, fuzzy
+msgid "Select folder"
+msgstr "选择 %s 个颜色"
+
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "全选"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "选择 %s 个颜色"
+
+#: source/gx/gtk/actions.d:25
+msgid "disabled"
+msgstr "已禁用"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr "你的 GTK 版本太老，需要至少 GTK %d.%d.%d！"
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr "发生未预期错误"
+
+#: source/app.d:128
+msgid "Error: "
+msgstr "错误： "
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "波斯"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "复制"
+msgid "Terminix version: %s"
+msgstr "在 %s 打开 Terminix"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "在 %s 打开 Terminix"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "打开首选项"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 # ******************
 # Nautilus extension

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Terminix 20160222\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-05 18:40-0500\n"
+"POT-Creation-Date: 2017-02-14 10:42+0100\n"
 "PO-Revision-Date: 2016-11-08 15:29+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) <https://hosted.weblate.org/projects/"
@@ -17,181 +17,1585 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.9\n"
 
-#: source/app.d:110
-#, c-format
-msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+#: source/gx/terminix/preferences.d:212
+msgid "UpdateState"
 msgstr ""
 
-#: source/app.d:127
-msgid "Unexpected exception occurred"
-msgstr ""
-
-#: source/app.d:128
-msgid "Error: "
-msgstr ""
-
-#: source/app.d:138
+#: source/gx/terminix/preferences.d:213
 #, fuzzy
-msgid "Versions"
-msgstr "波斯"
+msgid "ExecuteCommand"
+msgstr "指令"
 
-#: source/app.d:139
+#: source/gx/terminix/preferences.d:214
+msgid "SendNotification"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:215
+#, fuzzy
+msgid "UpdateTitle"
+msgstr "標題"
+
+#: source/gx/terminix/preferences.d:216
+msgid "PlayBell"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:217
+msgid "SendText"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:218
+msgid "InsertPassword"
+msgstr ""
+
+#: source/gx/terminix/preferences.d:219
+#, fuzzy
+msgid "UpdateBadge"
+msgstr "標題"
+
+#: source/gx/terminix/preferences.d:326
 #, fuzzy, c-format
-msgid "Terminix version: %s"
-msgstr "在 %s 開啟 Terminix"
+msgid "%s (Copy)"
+msgstr "複製"
 
-#: source/app.d:140
-#, fuzzy, c-format
-msgid "VTE version: %s"
-msgstr "在 %s 開啟 Terminix"
+#: source/gx/terminix/prefeditor/profileeditor.d:99
+msgid "General"
+msgstr "常規"
 
-#: source/app.d:141
-#, c-format
-msgid "GTK Version: %d.%d.%d"
-msgstr ""
-
-#: source/app.d:142
-#, fuzzy
-msgid "Terminix Special Features"
-msgstr "偏好設定"
-
-#: source/app.d:143
-msgid "Notifications enabled=%b"
-msgstr ""
-
-#: source/app.d:144
-msgid "Triggers enabled=%b"
-msgstr ""
-
-#: source/app.d:145
-msgid "Badges enabled=%b"
-msgstr ""
-
-#: source/gx/gtk/actions.d:25
-#, fuzzy
-msgid "disabled"
-msgstr "已啟用"
-
-#: source/gx/terminix/bookmark/bmeditor.d:68
-#: source/gx/terminix/bookmark/bmchooser.d:104
-#, fuzzy
-msgid "Select Folder"
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/bookmark/bmeditor.d:74
-#, fuzzy
-msgid "Select folder"
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/bookmark/bmeditor.d:86
-msgid "Clear folder"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Add Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:147
-msgid "Edit Bookmark"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195
-msgid "OK"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:148
-#: source/gx/terminix/bookmark/bmchooser.d:105
-#: source/gx/terminix/terminal/layout.d:30
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/terminal/advpaste.d:137
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/terminal/password.d:481
-#: source/gx/terminix/closedialog.d:195 source/gx/terminix/appwindow.d:1274
-#: source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Cancel"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:228
-#: source/gx/terminix/bookmark/bmtreeview.d:74
-#: source/gx/terminix/session.d:1428 source/gx/terminix/terminal/password.d:133
-#: source/gx/terminix/terminal/password.d:425
-msgid "Name"
-msgstr "名稱"
-
-#: source/gx/terminix/bookmark/bmeditor.d:289
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Path"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:291
-#, fuzzy
-msgid "Select Path"
-msgstr "全選"
-
-#: source/gx/terminix/bookmark/bmeditor.d:330
-#: source/gx/terminix/bookmark/bmeditor.d:425
-#: source/gx/terminix/bookmark/manager.d:623
-#: source/gx/terminix/terminal/layout.d:76
 #: source/gx/terminix/prefeditor/profileeditor.d:100
 #: source/gx/terminix/prefeditor/profileeditor.d:1030
 #: source/gx/terminix/prefeditor/profileeditor.d:1328
+#: source/gx/terminix/terminal/layout.d:76
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:330
+#: source/gx/terminix/bookmark/bmeditor.d:425
 msgid "Command"
 msgstr "指令"
 
-#: source/gx/terminix/bookmark/bmeditor.d:379
-msgid "Protocol"
+#: source/gx/terminix/prefeditor/profileeditor.d:101
+msgid "Color"
+msgstr "顏色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:102
+msgid "Scrolling"
+msgstr "滾動"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:103
+msgid "Compatibility"
+msgstr "相容性"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:489
+msgid "Advanced"
 msgstr ""
 
-#: source/gx/terminix/bookmark/bmeditor.d:395
-msgid "Host"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:411
-msgid "User"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmeditor.d:418
-msgid "Parameters"
-msgstr ""
-
-#: source/gx/terminix/bookmark/bmchooser.d:104
+#: source/gx/terminix/prefeditor/profileeditor.d:216
 #, fuzzy
-msgid "Select Bookmark"
-msgstr "選擇 %s 個顏色"
+msgid "Profile name"
+msgstr "配置方案名稱"
 
-#: source/gx/terminix/bookmark/bmtreeview.d:71
-#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/prefeditor/profileeditor.d:240
+#, fuzzy
+msgid "Terminal size"
+msgstr "終端大小"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:250
+msgid "columns"
+msgstr "行"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:256
+msgid "rows"
+msgstr "列"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:261
+#: source/gx/terminix/terminal/terminal.d:727
+msgid "Reset"
+msgstr "重置"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:272
+#: source/gx/terminix/prefeditor/profileeditor.d:569
+msgid "Cursor"
+msgstr "游標"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Block"
+msgstr "方塊"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "IBeam"
+msgstr "IBeam"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:275
+msgid "Underline"
+msgstr "下劃線"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:283
+#, fuzzy
+msgid "Blink mode"
+msgstr "閃爍模式"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "System"
+msgstr "系統"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "On"
+msgstr "開啟"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:286
+msgid "Off"
+msgstr "關閉"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:292
+#: source/gx/terminix/terminal/terminal.d:379
+#, fuzzy
+msgid "Terminal bell"
+msgstr "終端響鈴"
+
 #: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "None"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Sound"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+#: source/gx/terminix/closedialog.d:119
+#: source/gx/terminix/bookmark/bmtreeview.d:71
 msgid "Icon"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:226
-msgid "Error deserializing bookmark"
+#: source/gx/terminix/prefeditor/profileeditor.d:295
+msgid "Icon and Sound"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:501
-msgid "Root"
-msgstr ""
-
-#: source/gx/terminix/bookmark/manager.d:569
+#: source/gx/terminix/prefeditor/profileeditor.d:301
 #, fuzzy
-msgid "Could not load bookmarks due to unexpected error"
+msgid "Terminal title"
+msgstr "終端標題"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:313
+#: source/gx/terminix/prefeditor/profileeditor.d:605
+#: source/gx/terminix/terminal/layout.d:60
+msgid "Badge"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:323
+msgid "Badge position"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Northeast"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+msgid "Southwest"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:327
+#, fuzzy
+msgid "Southeast"
+msgstr "南歐"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:338
+msgid "Text Appearance"
+msgstr "文字外觀"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:344
+msgid "Allow bold text"
+msgstr "允許粗體"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:349
+msgid "Rewrap on resize"
+msgstr "縮放時重新換行"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:355
+#, fuzzy
+msgid "Custom font"
+msgstr "自訂字型"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:361
+msgid "Choose A Terminal Font"
+msgstr "選擇終端字型"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:381
+#, c-format
+msgid "ID: %s"
+msgstr "ID：%s"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:427
+msgid "Color scheme"
+msgstr "配色方案"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:437
+#: source/gx/terminix/prefeditor/profileeditor.d:884
+msgid "Custom"
+msgstr "自訂"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:450
+msgid "Export"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:462
+msgid "Color palette"
+msgstr "調色盤"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:470
+#: source/gx/terminix/prefeditor/prefdialog.d:1099
+msgid "Options"
+msgstr "選項"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:484
+msgid "Use theme colors for foreground/background"
+msgstr "為前景/背景色使用主題顏色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:502
+msgid "Transparency"
+msgstr "透明度"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:516
+msgid "Unfocused dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:564
+msgid "Text"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:565
+#: source/gx/terminix/prefeditor/profileeditor.d:669
+msgid "Background"
+msgstr "背景"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:576
+#, fuzzy
+msgid "Select Cursor Foreground Color"
+msgstr "選擇前景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:578
+#, fuzzy
+msgid "Select Cursor Background Color"
+msgstr "選擇背景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:583
+msgid "Highlight"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:588
+#, fuzzy
+msgid "Select Highlight Foreground Color"
+msgstr "選擇前景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:590
+#, fuzzy
+msgid "Select Highlight Background Color"
+msgstr "選擇背景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:595
+msgid "Dim"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:600
+#, fuzzy
+msgid "Select Dim Color"
+msgstr "選擇 %s 個顏色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:609
+#, fuzzy
+msgid "Select Badge Color"
+msgstr "選擇 %s 個顏色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:658
+msgid "Select Background Color"
+msgstr "選擇背景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:674
+#: source/gx/terminix/prefeditor/profileeditor.d:690
+msgid "Select Foreground Color"
+msgstr "選擇前景色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:689
+msgid "Foreground"
+msgstr "前景"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Black"
+msgstr "黑"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Red"
+msgstr "紅色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Green"
+msgstr "綠"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Orange"
+msgstr "橙色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Blue"
+msgstr "藍色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Purple"
+msgstr "紫色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Turquoise"
+msgstr "綠鬆色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:693
+msgid "Grey"
+msgstr "灰"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:699
+#, c-format
+msgid "Select %s Color"
+msgstr "選擇 %s 個顏色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:706
+#, c-format
+msgid "Select %s Light Color"
+msgstr "選擇 %s 個淡色"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:841
+#, fuzzy
+msgid "Export Color Scheme"
+msgstr "配色方案"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1312
+msgid "Save"
+msgstr "儲存"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:844
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/password.d:367
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/terminal.d:2718
+#: source/gx/terminix/terminal/layout.d:30 source/gx/terminix/appwindow.d:1278
+#: source/gx/terminix/appwindow.d:1312
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "Cancel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:857
+#: source/gx/terminix/appwindow.d:1232
+msgid "All JSON Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:861
+#: source/gx/terminix/prefeditor/prefdialog.d:953
+#: source/gx/terminix/terminal/terminal.d:2728
+#: source/gx/terminix/appwindow.d:1236
+msgid "All Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:916
+msgid "Show scrollbar"
+msgstr "顯示滾動條"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:920
+msgid "Scroll on output"
+msgstr "輸出時滾動"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:924
+msgid "Scroll on keystroke"
+msgstr "擊鍵時滾動"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:928
+msgid "Limit scrollback to:"
+msgstr "回滾限制："
+
+#: source/gx/terminix/prefeditor/profileeditor.d:963
+msgid "Backspace key generates"
+msgstr "按退格鍵生成"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Automatic"
+msgstr "自動"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Control-H"
+msgstr "Control-H"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "Escape sequence"
+msgstr "轉義序列"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:966
+#: source/gx/terminix/prefeditor/profileeditor.d:975
+msgid "TTY"
+msgstr "TTY"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:972
+msgid "Delete key generates"
+msgstr "按 Delete 鍵生成"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:981
+#: source/gx/terminix/prefeditor/prefdialog.d:154
+#: source/gx/terminix/prefeditor/prefdialog.d:155
+#: source/gx/terminix/prefeditor/prefdialog.d:407
+#: source/gx/terminix/prefeditor/prefdialog.d:615
+#: source/gx/terminix/terminal/terminal.d:732
+msgid "Encoding"
+msgstr "編碼"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:996
+msgid "Ambiguous-width characters"
+msgstr "模糊寬度字元"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Narrow"
+msgstr "窄"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:999
+msgid "Wide"
+msgstr "寬"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1020
+msgid "Run command as a login shell"
+msgstr "作為登入 shell 執行指令"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1024
+msgid "Run a custom command instead of my shell"
+msgstr "執行自訂指令而不是我的指令列外殼"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1040
+msgid "When command exits"
+msgstr "指令退出時"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Exit the terminal"
+msgstr "退出此終端"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Restart the command"
+msgstr "重啟該指令"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1042
+msgid "Hold the terminal open"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1081
+#, fuzzy
+msgid "Custom Links"
+msgstr "自訂字型"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1086
+msgid ""
+"A list of user defined links that can be clicked on in the terminal based on "
+"regular expression definitions."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1089
+#: source/gx/terminix/prefeditor/profileeditor.d:1116
+#: source/gx/terminix/prefeditor/profileeditor.d:1183
+#: source/gx/terminix/terminal/password.d:180
+msgid "Edit"
+msgstr "編輯"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1107
+msgid "Triggers"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1113
+msgid ""
+"Triggers are regular expressions that are used to check against output text "
+"in the terminal. When a match is detected the configured action is executed."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1133
+msgid "Automatic Profile Switching"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1141
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>username@hostname:directory</i> format. Either "
+"the hostname or directory can be omitted but the colon must be present. "
+"Entries with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1143
+msgid ""
+"Profiles are automatically selected based on the values entered here.\n"
+"Values are entered using a <i>hostname:directory</i> format. Either the "
+"hostname or directory can be omitted but the colon must be present. Entries "
+"with neither hostname or directory are not permitted."
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1154
+#, fuzzy
+msgid "Match"
+msgstr "區分大小寫"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1165
+#: source/gx/terminix/prefeditor/profileeditor.d:1353
+#: source/gx/terminix/prefeditor/profileeditor.d:1506
+msgid "Add"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1169
+msgid "Enter username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1171
+msgid "Enter hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1173
+msgid "Add New Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1190
+msgid "Edit username@hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1192
+msgid "Edit hostname:directory to match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1194
+msgid "Edit Match"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1202
+#: source/gx/terminix/prefeditor/profileeditor.d:1359
+#: source/gx/terminix/prefeditor/profileeditor.d:1512
+#: source/gx/terminix/prefeditor/prefdialog.d:496
+#: source/gx/terminix/terminal/password.d:209
+msgid "Delete"
+msgstr "刪除"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1316
+#: source/gx/terminix/prefeditor/profileeditor.d:1454
+msgid "Regex"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1340
+msgid "Case Insensitive"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+msgid "Edit Custom Links"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1385
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#: source/gx/terminix/terminal/password.d:367
+msgid "Apply"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1480
+#: source/gx/terminix/prefeditor/prefdialog.d:688
+msgid "Action"
+msgstr "動作"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1492
+msgid "Parameter"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1528
+msgid "Limit number of lines for trigger processing to:"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1554
+#, fuzzy
+msgid "Edit Triggers"
+msgstr "編輯配置檔"
+
+#: source/gx/terminix/prefeditor/profileeditor.d:1597
+#, c-format
+msgid "Row %d: "
+msgstr ""
+
+#: source/gx/terminix/prefeditor/titleeditor.d:90
+#: source/gx/terminix/terminal/terminal.d:315
+#: source/gx/terminix/terminal/terminal.d:3078
+msgid "Terminal"
+msgstr "終端"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:108
+#, fuzzy
+msgid "Window"
+msgstr "新建視窗"
+
+#: source/gx/terminix/prefeditor/titleeditor.d:118
+#: source/gx/terminix/prefeditor/titleeditor.d:119
+msgid "Help"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:117
+#, fuzzy
+msgid "Terminix Preferences"
+msgstr "偏好設定"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:134
+#: source/gx/terminix/prefeditor/prefdialog.d:135
+#: source/gx/terminix/prefeditor/prefdialog.d:203
+msgid "Global"
+msgstr "全局"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:138
+#: source/gx/terminix/prefeditor/prefdialog.d:139
+#, fuzzy
+msgid "Appearance"
+msgstr "外觀"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:142
+#: source/gx/terminix/prefeditor/prefdialog.d:143
+msgid "Quake"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:146
+#: source/gx/terminix/prefeditor/prefdialog.d:147
+msgid "Bookmarks"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:150
+#: source/gx/terminix/prefeditor/prefdialog.d:151
+#: source/gx/terminix/application.d:223
+msgid "Shortcuts"
+msgstr "快捷鍵"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:160
+#: source/gx/terminix/session.d:1439
+msgid "Profile"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:173
+#, fuzzy
+msgid "Add profile"
+msgstr "編輯配置檔"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:178
+#, fuzzy
+msgid "Delete profile"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:235
+#: source/gx/terminix/prefeditor/prefdialog.d:358
+#: source/gx/terminix/appwindow.d:654 source/gx/terminix/application.d:221
+msgid "Preferences"
+msgstr "偏好"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:255
+#: source/gx/terminix/terminal/terminal.d:720
+msgid "Profiles"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:279
+#: source/gx/terminix/prefeditor/prefdialog.d:287
+#, fuzzy, c-format
+msgid "Profile: %s"
+msgstr "配置方案"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:497
+msgid "Clone"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:501
+#, fuzzy
+msgid "Use for new terminals"
+msgstr "退出此終端"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:577
+msgid "Encodings showing in menu:"
+msgstr "選單中顯示的編碼："
+
+#: source/gx/terminix/prefeditor/prefdialog.d:613
+msgid "Enabled"
+msgstr "已啟用"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:719
+msgid "Shortcut Key"
+msgstr "快捷鍵"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:731
+#, fuzzy
+msgid "Enable shortcuts"
+msgstr "快捷鍵"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:759
+msgid "Overwrite Existing Shortcut"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:760
+#, c-format
+msgid ""
+"The shortcut %s is already assigned to %s.\n"
+"Disable the shortcut for the other action and assign here instead?"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:901
+msgid "Enable transparency, requires re-start"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:912
+#, fuzzy
+msgid "Window style"
+msgstr "新建視窗"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Normal"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+#, fuzzy
+msgid "Disable CSD"
+msgstr "已啟用"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Disable CSD, hide toolbar"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:914
+msgid "Borderless"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:918
+msgid "Window restart required"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:927
+#, fuzzy
+msgid "Terminal title style"
+msgstr "終端標題"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:928
+msgid "Small"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:934
+#, fuzzy
+msgid "Theme variant"
+msgstr "主題變種"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+#: source/gx/terminix/appwindow.d:880 source/gx/terminix/session.d:1120
+msgid "Default"
+msgstr "預設"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Light"
+msgstr "淡色"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:935
+msgid "Dark"
+msgstr "深色"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:941
+#, fuzzy
+msgid "Background image"
+msgstr "背景"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:943
+#, fuzzy
+msgid "Select Image"
+msgstr "全選"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:946
+msgid "All Image Files"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:967
+#, fuzzy
+msgid "Reset background image"
+msgstr "透明度"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Scale"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Tile"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Center"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:973
+msgid "Stretch"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:992
+#, fuzzy
+msgid "Default session name"
+msgstr "切換到會話 1"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1003
+#, fuzzy
+msgid "Application title"
+msgstr "動作"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1016
+msgid "Use a wide handle for splitters"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1021
+msgid "Place the sidebar on the right"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1025
+#, fuzzy
+msgid "Show the terminal title even if it's the only terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1057
+msgid "Size"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1068
+msgid "Height percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1079
+msgid "Width percent"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1089
+msgid "Alignment"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+msgid "Left"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1090
+#, fuzzy
+msgid "Right"
+msgstr "淡色"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1107
+msgid "Show terminal on all workspaces"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1112
+msgid "Set hint for window manager to disable animation"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1117
+msgid "Hide window when focus is lost"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1122
+#, fuzzy
+msgid "Hide the titlebar of the window"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1137
+#, fuzzy
+msgid "Display terminal on active monitor"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1144
+msgid "Display on specific monitor"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1186
+msgid "Behavior"
+msgstr "行為"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1192
+msgid "Prompt when creating a new session"
+msgstr "建立新會話時提示"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1197
+msgid "Focus a terminal when the mouse moves over it"
+msgstr "在滑鼠移入時啟用終端"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1202
+msgid "Autohide the mouse pointer when typing"
+msgstr "打字時自動隱藏滑鼠指針"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1207
+msgid "Close terminal by clicking middle mouse button on title"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1212
+msgid "Zoom the terminal using <Control> and scroll wheel"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1217
+msgid "Close window when last session is closed"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1223
+msgid "Send desktop notification on process complete"
+msgstr "程序完成時傳送桌面通知"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1231
+msgid "On new instance"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:217
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
+msgid "New Window"
+msgstr "新建視窗"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#: source/gx/terminix/application.d:216 source/gx/terminix/session.d:1462
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
+msgid "New Session"
+msgstr "新建會話"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+msgid "Split Down"
+msgstr "向下分割"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1234
+#, fuzzy
+msgid "Focus Window"
+msgstr "新建視窗"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1240
+#: source/gx/terminix/terminal/terminal.d:1459
+msgid "Clipboard"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1246
+msgid "Always use advanced paste dialog"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1251
+msgid "Warn when attempting unsafe paste"
+msgstr "進行不安全複製時警告"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1256
+msgid "Strip first character of paste if comment or variable declaration"
+msgstr "如果貼上內容為註釋或變數聲明則切除第一個字元"
+
+#: source/gx/terminix/prefeditor/prefdialog.d:1261
+msgid "Automatically copy text to clipboard when selecting"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
+msgid "Add bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
+msgid "Edit bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
+msgid "Delete bookmark"
+msgstr ""
+
+#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
+msgid "Unselect bookmark"
+msgstr ""
+
+#: source/gx/terminix/closedialog.d:113 source/gx/terminix/terminal/layout.d:51
+#: source/gx/terminix/constants.d:116
+#, fuzzy
+msgid "Title"
+msgstr "標題"
+
+#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
+#, fuzzy
+msgid "Do not show this again"
+msgstr "不再顯示該資訊"
+
+#: source/gx/terminix/closedialog.d:160
+#, fuzzy, c-format
+msgid "Window (%s)"
+msgstr "新建視窗"
+
+#: source/gx/terminix/closedialog.d:163
+#, fuzzy, c-format
+msgid "Session (%s)"
+msgstr "會話"
+
+#: source/gx/terminix/closedialog.d:183
+#, fuzzy
+msgid "Close Application"
+msgstr "動作"
+
+#: source/gx/terminix/closedialog.d:186
+#, fuzzy
+msgid "Close Window"
+msgstr "新建視窗"
+
+#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
+#, fuzzy
+msgid "Close Session"
+msgstr "新建會話"
+
+#: source/gx/terminix/closedialog.d:195
+#: source/gx/terminix/terminal/password.d:481
+#: source/gx/terminix/terminal/layout.d:30
+#: source/gx/terminix/bookmark/bmeditor.d:148
+#: source/gx/terminix/bookmark/bmchooser.d:105
+msgid "OK"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:33
+msgid "This command is asking for Administrative access to your computer"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:34
+msgid "Copying commands from the internet can be dangerous. "
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:35
+msgid "Be sure you understand what each part of this command does."
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:96
+msgid "Transform"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:104
+msgid "Convert spaces to tabs"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:115
+msgid "Convert CRLF and CR to LF"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+msgid "Advanced Paste"
+msgstr ""
+
+#: source/gx/terminix/terminal/advpaste.d:137
+#: source/gx/terminix/terminal/terminal.d:1440
+#: source/gx/terminix/terminal/terminal.d:1451
+msgid "Paste"
+msgstr "貼上"
+
+#: source/gx/terminix/terminal/password.d:133
+#: source/gx/terminix/terminal/password.d:425 source/gx/terminix/session.d:1428
+#: source/gx/terminix/bookmark/bmeditor.d:228
+#: source/gx/terminix/bookmark/bmtreeview.d:74
+msgid "Name"
+msgstr "名稱"
+
+#: source/gx/terminix/terminal/password.d:136
+#: source/gx/terminix/constants.d:118
+msgid "ID"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:157
+msgid "New"
+msgstr "新建"
+
+#: source/gx/terminix/terminal/password.d:231
+msgid "Include return character with password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:367
+msgid "Insert Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:433
+msgid "Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:441
+msgid "Confirm Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:487
+msgid "Add Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/password.d:492
+msgid "Edit Password"
+msgstr ""
+
+#: source/gx/terminix/terminal/search.d:122
+msgid "Search Options"
+msgstr "搜尋選項"
+
+#: source/gx/terminix/terminal/search.d:135
+#, fuzzy
+msgid "Find next"
+msgstr "查詢下一個"
+
+# ***********************************************
+# Keyboard shortcuts to the end, these are shown
+# in the Shortcut preferences and in the future
+# the shortcut overview if available in Gnome 3.20
+# ***********************************************
+#: source/gx/terminix/terminal/search.d:141
+#, fuzzy
+msgid "Find previous"
+msgstr "查詢上一個"
+
+#: source/gx/terminix/terminal/search.d:188
+msgid "Match case"
+msgstr "區分大小寫"
+
+#: source/gx/terminix/terminal/search.d:189
+msgid "Match entire word only"
+msgstr "只匹配整個單詞"
+
+#: source/gx/terminix/terminal/search.d:190
+msgid "Match as regular expression"
+msgstr "使用正規表示式匹配"
+
+#: source/gx/terminix/terminal/search.d:191
+msgid "Wrap around"
+msgstr "折列"
+
+#: source/gx/terminix/terminal/terminal.d:346
+#: source/gx/terminix/terminal/terminal.d:1469 source/gx/terminix/sidebar.d:362
+#: source/gx/terminix/appwindow.d:644
+msgid "Close"
+msgstr "關閉"
+
+#: source/gx/terminix/terminal/terminal.d:354
+#: source/gx/terminix/terminal/terminal.d:1092
+#: source/gx/terminix/terminal/terminal.d:1468
+#, fuzzy
+msgid "Maximize"
+msgstr "最大化"
+
+#: source/gx/terminix/terminal/terminal.d:364
+#: source/gx/terminix/terminal/terminal.d:604
+msgid "Disable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:373
+#: source/gx/terminix/terminal/terminal.d:710
+msgid "Read-Only"
+msgstr "只讀"
+
+#: source/gx/terminix/terminal/terminal.d:424
+msgid "Edit Profile"
+msgstr "編輯配置檔"
+
+#: source/gx/terminix/terminal/terminal.d:442
+#, fuzzy
+msgid "Edit Encodings"
+msgstr "編碼"
+
+#: source/gx/terminix/terminal/terminal.d:606
+msgid "Enable input synchronization for this terminal"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+#, c-format
+msgid ""
+"The library %s could not be loaded, password functionality is unavailable."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:635
+msgid "Library Not Loaded"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:709
+msgid "Find…"
+msgstr "查詢…"
+
+#: source/gx/terminix/terminal/terminal.d:714
+msgid "Password..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:715
+#, fuzzy
+msgid "Bookmark..."
+msgstr "選擇 %s 個顏色"
+
+#: source/gx/terminix/terminal/terminal.d:716
+msgid "Add Bookmark..."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:726
+#, fuzzy
+msgid "Save Output…"
+msgstr "另存為…"
+
+#: source/gx/terminix/terminal/terminal.d:728
+msgid "Reset and Clear"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:733
+msgid "Layout Options…"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:736
+msgid "Other"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:745
+#, fuzzy
+msgid "Add Right"
+msgstr "向右分割"
+
+#: source/gx/terminix/terminal/terminal.d:749
+msgid "Add Down"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1089
+#: source/gx/terminix/terminal/terminal.d:1468
+msgid "Restore"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1428
+msgid "Open Link"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1429
+msgid "Copy Link Address"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:1439
+#: source/gx/terminix/terminal/terminal.d:1446
+msgid "Copy"
+msgstr "複製"
+
+#: source/gx/terminix/terminal/terminal.d:1441
+#: source/gx/terminix/terminal/terminal.d:1456
+msgid "Select All"
+msgstr "全選"
+
+#: source/gx/terminix/terminal/terminal.d:1473
+#, fuzzy
+msgid "Synchronize input"
+msgstr "同步輸入"
+
+#: source/gx/terminix/terminal/terminal.d:1967
+#, c-format
+msgid "Custom link regex '%s' has an error, ignoring"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2105
+msgid "Unexpected error occurred, no additional information available"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2111
+#, c-format
+msgid "Unexpected error occurred: %s"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2715
+msgid "Save Terminal Output"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:2724
+msgid "All Text Files"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3228
+#, c-format
+msgid "The child process exited normally with status %d"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3229
+#, c-format
+msgid "The child process was aborted by signal %d."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3230
+msgid "The child process was aborted."
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3236
+msgid "Relaunch"
+msgstr ""
+
+#: source/gx/terminix/terminal/terminal.d:3281
+#, fuzzy
+msgid "Don't Paste"
+msgstr "貼上"
+
+#: source/gx/terminix/terminal/terminal.d:3282
+msgid "Paste Anyway"
+msgstr ""
+
+#: source/gx/terminix/terminal/layout.d:30
+#, fuzzy
+msgid "Layout Options"
+msgstr "選項"
+
+#: source/gx/terminix/terminal/layout.d:45
+#, fuzzy
+msgid "Active"
+msgstr "動作"
+
+#: source/gx/terminix/terminal/layout.d:69
+#, fuzzy
+msgid "Session Load"
+msgstr "會話"
+
+#: source/gx/terminix/terminal/layout.d:85
+msgid ""
+"Active options are always in effect and apply immediately.\n"
+"Session Load options only apply when loading a session file."
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:320
+#, fuzzy
+msgid "View session sidebar"
+msgstr "顯示側邊列"
+
+#: source/gx/terminix/appwindow.d:345
+msgid "Create a new session"
+msgstr "建立會話"
+
+#: source/gx/terminix/appwindow.d:363
+#, fuzzy
+msgid "Add terminal right"
+msgstr "切換到終端 10"
+
+#: source/gx/terminix/appwindow.d:367
+#, fuzzy
+msgid "Add terminal down"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/appwindow.d:373
+#, fuzzy
+msgid "Find text in terminal"
+msgstr "退出此終端"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Change Session Name"
+msgstr "更改會話名稱"
+
+#: source/gx/terminix/appwindow.d:586
+msgid "Enter a new name for the session"
+msgstr "為會話新建名稱"
+
+#: source/gx/terminix/appwindow.d:641
+msgid "Open…"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:643
+msgid "Save As…"
+msgstr "另存為…"
+
+#: source/gx/terminix/appwindow.d:648
+msgid "Name…"
+msgstr "名稱…"
+
+#: source/gx/terminix/appwindow.d:649
+msgid "Synchronize Input"
+msgstr "同步輸入"
+
+#: source/gx/terminix/appwindow.d:660
+msgid "GC"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:977
+#, fuzzy
+msgid "There are multiple sessions open, close anyway?"
+msgstr "仍有正在執行的程序，依然要關閉嗎？"
+
+#: source/gx/terminix/appwindow.d:1245
+#, c-format
+msgid "Filename '%s' does not exist"
+msgstr "檔名「%s」不存在"
+
+#: source/gx/terminix/appwindow.d:1275
+msgid "Load Session"
+msgstr "載入會話"
+
+#: source/gx/terminix/appwindow.d:1278
+msgid "Open"
+msgstr ""
+
+#: source/gx/terminix/appwindow.d:1293
+msgid "Could not load session due to unexpected error."
 msgstr "發生未知錯誤，無法載入會話。"
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Folder"
+#: source/gx/terminix/appwindow.d:1293
+#, fuzzy
+msgid "Error Loading Session"
+msgstr "載入會話"
+
+#: source/gx/terminix/appwindow.d:1309
+msgid "Save Session"
+msgstr "儲存會話"
+
+#: source/gx/terminix/appwindow.d:1392 source/gx/terminix/application.d:321
+#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
+#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
+msgid "Terminix"
+msgstr "Terminix"
+
+#: source/gx/terminix/application.d:228
+msgid "About"
+msgstr "關於"
+
+#: source/gx/terminix/application.d:229
+msgid "Quit"
+msgstr "退出"
+
+#. TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+#: source/gx/terminix/application.d:275
+msgid "translator-credits"
+msgstr "Mingcong Bai"
+
+#: source/gx/terminix/application.d:284
+msgid "Credits"
 msgstr ""
 
-#: source/gx/terminix/bookmark/manager.d:623
-msgid "Remote"
+#: source/gx/terminix/application.d:623
+msgid "Set the working directory of the terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/application.d:623
+msgid "DIRECTORY"
 msgstr ""
+
+#: source/gx/terminix/application.d:624
+msgid "Set the starting profile"
+msgstr "設定啟動配置檔"
+
+#: source/gx/terminix/application.d:624
+msgid "PROFILE_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:625
+#, fuzzy
+msgid "Set the title of the new terminal"
+msgstr "設定終端的工作目錄"
+
+#: source/gx/terminix/application.d:625
+msgid "TITLE"
+msgstr ""
+
+#: source/gx/terminix/application.d:626
+msgid "Open the specified session"
+msgstr "開啟指定的會話"
+
+#: source/gx/terminix/application.d:626
+msgid "SESSION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:627
+msgid "Send an action to current Terminix instance"
+msgstr "向當前 Terminix 例項傳送動作"
+
+#: source/gx/terminix/application.d:627
+msgid "ACTION_NAME"
+msgstr ""
+
+#: source/gx/terminix/application.d:628
+#, fuzzy
+msgid "Execute the parameter as a command"
+msgstr "執行傳入的指令"
+
+#: source/gx/terminix/application.d:628
+msgid "COMMAND"
+msgstr ""
+
+#: source/gx/terminix/application.d:629
+#, fuzzy
+msgid "Maximize the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:630
+#, fuzzy
+msgid "Minimize the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:631
+#, fuzzy
+msgid "Full-screen the terminal window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:632
+#, fuzzy
+msgid "Focus the existing window"
+msgstr "保持終端開啟"
+
+#: source/gx/terminix/application.d:633
+msgid "Start additional instance as new process (Not Recommended)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid ""
+"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
+msgstr ""
+
+#: source/gx/terminix/application.d:634
+msgid "GEOMETRY"
+msgstr ""
+
+#: source/gx/terminix/application.d:635
+msgid ""
+"Opens a window in quake mode or toggles existing quake mode window visibility"
+msgstr ""
+
+#: source/gx/terminix/application.d:636
+msgid "Show the Terminix and dependant component versions"
+msgstr ""
+
+#: source/gx/terminix/application.d:637
+msgid "Show the Terminix preferences dialog directly"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "Hidden argument to pass terminal UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:640
+msgid "TERMINAL_UUID"
+msgstr ""
+
+#: source/gx/terminix/application.d:801
+msgid ""
+"There appears to be an issue with the configuration of the terminal.\n"
+"This issue is not serious, but correcting it will improve your experience.\n"
+"Click the link below for more information:"
+msgstr ""
+"終端配置似乎存在問題。這並不是嚴重問題，但是更正這些問題將改善你的使用體驗。"
+"點選如下連結以獲取更多資訊："
+
+#: source/gx/terminix/application.d:802
+msgid "Configuration Issue Detected"
+msgstr "檢測到配置問題"
+
+#: source/gx/terminix/application.d:814
+msgid "Do not show this message again"
+msgstr "不再顯示該資訊"
+
+#: source/gx/terminix/colorschemes.d:182
+#, c-format
+msgid "File %s is not a color scheme compliant JSON file"
+msgstr ""
+
+#: source/gx/terminix/colorschemes.d:245
+msgid "Color scheme palette requires 16 colors"
+msgstr ""
+
+#: source/gx/terminix/session.d:544
+msgid "Could not locate dropped terminal"
+msgstr "無法定位放置的終端"
+
+#: source/gx/terminix/session.d:549
+msgid "Could not locate session for dropped terminal"
+msgstr "無法定位放置的終端的會話"
 
 #: source/gx/terminix/constants.d:60
 msgid "A VTE based terminal emulator for Linux"
@@ -216,81 +1620,46 @@ msgstr ""
 msgid "Dlang.org for such an excellent language, D"
 msgstr ""
 
-#: source/gx/terminix/constants.d:117 source/gx/terminix/terminal/layout.d:51
-#: source/gx/terminix/closedialog.d:113
-#, fuzzy
-msgid "Title"
-msgstr "標題"
-
-#: source/gx/terminix/constants.d:118
+#: source/gx/terminix/constants.d:117
 #, fuzzy
 msgid "Icon title"
 msgstr "動作"
 
 #: source/gx/terminix/constants.d:119
-#: source/gx/terminix/terminal/password.d:136
-msgid "ID"
-msgstr ""
-
-#: source/gx/terminix/constants.d:120
 msgid "Directory"
 msgstr ""
 
-#: source/gx/terminix/constants.d:121
+#: source/gx/terminix/constants.d:120
 msgid "Hostname"
 msgstr ""
 
-#: source/gx/terminix/constants.d:122
+#: source/gx/terminix/constants.d:121
 msgid "Username"
 msgstr ""
 
-#: source/gx/terminix/constants.d:123
+#: source/gx/terminix/constants.d:122
 #, fuzzy
 msgid "Columns"
 msgstr "行"
 
-#: source/gx/terminix/constants.d:124
+#: source/gx/terminix/constants.d:123
 msgid "Rows"
 msgstr ""
 
-#: source/gx/terminix/constants.d:139
+#: source/gx/terminix/constants.d:138
 #, fuzzy
 msgid "Application name"
 msgstr "動作"
 
-#: source/gx/terminix/constants.d:140
+#: source/gx/terminix/constants.d:139
 #, fuzzy
 msgid "Session name"
 msgstr "會話"
 
-#: source/gx/terminix/constants.d:141
+#: source/gx/terminix/constants.d:140
 #, fuzzy
 msgid "Session number"
 msgstr "會話"
-
-#: source/gx/terminix/session.d:544
-msgid "Could not locate dropped terminal"
-msgstr "無法定位放置的終端"
-
-#: source/gx/terminix/session.d:549
-msgid "Could not locate session for dropped terminal"
-msgstr "無法定位放置的終端的會話"
-
-#: source/gx/terminix/session.d:1120 source/gx/terminix/appwindow.d:880
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Default"
-msgstr "預設"
-
-#: source/gx/terminix/session.d:1439
-#: source/gx/terminix/prefeditor/prefdialog.d:155
-msgid "Profile"
-msgstr "配置方案"
-
-#: source/gx/terminix/session.d:1462 source/gx/terminix/application.d:216
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:21
-msgid "New Session"
-msgstr "新建會話"
 
 #: source/gx/terminix/encoding.d:18 source/gx/terminix/encoding.d:31
 #: source/gx/terminix/encoding.d:45 source/gx/terminix/encoding.d:67
@@ -431,1453 +1800,6 @@ msgstr "越南語"
 msgid "Thai"
 msgstr "泰語"
 
-#: source/gx/terminix/terminal/layout.d:30
-#, fuzzy
-msgid "Layout Options"
-msgstr "選項"
-
-#: source/gx/terminix/terminal/layout.d:45
-#, fuzzy
-msgid "Active"
-msgstr "動作"
-
-#: source/gx/terminix/terminal/layout.d:60
-#: source/gx/terminix/prefeditor/profileeditor.d:313
-#: source/gx/terminix/prefeditor/profileeditor.d:605
-msgid "Badge"
-msgstr ""
-
-#: source/gx/terminix/terminal/layout.d:69
-#, fuzzy
-msgid "Session Load"
-msgstr "會話"
-
-#: source/gx/terminix/terminal/layout.d:85
-msgid ""
-"Active options are always in effect and apply immediately.\n"
-"Session Load options only apply when loading a session file."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:315
-#: source/gx/terminix/terminal/terminal.d:3056
-#: source/gx/terminix/prefeditor/titleeditor.d:90
-msgid "Terminal"
-msgstr "終端"
-
-#: source/gx/terminix/terminal/terminal.d:346
-#: source/gx/terminix/terminal/terminal.d:1461
-#: source/gx/terminix/appwindow.d:644 source/gx/terminix/sidebar.d:362
-msgid "Close"
-msgstr "關閉"
-
-#: source/gx/terminix/terminal/terminal.d:354
-#: source/gx/terminix/terminal/terminal.d:1085
-#: source/gx/terminix/terminal/terminal.d:1460
-#, fuzzy
-msgid "Maximize"
-msgstr "最大化"
-
-#: source/gx/terminix/terminal/terminal.d:364
-#: source/gx/terminix/terminal/terminal.d:604
-msgid "Disable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:373
-#: source/gx/terminix/terminal/terminal.d:727
-msgid "Read-Only"
-msgstr "只讀"
-
-#: source/gx/terminix/terminal/terminal.d:379
-#: source/gx/terminix/prefeditor/profileeditor.d:292
-#, fuzzy
-msgid "Terminal bell"
-msgstr "終端響鈴"
-
-#: source/gx/terminix/terminal/terminal.d:424
-msgid "Edit Profile"
-msgstr "編輯配置檔"
-
-#: source/gx/terminix/terminal/terminal.d:442
-#, fuzzy
-msgid "Edit Encodings"
-msgstr "編碼"
-
-#: source/gx/terminix/terminal/terminal.d:606
-msgid "Enable input synchronization for this terminal"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-#, c-format
-msgid ""
-"The library %s could not be loaded, password functionality is unavailable."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:635
-msgid "Library Not Loaded"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:709
-#, fuzzy
-msgid "Save Output…"
-msgstr "另存為…"
-
-#: source/gx/terminix/terminal/terminal.d:710
-#: source/gx/terminix/prefeditor/profileeditor.d:261
-msgid "Reset"
-msgstr "重置"
-
-#: source/gx/terminix/terminal/terminal.d:711
-msgid "Reset and Clear"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:715
-#: source/gx/terminix/prefeditor/prefdialog.d:250
-msgid "Profiles"
-msgstr "配置方案"
-
-#: source/gx/terminix/terminal/terminal.d:716
-#: source/gx/terminix/prefeditor/prefdialog.d:149
-#: source/gx/terminix/prefeditor/prefdialog.d:150
-#: source/gx/terminix/prefeditor/prefdialog.d:402
-#: source/gx/terminix/prefeditor/prefdialog.d:610
-#: source/gx/terminix/prefeditor/profileeditor.d:981
-msgid "Encoding"
-msgstr "編碼"
-
-#: source/gx/terminix/terminal/terminal.d:720
-msgid "Add Bookmark..."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:721
-#, fuzzy
-msgid "Select Bookmark..."
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/terminal/terminal.d:722
-#: source/gx/terminix/prefeditor/prefdialog.d:141
-#: source/gx/terminix/prefeditor/prefdialog.d:142
-msgid "Bookmarks"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:725
-msgid "Find…"
-msgstr "查詢…"
-
-#: source/gx/terminix/terminal/terminal.d:726
-msgid "Layout Options…"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:737
-#, fuzzy
-msgid "Add Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/terminal/terminal.d:741
-msgid "Add Down"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1082
-#: source/gx/terminix/terminal/terminal.d:1460
-msgid "Restore"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1420
-msgid "Open Link"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1421
-msgid "Copy Link Address"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1431
-#: source/gx/terminix/terminal/terminal.d:1438
-msgid "Copy"
-msgstr "複製"
-
-#: source/gx/terminix/terminal/terminal.d:1432
-#: source/gx/terminix/terminal/terminal.d:1443
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Paste"
-msgstr "貼上"
-
-#: source/gx/terminix/terminal/terminal.d:1433
-#: source/gx/terminix/terminal/terminal.d:1448
-msgid "Select All"
-msgstr "全選"
-
-#: source/gx/terminix/terminal/terminal.d:1451
-#: source/gx/terminix/prefeditor/prefdialog.d:1210
-msgid "Clipboard"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:1465
-#, fuzzy
-msgid "Synchronize input"
-msgstr "同步輸入"
-
-#: source/gx/terminix/terminal/terminal.d:1945
-#, c-format
-msgid "Custom link regex '%s' has an error, ignoring"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2083
-msgid "Unexpected error occurred, no additional information available"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2089
-#, c-format
-msgid "Unexpected error occurred: %s"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2693
-msgid "Save Terminal Output"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2696
-#: source/gx/terminix/appwindow.d:642 source/gx/terminix/appwindow.d:1308
-#: source/gx/terminix/prefeditor/profileeditor.d:844
-msgid "Save"
-msgstr "儲存"
-
-#: source/gx/terminix/terminal/terminal.d:2702
-msgid "All Text Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:2706
-#: source/gx/terminix/appwindow.d:1232
-#: source/gx/terminix/prefeditor/prefdialog.d:923
-#: source/gx/terminix/prefeditor/profileeditor.d:861
-msgid "All Files"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3206
-#, c-format
-msgid "The child process exited normally with status %d"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3207
-#, c-format
-msgid "The child process was aborted by signal %d."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3208
-msgid "The child process was aborted."
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3214
-msgid "Relaunch"
-msgstr ""
-
-#: source/gx/terminix/terminal/terminal.d:3259
-#, fuzzy
-msgid "Don't Paste"
-msgstr "貼上"
-
-#: source/gx/terminix/terminal/terminal.d:3260
-msgid "Paste Anyway"
-msgstr ""
-
-#: source/gx/terminix/terminal/search.d:122
-msgid "Search Options"
-msgstr "搜尋選項"
-
-#: source/gx/terminix/terminal/search.d:135
-#, fuzzy
-msgid "Find next"
-msgstr "查詢下一個"
-
-# ***********************************************
-# Keyboard shortcuts to the end, these are shown
-# in the Shortcut preferences and in the future
-# the shortcut overview if available in Gnome 3.20
-# ***********************************************
-#: source/gx/terminix/terminal/search.d:141
-#, fuzzy
-msgid "Find previous"
-msgstr "查詢上一個"
-
-#: source/gx/terminix/terminal/search.d:188
-msgid "Match case"
-msgstr "區分大小寫"
-
-#: source/gx/terminix/terminal/search.d:189
-msgid "Match entire word only"
-msgstr "只匹配整個單詞"
-
-#: source/gx/terminix/terminal/search.d:190
-msgid "Match as regular expression"
-msgstr "使用正規表示式匹配"
-
-#: source/gx/terminix/terminal/search.d:191
-msgid "Wrap around"
-msgstr "折列"
-
-#: source/gx/terminix/terminal/advpaste.d:33
-msgid "This command is asking for Administrative access to your computer"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:34
-msgid "Copying commands from the internet can be dangerous. "
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:35
-msgid "Be sure you understand what each part of this command does."
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:96
-msgid "Transform"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:104
-msgid "Convert spaces to tabs"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:115
-msgid "Convert CRLF and CR to LF"
-msgstr ""
-
-#: source/gx/terminix/terminal/advpaste.d:137
-msgid "Advanced Paste"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:157
-msgid "New"
-msgstr "新建"
-
-#: source/gx/terminix/terminal/password.d:180
-#: source/gx/terminix/prefeditor/profileeditor.d:1089
-#: source/gx/terminix/prefeditor/profileeditor.d:1116
-#: source/gx/terminix/prefeditor/profileeditor.d:1183
-msgid "Edit"
-msgstr "編輯"
-
-#: source/gx/terminix/terminal/password.d:209
-#: source/gx/terminix/prefeditor/prefdialog.d:491
-#: source/gx/terminix/prefeditor/profileeditor.d:1202
-#: source/gx/terminix/prefeditor/profileeditor.d:1359
-#: source/gx/terminix/prefeditor/profileeditor.d:1512
-msgid "Delete"
-msgstr "刪除"
-
-#: source/gx/terminix/terminal/password.d:231
-msgid "Include return character with password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-msgid "Insert Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:367
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-msgid "Apply"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:433
-msgid "Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:441
-msgid "Confirm Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:487
-msgid "Add Password"
-msgstr ""
-
-#: source/gx/terminix/terminal/password.d:492
-msgid "Edit Password"
-msgstr ""
-
-#: source/gx/terminix/closedialog.d:133 source/gx/terminix/appwindow.d:978
-#, fuzzy
-msgid "Do not show this again"
-msgstr "不再顯示該資訊"
-
-#: source/gx/terminix/closedialog.d:160
-#, fuzzy, c-format
-msgid "Window (%s)"
-msgstr "新建視窗"
-
-#: source/gx/terminix/closedialog.d:163
-#, fuzzy, c-format
-msgid "Session (%s)"
-msgstr "會話"
-
-#: source/gx/terminix/closedialog.d:183
-#, fuzzy
-msgid "Close Application"
-msgstr "動作"
-
-#: source/gx/terminix/closedialog.d:186
-#, fuzzy
-msgid "Close Window"
-msgstr "新建視窗"
-
-#: source/gx/terminix/closedialog.d:189 source/gx/terminix/closedialog.d:192
-#, fuzzy
-msgid "Close Session"
-msgstr "新建會話"
-
-#: source/gx/terminix/application.d:217
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:17
-msgid "New Window"
-msgstr "新建視窗"
-
-#: source/gx/terminix/application.d:221 source/gx/terminix/appwindow.d:654
-#: source/gx/terminix/prefeditor/prefdialog.d:230
-#: source/gx/terminix/prefeditor/prefdialog.d:353
-msgid "Preferences"
-msgstr "偏好"
-
-#: source/gx/terminix/application.d:223
-#: source/gx/terminix/prefeditor/prefdialog.d:145
-#: source/gx/terminix/prefeditor/prefdialog.d:146
-msgid "Shortcuts"
-msgstr "快捷鍵"
-
-#: source/gx/terminix/application.d:228
-msgid "About"
-msgstr "關於"
-
-#: source/gx/terminix/application.d:229
-msgid "Quit"
-msgstr "退出"
-
-#: source/gx/terminix/application.d:283
-msgid "Credits"
-msgstr ""
-
-#: source/gx/terminix/application.d:320 source/gx/terminix/appwindow.d:1388
-#: data/pkg/desktop/com.gexperts.Terminix.desktop.in:4
-#: data/appdata/com.gexperts.Terminix.appdata.xml.in:8
-msgid "Terminix"
-msgstr "Terminix"
-
-#: source/gx/terminix/application.d:622
-msgid "Set the working directory of the terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/application.d:622
-msgid "DIRECTORY"
-msgstr ""
-
-#: source/gx/terminix/application.d:623
-msgid "Set the starting profile"
-msgstr "設定啟動配置檔"
-
-#: source/gx/terminix/application.d:623
-msgid "PROFILE_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:624
-#, fuzzy
-msgid "Set the title of the new terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/application.d:624
-msgid "TITLE"
-msgstr ""
-
-#: source/gx/terminix/application.d:625
-msgid "Open the specified session"
-msgstr "開啟指定的會話"
-
-#: source/gx/terminix/application.d:625
-msgid "SESSION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:626
-msgid "Send an action to current Terminix instance"
-msgstr "向當前 Terminix 例項傳送動作"
-
-#: source/gx/terminix/application.d:626
-msgid "ACTION_NAME"
-msgstr ""
-
-#: source/gx/terminix/application.d:627
-#, fuzzy
-msgid "Execute the parameter as a command"
-msgstr "執行傳入的指令"
-
-#: source/gx/terminix/application.d:627
-msgid "COMMAND"
-msgstr ""
-
-#: source/gx/terminix/application.d:628
-#, fuzzy
-msgid "Maximize the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:629
-#, fuzzy
-msgid "Minimize the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:630
-#, fuzzy
-msgid "Full-screen the terminal window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:631
-#, fuzzy
-msgid "Focus the existing window"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/application.d:632
-msgid "Start additional instance as new process (Not Recommended)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid ""
-"Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"
-msgstr ""
-
-#: source/gx/terminix/application.d:633
-msgid "GEOMETRY"
-msgstr ""
-
-#: source/gx/terminix/application.d:634
-msgid ""
-"Opens a window in quake mode or toggles existing quake mode window visibility"
-msgstr ""
-
-#: source/gx/terminix/application.d:635
-msgid "Show the Terminix and dependant component versions"
-msgstr ""
-
-#: source/gx/terminix/application.d:636
-msgid "Show the Terminix preferences dialog directly"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "Hidden argument to pass terminal UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:639
-msgid "TERMINAL_UUID"
-msgstr ""
-
-#: source/gx/terminix/application.d:800
-msgid ""
-"There appears to be an issue with the configuration of the terminal.\n"
-"This issue is not serious, but correcting it will improve your experience.\n"
-"Click the link below for more information:"
-msgstr ""
-"終端配置似乎存在問題。這並不是嚴重問題，但是更正這些問題將改善你的使用體驗。"
-"點選如下連結以獲取更多資訊："
-
-#: source/gx/terminix/application.d:801
-msgid "Configuration Issue Detected"
-msgstr "檢測到配置問題"
-
-#: source/gx/terminix/application.d:813
-msgid "Do not show this message again"
-msgstr "不再顯示該資訊"
-
-#: source/gx/terminix/appwindow.d:320
-#, fuzzy
-msgid "View session sidebar"
-msgstr "顯示側邊列"
-
-#: source/gx/terminix/appwindow.d:345
-msgid "Create a new session"
-msgstr "建立會話"
-
-#: source/gx/terminix/appwindow.d:363
-#, fuzzy
-msgid "Add terminal right"
-msgstr "切換到終端 10"
-
-#: source/gx/terminix/appwindow.d:367
-#, fuzzy
-msgid "Add terminal down"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/appwindow.d:373
-#, fuzzy
-msgid "Find text in terminal"
-msgstr "退出此終端"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Change Session Name"
-msgstr "更改會話名稱"
-
-#: source/gx/terminix/appwindow.d:586
-msgid "Enter a new name for the session"
-msgstr "為會話新建名稱"
-
-#: source/gx/terminix/appwindow.d:641
-msgid "Open…"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:643
-msgid "Save As…"
-msgstr "另存為…"
-
-#: source/gx/terminix/appwindow.d:648
-msgid "Name…"
-msgstr "名稱…"
-
-#: source/gx/terminix/appwindow.d:649
-msgid "Synchronize Input"
-msgstr "同步輸入"
-
-#: source/gx/terminix/appwindow.d:660
-msgid "GC"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:977
-#, fuzzy
-msgid "There are multiple sessions open, close anyway?"
-msgstr "仍有正在執行的程序，依然要關閉嗎？"
-
-#: source/gx/terminix/appwindow.d:1228
-#: source/gx/terminix/prefeditor/profileeditor.d:857
-msgid "All JSON Files"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1241
-#, c-format
-msgid "Filename '%s' does not exist"
-msgstr "檔名「%s」不存在"
-
-#: source/gx/terminix/appwindow.d:1271
-msgid "Load Session"
-msgstr "載入會話"
-
-#: source/gx/terminix/appwindow.d:1274
-msgid "Open"
-msgstr ""
-
-#: source/gx/terminix/appwindow.d:1289
-msgid "Could not load session due to unexpected error."
-msgstr "發生未知錯誤，無法載入會話。"
-
-#: source/gx/terminix/appwindow.d:1289
-#, fuzzy
-msgid "Error Loading Session"
-msgstr "載入會話"
-
-#: source/gx/terminix/appwindow.d:1305
-msgid "Save Session"
-msgstr "儲存會話"
-
-#: source/gx/terminix/colorschemes.d:182
-#, c-format
-msgid "File %s is not a color scheme compliant JSON file"
-msgstr ""
-
-#: source/gx/terminix/colorschemes.d:245
-msgid "Color scheme palette requires 16 colors"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:62
-msgid "Add bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:67
-msgid "Edit bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:72
-msgid "Delete bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/bookmarkeditor.d:77
-msgid "Unselect bookmark"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:112
-#, fuzzy
-msgid "Terminix Preferences"
-msgstr "偏好設定"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:129
-#: source/gx/terminix/prefeditor/prefdialog.d:130
-#: source/gx/terminix/prefeditor/prefdialog.d:198
-msgid "Global"
-msgstr "全局"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:133
-#: source/gx/terminix/prefeditor/prefdialog.d:134
-#, fuzzy
-msgid "Appearance"
-msgstr "外觀"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:137
-#: source/gx/terminix/prefeditor/prefdialog.d:138
-msgid "Quake"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:168
-#, fuzzy
-msgid "Add profile"
-msgstr "編輯配置檔"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:173
-#, fuzzy
-msgid "Delete profile"
-msgstr "配置方案"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:274
-#: source/gx/terminix/prefeditor/prefdialog.d:282
-#, fuzzy, c-format
-msgid "Profile: %s"
-msgstr "配置方案"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:492
-msgid "Clone"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:496
-#, fuzzy
-msgid "Use for new terminals"
-msgstr "退出此終端"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:572
-msgid "Encodings showing in menu:"
-msgstr "選單中顯示的編碼："
-
-#: source/gx/terminix/prefeditor/prefdialog.d:608
-msgid "Enabled"
-msgstr "已啟用"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:669
-#: source/gx/terminix/prefeditor/profileeditor.d:1480
-msgid "Action"
-msgstr "動作"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:698
-msgid "Shortcut Key"
-msgstr "快捷鍵"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:710
-#, fuzzy
-msgid "Enable shortcuts"
-msgstr "快捷鍵"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:738
-msgid "Overwrite Existing Shortcut"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:739
-#, c-format
-msgid ""
-"The shortcut %s is already assigned to %s.\n"
-"Disable the shortcut for the other action and assign here instead?"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:871
-msgid "Enable transparency, requires re-start"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:882
-#, fuzzy
-msgid "Window style"
-msgstr "新建視窗"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Normal"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-#, fuzzy
-msgid "Disable CSD"
-msgstr "已啟用"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Disable CSD, hide toolbar"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:884
-msgid "Borderless"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:888
-msgid "Window restart required"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:897
-#, fuzzy
-msgid "Terminal title style"
-msgstr "終端標題"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-msgid "Small"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:898
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "None"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:904
-#, fuzzy
-msgid "Theme variant"
-msgstr "主題變種"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Light"
-msgstr "淡色"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:905
-msgid "Dark"
-msgstr "深色"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:911
-#, fuzzy
-msgid "Background image"
-msgstr "背景"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:913
-#, fuzzy
-msgid "Select Image"
-msgstr "全選"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:916
-msgid "All Image Files"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:937
-#, fuzzy
-msgid "Reset background image"
-msgstr "透明度"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Scale"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Tile"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Center"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:943
-msgid "Stretch"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:962
-#, fuzzy
-msgid "Default session name"
-msgstr "切換到會話 1"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:973
-#, fuzzy
-msgid "Application title"
-msgstr "動作"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:986
-msgid "Use a wide handle for splitters"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:991
-msgid "Place the sidebar on the right"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:995
-#, fuzzy
-msgid "Show the terminal title even if it's the only terminal"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1027
-msgid "Size"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1038
-msgid "Height percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1049
-msgid "Width percent"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1059
-msgid "Alignment"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-msgid "Left"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1060
-#, fuzzy
-msgid "Right"
-msgstr "淡色"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1069
-#: source/gx/terminix/prefeditor/profileeditor.d:470
-msgid "Options"
-msgstr "選項"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1077
-msgid "Show terminal on all workspaces"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1082
-msgid "Set hint for window manager to disable animation"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1087
-msgid "Hide window when focus is lost"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1092
-#, fuzzy
-msgid "Hide the titlebar of the window"
-msgstr "設定終端的工作目錄"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1107
-#, fuzzy
-msgid "Display terminal on active monitor"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1114
-msgid "Display on specific monitor"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1156
-msgid "Behavior"
-msgstr "行為"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1162
-msgid "Prompt when creating a new session"
-msgstr "建立新會話時提示"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1167
-msgid "Focus a terminal when the mouse moves over it"
-msgstr "在滑鼠移入時啟用終端"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1172
-msgid "Autohide the mouse pointer when typing"
-msgstr "打字時自動隱藏滑鼠指針"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1177
-msgid "Close terminal by clicking middle mouse button on title"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1182
-msgid "Zoom the terminal using <Control> and scroll wheel"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1187
-msgid "Close window when last session is closed"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1193
-msgid "Send desktop notification on process complete"
-msgstr "程序完成時傳送桌面通知"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1201
-msgid "On new instance"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Right"
-msgstr "向右分割"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-msgid "Split Down"
-msgstr "向下分割"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1204
-#, fuzzy
-msgid "Focus Window"
-msgstr "新建視窗"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1216
-msgid "Always use advanced paste dialog"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1221
-msgid "Warn when attempting unsafe paste"
-msgstr "進行不安全複製時警告"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1226
-msgid "Strip first character of paste if comment or variable declaration"
-msgstr "如果貼上內容為註釋或變數聲明則切除第一個字元"
-
-#: source/gx/terminix/prefeditor/prefdialog.d:1231
-msgid "Automatically copy text to clipboard when selecting"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:99
-msgid "General"
-msgstr "常規"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:101
-msgid "Color"
-msgstr "顏色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:102
-msgid "Scrolling"
-msgstr "滾動"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:103
-msgid "Compatibility"
-msgstr "相容性"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:104
-#: source/gx/terminix/prefeditor/profileeditor.d:489
-msgid "Advanced"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:216
-#, fuzzy
-msgid "Profile name"
-msgstr "配置方案名稱"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:240
-#, fuzzy
-msgid "Terminal size"
-msgstr "終端大小"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:250
-msgid "columns"
-msgstr "行"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:256
-msgid "rows"
-msgstr "列"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:272
-#: source/gx/terminix/prefeditor/profileeditor.d:569
-msgid "Cursor"
-msgstr "游標"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Block"
-msgstr "方塊"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "IBeam"
-msgstr "IBeam"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:275
-msgid "Underline"
-msgstr "下劃線"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:283
-#, fuzzy
-msgid "Blink mode"
-msgstr "閃爍模式"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "System"
-msgstr "系統"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "On"
-msgstr "開啟"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:286
-msgid "Off"
-msgstr "關閉"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:295
-msgid "Icon and Sound"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:301
-#, fuzzy
-msgid "Terminal title"
-msgstr "終端標題"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:323
-msgid "Badge position"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Northeast"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-msgid "Southwest"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:327
-#, fuzzy
-msgid "Southeast"
-msgstr "南歐"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:338
-msgid "Text Appearance"
-msgstr "文字外觀"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:344
-msgid "Allow bold text"
-msgstr "允許粗體"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:349
-msgid "Rewrap on resize"
-msgstr "縮放時重新換行"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:355
-#, fuzzy
-msgid "Custom font"
-msgstr "自訂字型"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:361
-msgid "Choose A Terminal Font"
-msgstr "選擇終端字型"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:381
-#, c-format
-msgid "ID: %s"
-msgstr "ID：%s"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:427
-msgid "Color scheme"
-msgstr "配色方案"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:437
-#: source/gx/terminix/prefeditor/profileeditor.d:884
-msgid "Custom"
-msgstr "自訂"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:450
-msgid "Export"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:462
-msgid "Color palette"
-msgstr "調色盤"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:484
-msgid "Use theme colors for foreground/background"
-msgstr "為前景/背景色使用主題顏色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:502
-msgid "Transparency"
-msgstr "透明度"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:516
-msgid "Unfocused dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:564
-msgid "Text"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:565
-#: source/gx/terminix/prefeditor/profileeditor.d:669
-msgid "Background"
-msgstr "背景"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:576
-#, fuzzy
-msgid "Select Cursor Foreground Color"
-msgstr "選擇前景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:578
-#, fuzzy
-msgid "Select Cursor Background Color"
-msgstr "選擇背景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:583
-msgid "Highlight"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:588
-#, fuzzy
-msgid "Select Highlight Foreground Color"
-msgstr "選擇前景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:590
-#, fuzzy
-msgid "Select Highlight Background Color"
-msgstr "選擇背景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:595
-msgid "Dim"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:600
-#, fuzzy
-msgid "Select Dim Color"
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:609
-#, fuzzy
-msgid "Select Badge Color"
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:658
-msgid "Select Background Color"
-msgstr "選擇背景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:674
-#: source/gx/terminix/prefeditor/profileeditor.d:690
-msgid "Select Foreground Color"
-msgstr "選擇前景色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:689
-msgid "Foreground"
-msgstr "前景"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Black"
-msgstr "黑"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Red"
-msgstr "紅色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Green"
-msgstr "綠"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Orange"
-msgstr "橙色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Blue"
-msgstr "藍色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Purple"
-msgstr "紫色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Turquoise"
-msgstr "綠鬆色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:693
-msgid "Grey"
-msgstr "灰"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:699
-#, c-format
-msgid "Select %s Color"
-msgstr "選擇 %s 個顏色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:706
-#, c-format
-msgid "Select %s Light Color"
-msgstr "選擇 %s 個淡色"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:841
-#, fuzzy
-msgid "Export Color Scheme"
-msgstr "配色方案"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:916
-msgid "Show scrollbar"
-msgstr "顯示滾動條"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:920
-msgid "Scroll on output"
-msgstr "輸出時滾動"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:924
-msgid "Scroll on keystroke"
-msgstr "擊鍵時滾動"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:928
-msgid "Limit scrollback to:"
-msgstr "回滾限制："
-
-#: source/gx/terminix/prefeditor/profileeditor.d:963
-msgid "Backspace key generates"
-msgstr "按退格鍵生成"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Automatic"
-msgstr "自動"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Control-H"
-msgstr "Control-H"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "Escape sequence"
-msgstr "轉義序列"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:966
-#: source/gx/terminix/prefeditor/profileeditor.d:975
-msgid "TTY"
-msgstr "TTY"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:972
-msgid "Delete key generates"
-msgstr "按 Delete 鍵生成"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:996
-msgid "Ambiguous-width characters"
-msgstr "模糊寬度字元"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Narrow"
-msgstr "窄"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:999
-msgid "Wide"
-msgstr "寬"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1020
-msgid "Run command as a login shell"
-msgstr "作為登入 shell 執行指令"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1024
-msgid "Run a custom command instead of my shell"
-msgstr "執行自訂指令而不是我的指令列外殼"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1040
-msgid "When command exits"
-msgstr "指令退出時"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Exit the terminal"
-msgstr "退出此終端"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Restart the command"
-msgstr "重啟該指令"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1042
-msgid "Hold the terminal open"
-msgstr "保持終端開啟"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1081
-#, fuzzy
-msgid "Custom Links"
-msgstr "自訂字型"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1086
-msgid ""
-"A list of user defined links that can be clicked on in the terminal based on "
-"regular expression definitions."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1107
-msgid "Triggers"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1113
-msgid ""
-"Triggers are regular expressions that are used to check against output text "
-"in the terminal. When a match is detected the configured action is executed."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1133
-msgid "Automatic Profile Switching"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1141
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>username@hostname:directory</i> format. Either "
-"the hostname or directory can be omitted but the colon must be present. "
-"Entries with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1143
-msgid ""
-"Profiles are automatically selected based on the values entered here.\n"
-"Values are entered using a <i>hostname:directory</i> format. Either the "
-"hostname or directory can be omitted but the colon must be present. Entries "
-"with neither hostname or directory are not permitted."
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1154
-#, fuzzy
-msgid "Match"
-msgstr "區分大小寫"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1165
-#: source/gx/terminix/prefeditor/profileeditor.d:1353
-#: source/gx/terminix/prefeditor/profileeditor.d:1506
-msgid "Add"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1169
-msgid "Enter username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1171
-msgid "Enter hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1173
-msgid "Add New Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1190
-msgid "Edit username@hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1192
-msgid "Edit hostname:directory to match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1194
-msgid "Edit Match"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1316
-#: source/gx/terminix/prefeditor/profileeditor.d:1454
-msgid "Regex"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1340
-msgid "Case Insensitive"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1385
-msgid "Edit Custom Links"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1492
-msgid "Parameter"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1528
-msgid "Limit number of lines for trigger processing to:"
-msgstr ""
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1554
-#, fuzzy
-msgid "Edit Triggers"
-msgstr "編輯配置檔"
-
-#: source/gx/terminix/prefeditor/profileeditor.d:1597
-#, c-format
-msgid "Row %d: "
-msgstr ""
-
-#: source/gx/terminix/prefeditor/titleeditor.d:108
-#, fuzzy
-msgid "Window"
-msgstr "新建視窗"
-
-#: source/gx/terminix/prefeditor/titleeditor.d:118
-#: source/gx/terminix/prefeditor/titleeditor.d:119
-msgid "Help"
-msgstr ""
-
 #: source/gx/terminix/cmdparams.d:113
 #, c-format
 msgid "Ignoring as '%s' is not a directory"
@@ -1908,45 +1830,135 @@ msgid ""
 "You cannot use the quake mode with maximize, minimize or geometry parameters"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:212
-msgid "UpdateState"
+#: source/gx/terminix/bookmark/manager.d:223
+msgid "Error deserializing bookmark"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:213
+#: source/gx/terminix/bookmark/manager.d:512
+msgid "Root"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:586
 #, fuzzy
-msgid "ExecuteCommand"
-msgstr "指令"
+msgid "Could not load bookmarks due to unexpected error"
+msgstr "發生未知錯誤，無法載入會話。"
 
-#: source/gx/terminix/preferences.d:214
-msgid "SendNotification"
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Folder"
 msgstr ""
 
-#: source/gx/terminix/preferences.d:215
+#: source/gx/terminix/bookmark/manager.d:640
+#: source/gx/terminix/bookmark/bmeditor.d:289
+msgid "Path"
+msgstr ""
+
+#: source/gx/terminix/bookmark/manager.d:640
+msgid "Remote"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:68
+#: source/gx/terminix/bookmark/bmchooser.d:104
 #, fuzzy
-msgid "UpdateTitle"
-msgstr "標題"
+msgid "Select Folder"
+msgstr "選擇 %s 個顏色"
 
-#: source/gx/terminix/preferences.d:216
-msgid "PlayBell"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:217
-msgid "SendText"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:218
-msgid "InsertPassword"
-msgstr ""
-
-#: source/gx/terminix/preferences.d:219
+#: source/gx/terminix/bookmark/bmeditor.d:74
 #, fuzzy
-msgid "UpdateBadge"
-msgstr "標題"
+msgid "Select folder"
+msgstr "選擇 %s 個顏色"
 
-#: source/gx/terminix/preferences.d:326
+#: source/gx/terminix/bookmark/bmeditor.d:86
+msgid "Clear folder"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Add Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:147
+msgid "Edit Bookmark"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:291
+#, fuzzy
+msgid "Select Path"
+msgstr "全選"
+
+#: source/gx/terminix/bookmark/bmeditor.d:379
+msgid "Protocol"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:395
+msgid "Host"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:411
+msgid "User"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmeditor.d:418
+msgid "Parameters"
+msgstr ""
+
+#: source/gx/terminix/bookmark/bmchooser.d:104
+#, fuzzy
+msgid "Select Bookmark"
+msgstr "選擇 %s 個顏色"
+
+#: source/gx/gtk/actions.d:25
+#, fuzzy
+msgid "disabled"
+msgstr "已啟用"
+
+#: source/app.d:110
+#, c-format
+msgid "Your GTK version is too old, you need at least GTK %d.%d.%d!"
+msgstr ""
+
+#: source/app.d:127
+msgid "Unexpected exception occurred"
+msgstr ""
+
+#: source/app.d:128
+msgid "Error: "
+msgstr ""
+
+#: source/app.d:138
+#, fuzzy
+msgid "Versions"
+msgstr "波斯"
+
+#: source/app.d:139
 #, fuzzy, c-format
-msgid "%s (Copy)"
-msgstr "複製"
+msgid "Terminix version: %s"
+msgstr "在 %s 開啟 Terminix"
+
+#: source/app.d:140
+#, fuzzy, c-format
+msgid "VTE version: %s"
+msgstr "在 %s 開啟 Terminix"
+
+#: source/app.d:141
+#, c-format
+msgid "GTK Version: %d.%d.%d"
+msgstr ""
+
+#: source/app.d:142
+#, fuzzy
+msgid "Terminix Special Features"
+msgstr "偏好設定"
+
+#: source/app.d:143
+msgid "Notifications enabled=%b"
+msgstr ""
+
+#: source/app.d:144
+msgid "Triggers enabled=%b"
+msgstr ""
+
+#: source/app.d:145
+msgid "Badges enabled=%b"
+msgstr ""
 
 # ******************
 # Nautilus extension

--- a/source/gx/terminix/application.d
+++ b/source/gx/terminix/application.d
@@ -271,7 +271,8 @@ private:
             setAuthors(APPLICATION_AUTHORS.dup);
             setArtists(APPLICATION_ARTISTS.dup);
             setDocumenters(APPLICATION_DOCUMENTERS.dup);
-            setTranslatorCredits(APPLICATION_TRANSLATORS);
+            // TRANSLATORS: Please add your name to the list of translators if you want to be credited for the translations you have done.
+            setTranslatorCredits(_("translator-credits"));
             setLicense(_(APPLICATION_LICENSE));
             setLogoIconName(APPLICATION_ICON_NAME);
 

--- a/source/gx/terminix/constants.d
+++ b/source/gx/terminix/constants.d
@@ -69,7 +69,6 @@ string[] APPLICATION_CREDITS = [
 ];
 immutable string[] APPLICATION_ARTISTS = [];
 immutable string[] APPLICATION_DOCUMENTERS = [""];
-immutable string APPLICATION_TRANSLATORS = "MetotoSakamoto, frnogueira, dsboger, Philipp Wolfer, MingcongBai, Arthur2e5";
 
 //GTK Settings
 enum GTK_APP_PREFER_DARK_THEME = "gtk-application-prefer-dark-theme";


### PR DESCRIPTION
Instead of a static string this uses the customary msgid “translator-credits” for the translator credts in the about dialog, as recommended at https://developer.gnome.org/gtk3/stable/GtkAboutDialog.html#gtk-about-dialog-set-translator-credits . This allows each translator to add himself to the credits, also makes the credits for the actual translation.

I have also updated the language files and added the existing contributors to the credits as they were credited in the PO files or commits already.