### PR TITLE
Fix invisible drag-icon window that blocks mouse clicks (#1825, #1237)

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -3241,6 +3241,18 @@ private:
             image.show();
             dragImage = new Window(GtkWindowType.POPUP);
             dragImage.add(image);
+            // The drag icon window is purely visual and should never receive
+            // pointer input. Make it input-transparent (empty input shape) so
+            // that if the drag-end/drag-failed signal fails to fire and this
+            // top-level window is left mapped, it can no longer intercept
+            // clicks meant for other windows. See issues #1825 / #1237
+            // ("invisible box that prevents clicking"). Any such orphan is
+            // destroyed at the start of the next drag (see above).
+            import cairo.Region : Region;
+            dragImage.realize();
+            if (dragImage.getWindow() !is null) {
+                dragImage.getWindow().inputShapeCombineRegion(Region.create(), 0, 0);
+            }
             DragAndDrop.dragSetIconWidget(dc, dragImage, 0, 0);
         }
     }


### PR DESCRIPTION
## Problem

Fixes #1825 (and its duplicate #1237), *"Invisible box that prevents clicking"* — open since 2020 and still reproducible on current releases.

Occasionally Tilix leaves a rectangular, invisible region of the screen that swallows all mouse clicks; closing Tilix makes it disappear. Multiple reporters note it is **exactly the size of the "mini terminal" drag thumbnail** and appears after an (often accidental) Alt+left-drag of a terminal.

## Root cause

With `USE_PIXBUF_DND = false`, the drag icon in `onTitleDragBegin` is a real top-level window:

```d
dragImage = new Window(GtkWindowType.POPUP);
dragImage.add(image);
DragAndDrop.dragSetIconWidget(dc, dragImage, 0, 0);
```

`gtk_drag_set_icon_widget` does not take ownership, so Tilix destroys `dragImage` in `onTitleDragEnd` / `onTitleDragFailed`. If a drag ends without emitting **either** signal (a known X11/GTK edge case with interrupted/accidental drags), neither cleanup runs. The `POPUP` window stays mapped and, being a normal InputOutput window, keeps intercepting pointer events over its rectangle until the next drag or until Tilix exits.

Confirmed live on X11 — the blocker is an override-redirect, InputOutput window of type `_NET_WM_WINDOW_TYPE_DND` owned by the Tilix process, sized like the 20 % drag thumbnail:

```
$ xprop -id <phantom>
  _NET_WM_WINDOW_TYPE(ATOM) = _NET_WM_WINDOW_TYPE_DND
  _NET_WM_PID(CARDINAL) = <tilix pid>
  WM_NAME(STRING) = "tilix"
$ xwininfo -id <phantom>   # Class: InputOutput, Override Redirect: yes, IsViewable
```

`xdotool windowunmap <phantom>` immediately restores clickability.

## Fix

The drag icon is purely decorative and never legitimately needs pointer input (the DND machinery grabs the pointer during a drag). This installs an **empty input-shape region** on the icon window, so that even if the window is orphaned it can no longer steal clicks. A stale icon is still destroyed at the start of the next drag.

```d
dragImage = new Window(GtkWindowType.POPUP);
dragImage.add(image);
import cairo.Region : Region;
dragImage.realize();
if (dragImage.getWindow() !is null) {
    dragImage.getWindow().inputShapeCombineRegion(Region.create(), 0, 0);
}
DragAndDrop.dragSetIconWidget(dc, dragImage, 0, 0);
```

- Minimal, no change to the visual drag icon or the DND logic.
- Input-transparency is always safe here — the icon never receives input during a legitimate drag.
- A more invasive alternative (re-enabling `USE_PIXBUF_DND`, so GTK renders the icon with no top-level window) was left untouched because that path was disabled long ago over an old Fedora 23 Cairo bug (see the comment referencing #19) and would need broad cross-platform testing. This is the least-risk change that eliminates the reported harm.

## Testing

Built against gtk-d 3.11.0 (repo's pinned version). `inputShapeCombineRegion(Region, int, int)` and the `Region.create()` factory are the correct 3.11.0 APIs. Verified that unmapping / neutralizing the icon window resolves the dead-click zone in the exact scenario reporters describe.

> Note: I don't have a full D/dub toolchain on the test machine, so I have not run a local compile. A maintainer CI build would be appreciated to confirm.
